### PR TITLE
feat: add sidebar onboarding tutorial

### DIFF
--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -10,14 +10,14 @@
 
   <div class="py-4">
     <!-- Início -->
-    <a href="/VendedorPro/index.html" class="sidebar-link">
+    <a href="/VendedorPro/index.html" class="sidebar-link" id="menu-inicio">
       <i class="fas fa-home"></i>
       <span class="link-text">Início</span>
     </a>
 
     <!-- Vendas -->
    <div class="sidebar-item">
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar" class="sidebar-link">
+      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar" class="sidebar-link" id="menu-vendas">
         <i class="fas fa-shopping-cart"></i>
         <span class="link-text">📦 Vendas</span>
       </a>
@@ -40,7 +40,7 @@
 
    <!-- Precificação -->
     <div class="sidebar-item">
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao" class="sidebar-link">
+      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao" class="sidebar-link" id="menu-precificacao">
         <i class="fas fa-tags"></i>
         <span class="link-text">🧮 Precificação</span>
       </a>
@@ -59,7 +59,7 @@
 
     <!-- Anúncios -->
     <div class="sidebar-item">
-      <a href="/VendedorPro/anuncios-tabs/cadastro.html" class="sidebar-link">
+      <a href="/VendedorPro/anuncios-tabs/cadastro.html" class="sidebar-link" id="menu-anuncios">
         <i class="fas fa-bullhorn"></i>
         <span class="link-text">📣 Anúncios</span>
       </a>
@@ -80,7 +80,7 @@
    
     <!-- Configurações -->
     <div class="sidebar-item">
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link">
+      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link" id="menu-configuracoes">
         <i class="fas fa-cog"></i>
         <span class="link-text">📣 Configurações</span>
       </a>
@@ -96,7 +96,12 @@
       <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=graficos" class="sidebar-link">Gráficos</a>
     </div>
 
-    <a href="/VendedorPro/manual.html" target="_blank" class="sidebar-link">📘 Manual</a>
+    <a href="/VendedorPro/manual.html" target="_blank" class="sidebar-link" id="menu-manual">📘 Manual</a>
+
+    <button id="startSidebarTourBtn" class="sidebar-link w-full text-left">
+      <i class="fas fa-question-circle"></i>
+      <span class="link-text">Modo Introdução</span>
+    </button>
     <!-- Modo Escuro -->
     <div class="flex items-center justify-between px-4 mt-6">
       <span class="text-sm text-gray-300">Modo Escuro</span>


### PR DESCRIPTION
## Summary
- highlight sidebar features with sequential intro.js steps
- allow manual launch of sidebar tour and skip once completed

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a6109f384832a8bbf93fb021c6feb