### PR TITLE
Add expedição tab with Firebase label storage

### DIFF
--- a/etiquetas-ocr.html
+++ b/etiquetas-ocr.html
@@ -9,6 +9,10 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/styles.css">
   <link rel="stylesheet" href="css/components.css">
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
+  <script type="module" src="firebase-config.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/pdf-lib/dist/pdf-lib.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>
@@ -121,6 +125,20 @@
   </div>
     <script>
     pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js';
+
+if (!firebase.apps.length) { firebase.initializeApp(firebaseConfig); }
+const db = firebase.firestore();
+let currentUser = null;
+firebase.auth().onAuthStateChanged(u => currentUser = u);
+
+function blobToBase64(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result.split(',')[1]);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}
 
 function showMessage(text) {
   const messageBox = document.getElementById("messageBox");
@@ -296,6 +314,14 @@ completoCtx.drawImage(
 
   const pdfFinal = await novoPdf.save();
   const blob = new Blob([pdfFinal], { type: "application/pdf" });
+  if (currentUser) {
+    const base64 = await blobToBase64(blob);
+    await db.collection('users').doc(currentUser.uid).collection('etiquetaenvio').add({
+      name: `etiquetas_editadas_${Date.now()}.pdf`,
+      pdf: base64,
+      createdAt: firebase.firestore.FieldValue.serverTimestamp()
+    });
+  }
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;

--- a/expedicao.html
+++ b/expedicao.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Expedição</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="css/components.css">
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
+  <script type="module" src="firebase-config.js"></script>
+</head>
+<body class="bg-gray-50">
+  <div id="sidebar-container"></div>
+  <div id="navbar-container"></div>
+  <div class="main-content p-4">
+    <h1 class="text-2xl font-bold mb-4">Expedição</h1>
+    <div id="labelsList" class="space-y-4"></div>
+  </div>
+  <script>
+    if (!firebase.apps.length) { firebase.initializeApp(firebaseConfig); }
+    const db = firebase.firestore();
+    let currentUser = null;
+    firebase.auth().onAuthStateChanged(user => {
+      if (user) {
+        currentUser = user;
+        carregarEtiquetas();
+      }
+    });
+
+    async function carregarEtiquetas() {
+      const list = document.getElementById('labelsList');
+      list.innerHTML = '';
+      const snap = await db.collection('users').doc(currentUser.uid).collection('etiquetaenvio').orderBy('createdAt', 'desc').get();
+      snap.forEach(doc => {
+        const data = doc.data();
+        const div = document.createElement('div');
+        div.className = 'p-4 bg-white rounded shadow';
+        const name = data.name || 'Etiqueta';
+        const base = data.pdf;
+        div.innerHTML = `
+          <p class="font-semibold">${name}</p>
+          <div class="mt-2 space-x-2">
+            <button class="btn btn-primary" onclick="visualizar('${base}')">Visualizar</button>
+            <button class="btn btn-primary" onclick="imprimir('${base}')">Imprimir</button>
+            <a class="btn btn-primary" href="data:application/pdf;base64,${base}" download="${name}">Baixar</a>
+            <button class="btn bg-red-500 text-white" onclick="excluir('${doc.id}')">Excluir</button>
+          </div>`;
+        list.appendChild(div);
+      });
+    }
+
+    function visualizar(base64) {
+      const win = window.open('', '_blank');
+      win.document.write('<iframe width="100%" height="100%" src="data:application/pdf;base64,' + base64 + '"></iframe>');
+    }
+
+    function imprimir(base64) {
+      const win = window.open('', '_blank');
+      win.document.write('<iframe id="printFrame" width="100%" height="100%" src="data:application/pdf;base64,' + base64 + '"></iframe>');
+      win.document.close();
+      win.focus();
+      win.onload = () => win.document.getElementById('printFrame').contentWindow.print();
+    }
+
+    async function excluir(id) {
+      if (!confirm('Deseja excluir esta etiqueta?')) return;
+      await db.collection('users').doc(currentUser.uid).collection('etiquetaenvio').doc(id).delete();
+      carregarEtiquetas();
+    }
+
+    loadSidebar();
+    loadNavbar();
+  </script>
+  <script src="shared.js"></script>
+</body>
+</html>

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -114,6 +114,7 @@
       <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link block py-2 px-4 transition-colors">Dashboard</a>
       <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=configuracoes" class="sidebar-link block py-2 px-4 transition-colors">Configurações</a>
       <a href="/VendedorPro/etiquetas-ocr.html" class="sidebar-link block py-2 px-4 transition-colors">Etiquetas OCR</a>
+      <a href="/VendedorPro/expedicao.html" class="sidebar-link block py-2 px-4 transition-colors">Expedição</a>
       <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a>
       <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=graficos" class="sidebar-link block py-2 px-4 transition-colors">Gráficos</a>
     </div>

--- a/zpl-import.html
+++ b/zpl-import.html
@@ -4,10 +4,14 @@
     <meta charset="UTF-8"> 
     <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
     <title>Combinador de Etiqueta ZPL</title> 
-    <script src="https://cdn.tailwindcss.com"></script> 
-    <!-- A biblioteca pdf-lib é carregada aqui --> 
-    <script src="https://unpkg.com/pdf-lib@1.4.0"></script> 
-    <style> 
+    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- A biblioteca pdf-lib é carregada aqui -->
+    <script src="https://unpkg.com/pdf-lib@1.4.0"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
+    <script type="module" src="firebase-config.js"></script>
+    <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@600;800&display=swap'); 
         body { 
             font-family: 'Inter', sans-serif; 
@@ -67,8 +71,32 @@
     </div> 
 </div> 
 
-<script> 
-    document.addEventListener('DOMContentLoaded', () => { 
+<script>
+    if (!firebase.apps.length) { firebase.initializeApp(firebaseConfig); }
+    const db = firebase.firestore();
+    let currentUser = null;
+    firebase.auth().onAuthStateChanged(u => currentUser = u);
+
+    function blobToBase64(blob) {
+        return new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(reader.result.split(',')[1]);
+            reader.onerror = reject;
+            reader.readAsDataURL(blob);
+        });
+    }
+
+    async function savePdf(blob, name) {
+        if (!currentUser) return;
+        const base64 = await blobToBase64(blob);
+        await db.collection('users').doc(currentUser.uid).collection('etiquetaenvio').add({
+            name: name,
+            pdf: base64,
+            createdAt: firebase.firestore.FieldValue.serverTimestamp()
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
         const fileInput = document.getElementById('zplFile'); 
         const converterButton = document.getElementById('converterButton'); 
         const progressContainer = document.getElementById('progress-container');
@@ -164,17 +192,21 @@
                 } 
 
                 // 7. Save the final PDF
-                const pdfBytes = await pdfDoc.save(); 
-                const pdfBlob = new Blob([pdfBytes], { type: 'application/pdf' }); 
-                const pdfUrl = URL.createObjectURL(pdfBlob); 
+                const pdfBytes = await pdfDoc.save();
+                const pdfBlob = new Blob([pdfBytes], { type: 'application/pdf' });
+                const pdfUrl = URL.createObjectURL(pdfBlob);
+
+                const fileName = `etiquetas-combinadas-${Date.now()}.pdf`;
 
                 // Add the download link
-                const link = document.createElement('a'); 
-                link.href = pdfUrl; 
-                link.download = `etiquetas-combinadas-${Date.now()}.pdf`; 
-                link.textContent = 'Transferir PDF Combinado'; 
-                link.classList.add('px-6', 'py-3', 'bg-green-600', 'text-white', 'font-bold', 'rounded-full', 'shadow-lg', 'hover:bg-green-500', 'transition-all', 'duration-300'); 
-                pdfLinksDiv.appendChild(link); 
+                const link = document.createElement('a');
+                link.href = pdfUrl;
+                link.download = fileName;
+                link.textContent = 'Transferir PDF Combinado';
+                link.classList.add('px-6', 'py-3', 'bg-green-600', 'text-white', 'font-bold', 'rounded-full', 'shadow-lg', 'hover:bg-green-500', 'transition-all', 'duration-300');
+                pdfLinksDiv.appendChild(link);
+
+                await savePdf(pdfBlob, fileName);
                 
                 // 8. Display the preview of the first label
                 const firstLabelImageBlob = await generateImageFromZpl(generateCombinedZPL(blocks[0], await extractDataFromImage(await blobToBase64(await generateImageFromZpl(blocks[1], dpmm, originalWidthIn, originalHeightIn)))), dpmm, originalWidthIn, calculateNewTotalHeight(originalHeightIn, (await extractDataFromImage(await blobToBase64(await generateImageFromZpl(blocks[1], dpmm, originalWidthIn, originalHeightIn)))).length, dpmm)); 


### PR DESCRIPTION
## Summary
- add Expedição tab to the sidebar and create a dedicated page listing generated shipping labels
- store OCR and ZPL-imported label PDFs in Firestore under each user's `etiquetaenvio` subcollection
- allow users to view, print, download or delete saved labels from the Expedição page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c77dd5ca0832a99a96005c4099c08