### PR TITLE
refactor: improve dashboard layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -9,6 +9,7 @@
   --hover: #fb923c;
   --dark: #1C2B36;
   --secondary: #273746;
+  --nav-bg: #1e3a8a;
   --success: #4CAF50;
   --error: #F44336;
   --danger: #F44336;
@@ -35,7 +36,7 @@
   right: 0;
   left: 250px;
   height: 70px;
-  background-color: #1c2b36;
+  background-color: var(--nav-bg);
   box-shadow: 0 2px 10px rgba(0,0,0,.05);
   z-index: 30;
   display: flex;
@@ -219,20 +220,24 @@ input:checked + .dark-mode-slider:before {
   background-color: #ff6600;
 }
 /* Estilos modernos para o card de tarefas */
+#tarefasCard {
+  border-left: 4px solid var(--primary);
+}
+
 #tarefasCard .card-header {
-  background: linear-gradient(135deg, var(--primary), var(--primary-light));
-  color: #fff;
-  border-bottom: none;
+  background-color: var(--card-bg);
+  color: var(--text-dark);
+  border-bottom: 1px solid var(--border);
   border-radius: 0.75rem 0.75rem 0 0;
 }
 
 #tarefasCard .card-header-icon {
-  background: rgba(255, 255, 255, 0.2);
-  color: inherit;
+  background-color: rgba(249,115,22,0.1);
+  color: var(--primary);
 }
 
 #tarefasCard .card-body {
-  background-color: #f9fafb;
+  background-color: var(--card-bg);
 }
 
 #tarefasCard .progress-wrapper {
@@ -1678,19 +1683,25 @@ button {
   font-weight: 500
 }
 .sidebar {
-  background-color: #fff;
-  color: #374151;
+  background-color: var(--nav-bg);
+  color: #f1f5f9;
 }
 
 .sidebar-link {
-  color: #374151;
+  color: #cbd5e1;
   text-decoration: none;
 }
 
 .sidebar-link.active {
-  border-left: 3px solid #F97316;
-  background-color: #F3F4F6;
+  border-left: 3px solid var(--primary);
+  background-color: rgba(255,255,255,0.1);
   font-weight: 700;
+  color: #fff;
+}
+
+.sidebar-link:hover {
+  background-color: rgba(255,255,255,0.1);
+  color: #fff;
 }
 
 #sidebar::-webkit-scrollbar {
