### PR TITLE
feat: allow users to save shipping contact email

### DIFF
--- a/email-expedicao.html
+++ b/email-expedicao.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>E-mail Responsável Expedição</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="css/components.css">
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
+</head>
+<body class="bg-gray-50">
+  <div id="sidebar-container"></div>
+  <div id="navbar-container"></div>
+  <div class="main-content p-4">
+    <h1 class="text-2xl font-bold mb-4">E-mail do Responsável pela Expedição</h1>
+    <form id="emailForm" class="space-y-4 max-w-lg">
+      <input type="email" id="emailExpedicao" placeholder="email@empresa.com" class="w-full p-2 border rounded">
+      <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Salvar</button>
+    </form>
+    <p id="status" class="mt-4 text-green-600 hidden"></p>
+  </div>
+  <script type="module">
+    import { firebaseConfig } from './firebase-config.js';
+    if (!firebase.apps.length) {
+      firebase.initializeApp(firebaseConfig);
+    }
+    const db = firebase.firestore();
+    let currentUser = null;
+    const input = document.getElementById('emailExpedicao');
+    const statusEl = document.getElementById('status');
+
+    firebase.auth().onAuthStateChanged(async user => {
+      if (!user) {
+        window.location.href = 'index.html?login=1';
+        return;
+      }
+      currentUser = user;
+      try {
+        const doc = await db.collection('uid').doc(user.uid).get();
+        const email = doc.data()?.responsavelExpedicaoEmail || '';
+        input.value = email;
+      } catch (e) {
+        console.error('Erro ao carregar e-mail:', e);
+      }
+    });
+
+    document.getElementById('emailForm').addEventListener('submit', async e => {
+      e.preventDefault();
+      statusEl.classList.add('hidden');
+      const email = input.value.trim();
+      try {
+        await db.collection('uid').doc(currentUser.uid).set({
+          responsavelExpedicaoEmail: email || null,
+          uid: currentUser.uid,
+          email: currentUser.email
+        }, { merge: true });
+        statusEl.textContent = 'E-mail salvo com sucesso!';
+        statusEl.classList.remove('hidden');
+        statusEl.classList.remove('text-red-600');
+        statusEl.classList.add('text-green-600');
+      } catch (err) {
+        console.error('Erro ao salvar e-mail:', err);
+        statusEl.textContent = 'Erro ao salvar e-mail';
+        statusEl.classList.remove('hidden');
+        statusEl.classList.remove('text-green-600');
+        statusEl.classList.add('text-red-600');
+      }
+    });
+
+    loadSidebar();
+    loadNavbar();
+  </script>
+  <script src="shared.js"></script>
+</body>
+</html>

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -116,6 +116,7 @@
       <a href="painel-usuarios.html" class="sidebar-link block py-2 px-4 transition-colors">Painel Usuários</a>
       <a href="/VendedorPro/etiquetas-ocr.html" class="sidebar-link block py-2 px-4 transition-colors">Etiquetas OCR</a>
       <a href="/VendedorPro/expedicao.html" class="sidebar-link block py-2 px-4 transition-colors">Expedição</a>
+      <a href="/VendedorPro/email-expedicao.html" class="sidebar-link block py-2 px-4 transition-colors">E-mail Expedição</a>
       <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a>
       <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=graficos" class="sidebar-link block py-2 px-4 transition-colors">Gráficos</a>
     </div>


### PR DESCRIPTION
## Summary
- add dedicated page where logged in users can manage the shipping responsible email
- expose new page in sidebar navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ca31cb464832ab3f655c3e8684ef2