### PR TITLE
feat: add faturamento meta chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 <link rel="stylesheet" href="css/styles.css">
   <link rel="stylesheet" href="css/components.css">
   <link rel="stylesheet" href="https://unpkg.com/intro.js/minified/introjs.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   
 </head>
 <body>
@@ -63,7 +64,21 @@
           <div class="card-body" id="topSkus"></div>
         </div>
         
- </div>
+      </div>
+      <!-- Gráfico de Faturamento x Meta -->
+      <div class="card mb-6" id="faturamentoMetaCard">
+        <div class="card-header">
+          <div class="card-header-icon">
+            <i class="fas fa-chart-bar text-xl"></i>
+          </div>
+          <div>
+            <h2 class="text-xl font-bold text-gray-800">Faturamento x Meta</h2>
+          </div>
+        </div>
+        <div class="card-body">
+          <canvas id="chartFaturamentoMeta" height="200"></canvas>
+        </div>
+      </div>
 
         <div class="card mb-6" id="tarefasCard">
           <div class="card-header">


### PR DESCRIPTION
## Summary
- add revenue vs target card on home page using Chart.js
- include Chart.js library and rendering logic

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b1d91d9bc832abae26001b984a6ae