### PR TITLE
Fix Tailwind and Firebase initialization

### DIFF
--- a/zpl-import.html
+++ b/zpl-import.html
@@ -4,13 +4,13 @@
     <meta charset="UTF-8"> 
     <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
     <title>Combinador de Etiqueta ZPL</title> 
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <!-- A biblioteca pdf-lib é carregada aqui -->
     <script src="https://unpkg.com/pdf-lib@1.4.0"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
-    <script type="module" src="firebase-config.js"></script>
+    <script src="firebase-config.js"></script>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@600;800&display=swap'); 
         body { 


### PR DESCRIPTION
## Summary
- use production Tailwind CSS build via jsDelivr
- load firebase config as classic script to expose `firebaseConfig`

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c7a45cd20832a94044b1fc95e820f