### PR TITLE
Fix Firebase config load in etiquetas-ocr

### DIFF
--- a/etiquetas-ocr.html
+++ b/etiquetas-ocr.html
@@ -12,7 +12,6 @@
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
-  <script type="module" src="firebase-config.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/pdf-lib/dist/pdf-lib.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>
@@ -123,7 +122,8 @@
       </div>
     </div>
   </div>
-    <script>
+    <script type="module">
+    import { firebaseConfig } from './firebase-config.js';
     pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js';
 
 if (!firebase.apps.length) { firebase.initializeApp(firebaseConfig); }
@@ -330,9 +330,6 @@ completoCtx.drawImage(
 
   status.textContent = "✅ PDF gerado com sucesso!";
 }
-  </script>
-  <script>
-    pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js';
   </script>
 
   <script src="shared.js"></script>


### PR DESCRIPTION
## Summary
- Ensure `firebaseConfig` is imported before usage in etiquetas-ocr
- Convert inline script to module so Firebase initializes correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c7a278da8832ab6eb9d27e686fdde