### PR TITLE
feat: add month filter to revenue chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 <link rel="stylesheet" href="css/styles.css">
   <link rel="stylesheet" href="css/components.css">
   <link rel="stylesheet" href="https://unpkg.com/intro.js/minified/introjs.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   
 </head>
 <body>
@@ -63,7 +64,24 @@
           <div class="card-body" id="topSkus"></div>
         </div>
         
- </div>
+      </div>
+      <!-- Gráfico de Faturamento x Meta -->
+      <div class="card mb-6" id="faturamentoMetaCard">
+        <div class="card-header">
+          <div class="card-header-icon">
+            <i class="fas fa-chart-bar text-xl"></i>
+          </div>
+          <div>
+            <h2 class="text-xl font-bold text-gray-800">Faturamento x Meta</h2>
+          </div>
+          <div class="ml-auto">
+            <input type="month" id="filtroMesFaturamento" class="border rounded p-1 text-sm" />
+          </div>
+        </div>
+        <div class="card-body">
+          <canvas id="chartFaturamentoMeta" height="200"></canvas>
+        </div>
+      </div>
 
         <div class="card mb-6" id="tarefasCard">
           <div class="card-header">

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import { getFirestore, collection, getDocs, doc, getDoc, collectionGroup, query,
 import { decryptString } from './crypto.js';
 import { loadSecureDoc } from './secure-firestore.js';
 import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { firebaseConfig } from './firebase-config.js';
 
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
@@ -330,9 +331,15 @@ async function iniciarPainel(user) {
   }
   await Promise.all([
     carregarResumoFaturamento(uid, isAdmin),
-  carregarTopSkus(uid, isAdmin),
+    carregarGraficoFaturamento(uid, isAdmin),
+    carregarTopSkus(uid, isAdmin),
     carregarTarefas(uid, isAdmin)
   ]);
+  const filtroMes = document.getElementById('filtroMesFaturamento');
+  if (filtroMes) {
+    filtroMes.value = new Date().toISOString().slice(0,7);
+    filtroMes.addEventListener('change', () => carregarGraficoFaturamento(uid, isAdmin));
+  }
   applyBlurStates();
   maybeStartTour();
 }
@@ -340,3 +347,70 @@ async function iniciarPainel(user) {
 onAuthStateChanged(auth, user => {
   if (user) iniciarPainel(user);
 });
+
+async function carregarGraficoFaturamento(uid, isAdmin) {
+  const canvas = document.getElementById('chartFaturamentoMeta');
+  if (!canvas || typeof Chart === 'undefined') return;
+  const ctx = canvas.getContext('2d');
+  const filtro = document.getElementById('filtroMesFaturamento');
+  const mesFiltro = filtro?.value || new Date().toISOString().slice(0,7);
+
+  const snap = isAdmin
+    ? await getDocs(collectionGroup(db, 'faturamento'))
+    : await getDocs(collection(db, `uid/${uid}/faturamento`));
+
+  const dados = [];
+  for (const docSnap of snap.docs) {
+    const [ano, mes, dia] = docSnap.id.split('-');
+    if (`${ano}-${mes}` !== mesFiltro) continue;
+    const ownerUid = isAdmin ? docSnap.ref.parent.parent.id : uid;
+    const subRef = collection(db, `uid/${ownerUid}/faturamento/${docSnap.id}/lojas`);
+    const subSnap = await getDocs(subRef);
+    let liquido = 0;
+    for (const s of subSnap.docs) {
+      let d = s.data();
+      if (d.encrypted) {
+        const passFn = typeof window !== 'undefined' ? window.getPassphrase : null;
+        const pass = passFn ? await passFn() : null;
+        let txt;
+        try {
+          txt = await decryptString(d.encrypted, pass || ownerUid);
+        } catch (e) {
+          if (pass) {
+            try {
+              txt = await decryptString(d.encrypted, ownerUid);
+            } catch (err) {}
+          }
+        }
+        if (txt) d = JSON.parse(txt);
+      }
+      liquido += d.valorLiquido || 0;
+    }
+    dados.push({ dia, liquido });
+  }
+
+  dados.sort((a,b) => a.dia.localeCompare(b.dia));
+  const labels = dados.map(d => d.dia);
+  const valores = dados.map(d => d.liquido);
+
+  if (window.chartFaturamentoMeta) window.chartFaturamentoMeta.destroy();
+
+  window.chartFaturamentoMeta = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [{
+        label: 'Líquido',
+        data: valores,
+        borderColor: '#34D399',
+        backgroundColor: 'rgba(52,211,153,0.2)',
+        tension: 0.1,
+        fill: true
+      }]
+    },
+    options: {
+      plugins: { legend: { display: false } },
+      scales: { y: { beginAtZero: true } }
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add month selector to faturamento chart card
- render daily liquid revenue for chosen month using acompanhamento mensal data
- import firebase config in index module so revenue card and chart render

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/VendedorPro/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689b1d91d9bc832abae26001b984a6ae