### PR TITLE
Avoid anonymous auth when not enabled

### DIFF
--- a/equipes.html
+++ b/equipes.html
@@ -921,7 +921,7 @@
     <script type="module">
         // Importa as funções necessárias do Firebase
         import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
-        import { getAuth, signInAnonymously, signInWithCustomToken, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
+        import { getAuth, signInWithCustomToken, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
         import { getFirestore, collection, addDoc, onSnapshot, query, where, updateDoc, doc, deleteDoc, getDocs } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
         import { firebaseConfig as defaultFirebaseConfig } from './firebase-config.js';
 
@@ -1091,8 +1091,8 @@
 
                 if (initialAuthToken) {
                     await signInWithCustomToken(auth, initialAuthToken);
-                } else {
-                    await signInAnonymously(auth);
+                } else if (!auth.currentUser) {
+                    console.warn('Nenhum método de autenticação disponível. Acesse com login.');
                 }
                 
                 onAuthStateChanged(auth, (user) => {


### PR DESCRIPTION
## Summary
- Remove anonymous Firebase auth attempt on Equipes page
- Warn users to login when no custom token is available

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d39032498832a98cc7e3c309f12da