### PR TITLE
fix missing global print and view handlers

### DIFF
--- a/expedicao.html
+++ b/expedicao.html
@@ -61,6 +61,7 @@
       const win = window.open('', '_blank');
       win.document.write('<iframe width="100%" height="100%" src="' + url + '"></iframe>');
     }
+    window.visualizar = visualizar;
 
     function imprimir(url) {
       const win = window.open('', '_blank');
@@ -69,6 +70,7 @@
       win.focus();
       win.onload = () => win.document.getElementById('printFrame').contentWindow.print();
     }
+    window.imprimir = imprimir;
 
     async function excluir(id) {
       if (!confirm('Deseja excluir esta etiqueta?')) return;
@@ -82,6 +84,7 @@
       await docRef.delete();
       carregarEtiquetas();
     }
+    window.excluir = excluir;
 
     loadSidebar();
     loadNavbar();


### PR DESCRIPTION
## Summary
- expose visualizar, imprimir, and excluir functions globally so inline handlers work

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c8c047d1c832ab0b83f8931880063