### PR TITLE
feat: add guided onboarding

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="css/styles.css">
   <link rel="stylesheet" href="css/components.css">
+  <link rel="stylesheet" href="https://unpkg.com/intro.js/minified/introjs.min.css">
   
 </head>
 <body>
@@ -121,6 +122,7 @@
   <script type="module" src="firebase-config.js"></script>
  <script type="module" src="login.js"></script>
   <script type="module" src="bling.js"></script>
+  <script src="https://unpkg.com/intro.js/minified/intro.min.js"></script>
     <script type="module" src="index.js"></script>
   <script type="module">
   

--- a/index.js
+++ b/index.js
@@ -40,6 +40,39 @@ function applyBlurStates() {
 // apply saved blur settings for static cards immediately
 applyBlurStates();
 
+function startTour(force = false) {
+  if (typeof introJs === 'undefined') return;
+  if (!force && localStorage.getItem('tourSeen') === 'true') return;
+  const intro = introJs();
+  intro.setOptions({
+    steps: [
+      { intro: 'Bem-vindo ao VendedorPro! Este tour apresenta os principais recursos da tela.' },
+      { element: '#resumoFaturamentoCard', intro: 'Resumo do faturamento do mês.' },
+      { element: '#topSkusCard', intro: 'Top 5 SKUs do mês.' },
+      { element: '#tarefasCard', intro: 'Aqui ficam suas tarefas do dia.' },
+      { element: '#atualizacoesCard', intro: 'Novidades e atualizações da Shopee.' }
+    ],
+    nextLabel: 'Próximo',
+    prevLabel: 'Anterior',
+    skipLabel: 'Pular',
+    doneLabel: 'Finalizar'
+  }).oncomplete(() => localStorage.setItem('tourSeen', 'true'))
+    .onexit(() => localStorage.setItem('tourSeen', 'true'))
+    .start();
+}
+
+document.addEventListener('navbarLoaded', () => {
+  const btn = document.getElementById('startTourBtn');
+  if (btn) {
+    btn.classList.remove('hidden');
+    btn.addEventListener('click', () => startTour(true));
+  }
+});
+
+function maybeStartTour() {
+  startTour(false);
+}
+
 
 async function carregarResumoFaturamento(uid, isAdmin) {
   const el = document.getElementById('resumoFaturamento');
@@ -301,6 +334,7 @@ async function iniciarPainel(user) {
     carregarTarefas(uid, isAdmin)
   ]);
   applyBlurStates();
+  maybeStartTour();
 }
 
 onAuthStateChanged(auth, user => {

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -11,7 +11,7 @@
         <button id="loginBtn" onclick="openModal('loginModal')" class="bg-orange-500 text-white px-4 py-2 rounded hover:bg-orange-600 transition flex items-center">
           <i class="fas fa-sign-in-alt mr-2"></i> Login
         </button>
-        
+
         <!-- Notificações -->
         <div class="relative tooltip" data-tooltip="Notificações">
           <button class="text-gray-600 hover:text-gray-900">
@@ -19,7 +19,12 @@
           </button>
           <span class="absolute top-0 right-0 bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs">3</span>
         </div>
-        
+
+        <!-- Modo Introdução -->
+        <button id="startTourBtn" class="text-gray-600 hover:text-gray-900 hidden tooltip" data-tooltip="Introdução">
+          <i class="fas fa-question-circle text-xl"></i>
+        </button>
+
         <!-- Perfil do usuário -->
         <div class="flex items-center space-x-3">
           <div class="bg-gray-200 border-2 border-dashed rounded-xl w-10 h-10"></div>


### PR DESCRIPTION
## Summary
- integrate Intro.js guided tour on index dashboard
- add manual tour button in navbar
- persist tutorial completion in localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a55cf37ac832aa722b9794337e309