### PR TITLE
Redirect to login when unauthenticated

### DIFF
--- a/equipes.html
+++ b/equipes.html
@@ -1093,8 +1093,6 @@
 
                 if (initialAuthToken) {
                     await signInWithCustomToken(auth, initialAuthToken);
-                } else if (!auth.currentUser) {
-                    console.warn('Nenhum método de autenticação disponível. Acesse com login.');
                 }
                 
                 onAuthStateChanged(auth, (user) => {
@@ -1108,12 +1106,7 @@
                         setupMembersListener();
                         showView('myBoardsView'); // Mostra a lista de quadros por padrão
                     } else {
-                        console.log('No user is signed in.');
-                        userId = null;
-                        isAuthReady = true;
-                        boardsGrid.innerHTML = '<div class="loading">Por favor, faça login para ver seus quadros.</div>';
-                        membersGrid.innerHTML = '<div class="loading">Por favor, faça login para ver seus membros.</div>';
-                        showView('dashboardView');
+                        window.location.href = 'index.html?login=1';
                     }
                 });
 


### PR DESCRIPTION
## Summary
- Ensure team management page redirects unauthenticated users to the login screen instead of leaving them on an unusable page.
- Remove console-only authentication warning in the TeamFlow page.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d3a5f4a2c832ab75720d31be2b5e7