@@ -1712,7 +1723,7 @@ button {
 
 .submenu a {
   display: block;
-  color: #ccc;
+  color: #cbd5e1;
   font-size: .9rem;
   padding: .4rem 1.5rem;
   border-left: 2px solid transparent;
@@ -1720,23 +1731,23 @@ button {
 }
 
 .submenu a:hover {
- color: #f45c00;
-  background-color: rgba(255,255,255,.05);
-  border-left-color: #f45c00
+ color: var(--primary);
+  background-color: rgba(255,255,255,.1);
+  border-left-color: var(--primary)
 }
 
 body.dark .sidebar {
-  background-color: #1c2b36
+  background-color: var(--nav-bg);
 }
 
 body.dark .sidebar-link,
 body.dark .submenu a {
-  color: #eee
+  color: #e2e8f0;
 }
 
 body.dark .sidebar-link:hover,
 body.dark .submenu a:hover {
-  color: #f45c00
+  color: var(--primary);
 }
 
 .navbar {

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>VendedorPro - Sistema Premium</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="css/styles.css">
   <link rel="stylesheet" href="css/components.css">
   <link rel="stylesheet" href="https://unpkg.com/intro.js/minified/introjs.min.css">
@@ -37,19 +37,20 @@
       
       <!-- Hero Section -->
       <div class="max-w-6xl w-full text-center mb-6">
-       <h1 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+      <h1 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
   <span class="text-orange-600 font-extrabold">Sistemas de Gestão</span> para sua Loja
 </h1>
         <p class="text-gray-600 max-w-2xl mx-auto mb-8">
           Ferramentas poderosas para otimizar seus negócios na Shopee. Controle de estoque, precificação inteligente e análise de desempenho em um só lugar.
         </p>
+        <button onclick="openModal('loginModal')" class="btn btn-primary">Iniciar teste gratuito</button>
       </div>
       
 
       <!-- Resumo Faturamento e Top SKUs -->
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
         <div id="resumoFaturamento"></div>
-        <div class="card cursor-pointer" id="topSkusCard" data-blur-id="topSkusCard" onclick="location.href='/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=controleVendas';">
+        <div class="card" id="topSkusCard" data-blur-id="topSkusCard">
           <div class="card-header">
            <div class="card-header-icon">
               <i class="fas fa-trophy text-xl"></i>
@@ -62,6 +63,9 @@
             </button>
           </div>
           <div class="card-body" id="topSkus"></div>
+          <div class="p-5 pt-0">
+            <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=controleVendas" class="btn btn-primary w-full">Ver lista</a>
+          </div>
         </div>
       </div>
 

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,9 +1,9 @@
  <div class="top-navbar">
       <div class="flex items-center">
-        <button class="mobile-menu-btn mr-4 text-gray-600 md:hidden">
+        <button class="mobile-menu-btn mr-4 text-gray-200 md:hidden">
           <i class="fas fa-bars text-xl"></i>
         </button>
-        <h2 class="text-lg font-semibold text-gray-800">Dashboard</h2>
+        <h2 class="text-lg font-semibold text-white">Dashboard</h2>
       </div>
       
       <div class="flex items-center space-x-5">
@@ -14,14 +14,14 @@
 
         <!-- Notificações -->
         <div class="relative tooltip" data-tooltip="Notificações">
-          <button class="text-gray-600 hover:text-gray-900">
+          <button class="text-gray-200 hover:text-white">
             <i class="fas fa-bell text-xl"></i>
           </button>
           <span class="absolute top-0 right-0 bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs">3</span>
         </div>
 
         <!-- Modo Introdução -->
-        <button id="startTourBtn" class="text-gray-600 hover:text-gray-900 hidden tooltip" data-tooltip="Introdução">
+        <button id="startTourBtn" class="text-gray-200 hover:text-white hidden tooltip" data-tooltip="Introdução">
           <i class="fas fa-question-circle text-xl"></i>
         </button>
 
@@ -29,10 +29,10 @@
         <div class="flex items-center space-x-3">
           <div class="bg-gray-200 border-2 border-dashed rounded-xl w-10 h-10"></div>
           <div>
-            <span id="currentUser" class="font-medium text-gray-800">Usuário</span>
-            <span class="block text-xs text-gray-500">Administrador</span>
+            <span id="currentUser" class="font-medium text-white">Usuário</span>
+            <span class="block text-xs text-gray-300">Administrador</span>
           </div>
-          <button id="logoutBtn" class="ml-2 text-gray-600 hover:text-gray-900 hidden">
+          <button id="logoutBtn" class="ml-2 text-gray-200 hover:text-white hidden">
             <i class="fas fa-sign-out-alt text-xl"></i>
           </button>
         </div>

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -1,4 +1,4 @@
-<div id="sidebar" class="sidebar bg-white w-64 h-screen overflow-y-auto fixed left-0 top-0 z-50">
+<div id="sidebar" class="sidebar w-64 h-screen overflow-y-auto fixed left-0 top-0 z-50 text-gray-100">
   <div class="sidebar-logo p-4">
     <div class="flex items-center">
       <div class="bg-white w-10 h-10 rounded-lg flex items-center justify-center mr-3">
@@ -6,13 +6,13 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"/>
         </svg>
       </div>
-      <span class="font-bold text-xl text-gray-900">VendedorPro</span>
+      <span class="font-bold text-xl text-white">VendedorPro</span>
     </div>
   </div>
 
-  <div class="py-4 text-gray-700">
+  <div class="py-4">
     <!-- Início -->
-    <a href="/VendedorPro/index.html" class="sidebar-link flex items-center py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors" id="menu-inicio">
+    <a href="/VendedorPro/index.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-inicio">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
         <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/>
       </svg>
@@ -21,7 +21,7 @@
 
     <!-- Vendas -->
     <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar" class="sidebar-link flex items-center py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors" id="menu-vendas">
+      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-vendas">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"/>
         </svg>
@@ -34,21 +34,21 @@
       </button>
     </div>
     <div id="menuVendas" class="pl-8 space-y-1 max-h-0 overflow-hidden transition-all duration-300">
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Conferir Sobras</a>
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Histórico</a>
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Registrar Faturamento</a>
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=registroFaturamento" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Acompanhamento Faturamento</a>
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=controleVendas" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Acompanhamento Vendas</a>
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamento" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Acompanhamento Mensal</a>
-      <a href="/VendedorPro/pedidos-bling.html" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Pedidos Bling</a>
-      <a href="/VendedorPro/pedidos-shopee.html" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Pedidos Shopee</a>
-      <a href="/VendedorPro/saques.html" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Saques</a>
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=metas" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Cadastro de Sobra</a>
+      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar" class="sidebar-link block py-2 px-4 transition-colors">Conferir Sobras</a>
+      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a>
+      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento" class="sidebar-link block py-2 px-4 transition-colors">Registrar Faturamento</a>
+      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=registroFaturamento" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Faturamento</a>
+      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=controleVendas" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Vendas</a>
+      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamento" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Mensal</a>
+      <a href="/VendedorPro/pedidos-bling.html" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Bling</a>
+      <a href="/VendedorPro/pedidos-shopee.html" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Shopee</a>
+      <a href="/VendedorPro/saques.html" class="sidebar-link block py-2 px-4 transition-colors">Saques</a>
+      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=metas" class="sidebar-link block py-2 px-4 transition-colors">Cadastro de Sobra</a>
     </div>
 
     <!-- Precificação -->
     <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao" class="sidebar-link flex items-center py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors" id="menu-precificacao">
+      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-precificacao">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"/>
           <path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6Z"/>
@@ -62,17 +62,17 @@
       </button>
     </div>
     <div id="menuPrecificacao" class="pl-8 space-y-1 max-h-0 overflow-hidden transition-all duration-300">
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Precificação</a>
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=lista-precos" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Lista Preços</a>
-      <a href="/VendedorPro/promocoes-shopee.html" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Promoções Shopee</a>
-      <a href="/VendedorPro/SISTEMA%20DE%20CUSTEIO%20DE%20PRODU%C3%87%C3%83O%20E%20PRODUTOS.html#mdf" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Custeio de Produção</a>
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=produtos" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Produtos</a>
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Histórico</a>
+      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao" class="sidebar-link block py-2 px-4 transition-colors">Precificação</a>
+      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=lista-precos" class="sidebar-link block py-2 px-4 transition-colors">Lista Preços</a>
+      <a href="/VendedorPro/promocoes-shopee.html" class="sidebar-link block py-2 px-4 transition-colors">Promoções Shopee</a>
+      <a href="/VendedorPro/SISTEMA%20DE%20CUSTEIO%20DE%20PRODU%C3%87%C3%83O%20E%20PRODUTOS.html#mdf" class="sidebar-link block py-2 px-4 transition-colors">Custeio de Produção</a>
+      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=produtos" class="sidebar-link block py-2 px-4 transition-colors">Produtos</a>
+      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a>
     </div>
 
     <!-- Anúncios -->
     <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/anuncios-tabs/cadastro.html" class="sidebar-link flex items-center py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors" id="menu-anuncios">
+      <a href="/VendedorPro/anuncios-tabs/cadastro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-anuncios">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46"/>
         </svg>
@@ -85,19 +85,19 @@
       </button>
     </div>
     <div id="menuAnuncios" class="pl-8 space-y-1 max-h-0 overflow-hidden transition-all duration-300">
-      <a href="/VendedorPro/anuncios-tabs/cadastro.html" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Cadastro / Atualização</a>
-      <a href="/VendedorPro/anuncios-tabs/anuncios.html" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Anúncios</a>
-      <a href="/VendedorPro/acompanhamento-promocoes.html" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Acompanhamento Promoções</a>
-      <a href="/VendedorPro/anuncios-tabs/analise.html" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Análise IA</a>
-      <a href="/VendedorPro/anuncios-tabs/criar-ia.html" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Criar Anúncio com IA</a>
-      <a href="/VendedorPro/anuncios-tabs/evolucao.html" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Evolução</a>
-      <a href="/VendedorPro/ads.html" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Shopee Ads</a>
-      <a href="/VendedorPro/ads-lista.html" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Anúncios Salvos</a>
+      <a href="/VendedorPro/anuncios-tabs/cadastro.html" class="sidebar-link block py-2 px-4 transition-colors">Cadastro / Atualização</a>
+      <a href="/VendedorPro/anuncios-tabs/anuncios.html" class="sidebar-link block py-2 px-4 transition-colors">Anúncios</a>
+      <a href="/VendedorPro/acompanhamento-promocoes.html" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Promoções</a>
+      <a href="/VendedorPro/anuncios-tabs/analise.html" class="sidebar-link block py-2 px-4 transition-colors">Análise IA</a>
+      <a href="/VendedorPro/anuncios-tabs/criar-ia.html" class="sidebar-link block py-2 px-4 transition-colors">Criar Anúncio com IA</a>
+      <a href="/VendedorPro/anuncios-tabs/evolucao.html" class="sidebar-link block py-2 px-4 transition-colors">Evolução</a>
+      <a href="/VendedorPro/ads.html" class="sidebar-link block py-2 px-4 transition-colors">Shopee Ads</a>
+      <a href="/VendedorPro/ads-lista.html" class="sidebar-link block py-2 px-4 transition-colors">Anúncios Salvos</a>
     </div>
 
     <!-- Configurações -->
     <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link flex items-center py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors" id="menu-configuracoes">
+      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-configuracoes">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"/>
           <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
@@ -111,21 +111,21 @@
       </button>
     </div>
     <div id="menuConfiguracoes" class="pl-8 space-y-1 max-h-0 overflow-hidden transition-all duration-300">
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Dashboard</a>
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=configuracoes" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Configurações</a>
-      <a href="/VendedorPro/etiquetas-ocr.html" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Etiquetas OCR</a>
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Histórico</a>
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=graficos" class="sidebar-link block py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">Gráficos</a>
+      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link block py-2 px-4 transition-colors">Dashboard</a>
+      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=configuracoes" class="sidebar-link block py-2 px-4 transition-colors">Configurações</a>
+      <a href="/VendedorPro/etiquetas-ocr.html" class="sidebar-link block py-2 px-4 transition-colors">Etiquetas OCR</a>
+      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a>
+      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=graficos" class="sidebar-link block py-2 px-4 transition-colors">Gráficos</a>
     </div>
 
-    <a href="/VendedorPro/manual.html" target="_blank" class="sidebar-link flex items-center py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors" id="menu-manual">
+    <a href="/VendedorPro/manual.html" target="_blank" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-manual">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/>
       </svg>
       <span class="link-text">Manual</span>
     </a>
 
-    <button id="startSidebarTourBtn" class="sidebar-link w-full text-left flex items-center py-2 px-4 hover:bg-gray-100 hover:shadow-inner transition-colors">
+    <button id="startSidebarTourBtn" class="sidebar-link w-full text-left flex items-center py-2 px-4 transition-colors">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z"/>
       </svg>
@@ -134,7 +134,7 @@
 
     <!-- Modo Escuro -->
     <div class="flex items-center justify-between px-4 mt-6">
-      <span class="text-sm text-gray-600">Modo Escuro</span>
+      <span class="text-sm text-gray-300">Modo Escuro</span>
       <label class="relative inline-flex items-center cursor-pointer">
         <input type="checkbox" id="darkModeToggle" class="sr-only peer">
         <div class="w-11 h-6 bg-gray-300 peer-focus:outline-none rounded-full peer peer-checked:bg-orange-500 transition"></div>


### PR DESCRIPTION
## Summary
- refine color palette with unified blue navigation and orange accents
- clarify top SKUs actions and add onboarding call-to-action
- simplify task card styling for cleaner appearance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c747268f8832aa0dc9f8183e5f5e3