### PR TITLE
Remove free trial button from landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,6 @@
         <p class="text-gray-600 max-w-2xl mx-auto mb-8">
           Ferramentas poderosas para otimizar seus negócios na Shopee. Controle de estoque, precificação inteligente e análise de desempenho em um só lugar.
         </p>
-        <button onclick="openModal('loginModal')" class="btn btn-primary">Iniciar teste gratuito</button>
       </div>
       
 


### PR DESCRIPTION
## Summary
- remove unusable "Iniciar teste gratuito" button from index page

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_689c784bfef0832aa86cb6fa4d0ab155