### PR TITLE
Fix media spreadsheet import skipping lines without IDs

### DIFF
--- a/gerenciamento.js
+++ b/gerenciamento.js
@@ -161,6 +161,8 @@ const COL_ALIASES = {
     }
 const normalizeKey = (str) =>
       str.toString().toLowerCase().normalize('NFD').replace(/[^\w]/g, '');
+    let ultimoId = null;
+    let ultimaVariacao = null;
     for (const linha of dados) {
       const map = {};
       for (const [k, v] of Object.entries(linha)) {
@@ -175,9 +177,9 @@ const normalizeKey = (str) =>
       };
       const getAlias = (campo) => get(...(COL_ALIASES[campo] || []));
 
-      let id = getAlias('idProduto');
+      let id = getAlias('idProduto') || ultimoId;
       const skuRef = getAlias('skuReferencia');
-      let varianteId = getAlias('idVariacao') || getAlias('skuVariacao');
+      let varianteId = getAlias('idVariacao') || getAlias('skuVariacao') || ultimaVariacao;
 
       if (!id && skuRef) {
         const skuNorm = String(skuRef).trim();
@@ -204,9 +206,12 @@ const normalizeKey = (str) =>
           }
         }
       }
-
       if (!id) continue;
       id = String(id).trim();
+      if (id !== ultimoId) {
+        ultimoId = id;
+        ultimaVariacao = null;
+      }
 
       if (!varianteId) {
         if (tipo === 'desempenho') {
@@ -216,6 +221,7 @@ const normalizeKey = (str) =>
         varianteId = 'unico_' + id;
       }
       varianteId = String(varianteId).trim();
+      ultimaVariacao = varianteId;
 
       // Criar estrutura do produto pai
       if (!window.produtos[id]) {


### PR DESCRIPTION
## Summary
- track last product and variation IDs when importing spreadsheets
- fill missing IDs to avoid skipping rows in media sheets

## Testing
- `node --check gerenciamento.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b27afa4ac832abcb0340a36b76b5d