### PR TITLE
fix: guard against missing anuncios parent for admin tasks

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,7 +234,15 @@ async function carregarTarefas(uid, isAdmin) {
     : await getDocs(collection(db, `uid/${uid}/anuncios`));
   const pass = typeof getPassphrase === 'function' ? getPassphrase() : null;
   for (const docSnap of snapAnuncios.docs) {
-    const ownerUid = isAdmin ? docSnap.ref.parent.parent.id : uid;
+    let ownerUid = uid;
+    if (isAdmin) {
+      const parentDoc = docSnap.ref.parent.parent;
+      if (!parentDoc) {
+        console.warn('Documento sem pai para anuncios:', docSnap.ref.path);
+        continue;
+      }
+      ownerUid = parentDoc.id;
+    }
     const dados = await loadSecureDoc(db, `uid/${ownerUid}/anuncios`, docSnap.id, pass);
     if (!dados || !dados.dataCriacao) continue;
     const dataCriacao = new Date(dados.dataCriacao);


### PR DESCRIPTION
## Summary
- avoid TypeError when admin tasks load anuncios without parent document

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `(cd functions && npm test)` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c9c7395b0832ab10012e407abbb17