### PR TITLE
Avoid crash in top SKU loader when document lacks parent

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,13 +152,21 @@ async function carregarTopSkus(uid, isAdmin) {
   const hoje = new Date();
   const mesAtual = hoje.toISOString().slice(0,7);
   const mapa = {};
-const snap = isAdmin
+  const snap = isAdmin
     ? await getDocs(collectionGroup(db, 'skusVendidos'))
     : await getDocs(collection(db, `uid/${uid}/skusVendidos`));
   for (const docSnap of snap.docs) {
     const [ano, mes] = docSnap.id.split('-');
     if (`${ano}-${mes}` !== mesAtual) continue;
-     const ownerUid = isAdmin ? docSnap.ref.parent.parent.id : uid;
+    let ownerUid = uid;
+    if (isAdmin) {
+      const parentDoc = docSnap.ref.parent.parent;
+      if (!parentDoc) {
+        console.warn('Documento sem pai para skusVendidos:', docSnap.ref.path);
+        continue;
+      }
+      ownerUid = parentDoc.id;
+    }
     const listaRef = collection(db, `uid/${ownerUid}/skusVendidos/${docSnap.id}/lista`);
     const listaSnap = await getDocs(listaRef);
     listaSnap.forEach(s => {


### PR DESCRIPTION
## Summary
- guard against null parent documents when loading top SKUs
- log and skip orphaned `skusVendidos` entries instead of throwing

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm test --prefix functions` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c9697bb1c832aacc9e14274b8f0ce