### PR TITLE
feat: detalhar sobra esperada por SKU

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -139,6 +139,7 @@
     let historico = [];
     let produtos = {};
         let dadosAcompanhamento = [];
+    let sobraPorSku = {};
     let usuarioLogado = { uid: null, perfil: '' };
     let pedidosProcessados = [];
     let graficoBarras, graficoPizza;
@@ -2028,6 +2029,7 @@ let uids = [];
       const filtroMes = document.getElementById('filtroMesAcompanhamento')?.value;
       let dados = [];
             dadosAcompanhamento = [];
+      sobraPorSku = {};
       let totalBruto = 0, totalLiquido = 0, totalVendas = 0, totalSobra = 0;
 
       for (const doc of snap.docs) {
@@ -2065,7 +2067,9 @@ let uids = [];
           listaSnap.forEach(item => {
             const { sku, total } = item.data();
             const custo = Number(produtos[sku] || 0);
-            sobraDia += (total || 0) * custo;
+            const valor = (total || 0) * custo;
+            sobraDia += valor;
+            sobraPorSku[sku] = (sobraPorSku[sku] || 0) + valor;
           });
         } catch (e) {
           console.warn('Erro ao calcular sobra esperada do dia', e);
@@ -2114,8 +2118,24 @@ const dias = dadosAcompanhamento.length;
    <div class="resumo-card"><h4>Total Bruto</h4><p>R$ ${totais.bruto.toLocaleString('pt-BR')}</p>${resumoBrutoMeta}</div>
         <div class="resumo-card"><h4>Total Líquido</h4><p>R$ ${totais.liquido.toLocaleString('pt-BR')}</p>${resumoLiquidoMeta}</div>
         <div class="resumo-card"><h4>Total Vendido</h4><p>${totais.vendas}</p></div>
-        <div class="resumo-card"><h4>Total Sobra Esperada</h4><p>R$ ${totais.sobra.toLocaleString('pt-BR')}</p></div>
+        <div class="resumo-card"><h4>Total Sobra Esperada</h4><p>R$ ${totais.sobra.toLocaleString('pt-BR')}</p><button class="btn btn-secondary btn-sm" style="margin-top:0.5rem" onclick="mostrarDetalhesSobra()">Ver mais</button></div>
         <div class="resumo-card"><h4>Ticket Médio</h4><p>R$ ${ticket.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</p></div>`;
+    }
+
+    function mostrarDetalhesSobra() {
+      if (!Object.keys(sobraPorSku).length) {
+        Swal.fire('Sem dados', 'Não há informações de sobra esperada por SKU para o período selecionado.', 'info');
+        return;
+      }
+      let html = '<div style="text-align:left">';
+      for (const [sku, valor] of Object.entries(sobraPorSku)) {
+        html += `<div><strong>${sku}</strong>: R$ ${valor.toLocaleString('pt-BR')}</div>`;
+      }
+      html += '</div>';
+      Swal.fire({
+        title: 'Sobra Esperada por SKU',
+        html
+      });
     }
 
      function exportarAcompanhamentoExcel() {
@@ -2224,6 +2244,7 @@ window.carregarRegistrosFaturamento = carregarRegistrosFaturamento;
 window.carregarControleVendas = carregarControleVendas;
 window.carregarAcompanhamento = carregarAcompanhamento;
   window.salvarMetasAcompanhamento = salvarMetasAcompanhamento;
+window.mostrarDetalhesSobra = mostrarDetalhesSobra;
 window.mostrarDetalhesFaturamento = mostrarDetalhesFaturamento;
 window.excluirFaturamento = excluirFaturamento;
 window.analisarSobrasIA = analisarSobrasIA;


### PR DESCRIPTION
## Summary
- exibe botão de detalhes no card de Sobra Esperada
- calcula sobra mensal por SKU e exibe em modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c6e28bf4c832aa403d4f3100bda54