### PR TITLE
feat: add gestor reports tab

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,6 +1,10 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    function isGestorOrADM(uid) {
+      return exists(/databases/$(database)/documents/usuarios/$(uid)) &&
+        get(/databases/$(database)/documents/usuarios/$(uid)).data.perfil in ['Gestor', 'ADM'];
+    }
     match /pdfDocs/{fileId} {
       allow read: if request.auth != null && (
         resource.data.ownerUid == request.auth.uid ||
@@ -8,6 +12,28 @@ service cloud.firestore {
       );
       allow create: if request.auth != null && request.resource.data.ownerUid == request.auth.uid;
       allow update, delete: if request.auth != null && resource.data.ownerUid == request.auth.uid;
+    }
+
+    match /relatorios/{relatorioId} {
+      allow create: if request.auth != null && request.resource.data.autorUid == request.auth.uid;
+      allow read: if request.auth != null && (
+        resource.data.autorUid == request.auth.uid ||
+        (resource.data.gestores != null && request.auth.uid in resource.data.gestores) ||
+        isGestorOrADM(request.auth.uid)
+      );
+      allow update: if request.auth != null && (
+        (resource.data.autorUid == request.auth.uid && resource.data.status != 'aprovado' && request.resource.data.status == resource.data.status) ||
+        (resource.data.gestores != null && request.auth.uid in resource.data.gestores) ||
+        isGestorOrADM(request.auth.uid)
+      );
+
+      match /comentarios/{comentId} {
+        allow read, create: if request.auth != null && (
+          get(/databases/$(database)/documents/relatorios/$(relatorioId)).data.autorUid == request.auth.uid ||
+          (get(/databases/$(database)/documents/relatorios/$(relatorioId)).data.gestores != null && request.auth.uid in get(/databases/$(database)/documents/relatorios/$(relatorioId)).data.gestores) ||
+          isGestorOrADM(request.auth.uid)
+        );
+      }
     }
   }
 }

--- a/gestor.html
+++ b/gestor.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Gestor</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="css/components.css">
+</head>
+<body class="bg-gray-100 text-gray-800">
+  <div id="sidebar-container"></div>
+  <div id="navbar-container"></div>
+  <main class="main-content p-4 space-y-6">
+    <!-- Formulário de envio -->
+    <div class="card">
+      <div class="card-header"><h2 class="text-xl font-bold">📤 Enviar relatório</h2></div>
+      <div class="card-body space-y-4">
+        <input id="relTitulo" class="form-control" placeholder="Título" />
+        <input id="relTipo" class="form-control" placeholder="Tipo" />
+        <div class="flex space-x-2">
+          <input type="date" id="relInicio" class="form-control" />
+          <input type="date" id="relFim" class="form-control" />
+        </div>
+        <select id="relGestores" multiple class="form-control"></select>
+        <textarea id="relMensagem" class="form-control" placeholder="Mensagem"></textarea>
+        <input type="file" id="relArquivos" multiple class="form-control" />
+        <button id="btnEnviarRelatorio" class="btn btn-primary">Enviar</button>
+      </div>
+    </div>
+
+    <!-- Meus relatórios -->
+    <div class="card">
+      <div class="card-header"><h2 class="text-xl font-bold">Meus relatórios</h2></div>
+      <div id="listaMeusRelatorios" class="card-body space-y-4"></div>
+    </div>
+
+    <!-- Caixa do Gestor -->
+    <div id="caixaGestor" class="hidden space-y-6">
+      <div class="card">
+        <div class="card-header flex flex-wrap items-center gap-2">
+          <h2 class="text-xl font-bold flex-1">Caixa do Gestor</h2>
+          <select id="filtroStatus" class="form-control w-40">
+            <option value="">Status</option>
+            <option value="enviado">Enviado</option>
+            <option value="em-analise">Em análise</option>
+            <option value="aprovado">Aprovado</option>
+            <option value="reprovado">Reprovado</option>
+            <option value="ajustes">Ajustes</option>
+          </select>
+          <input id="filtroAutor" class="form-control w-40" placeholder="Autor" />
+        </div>
+        <div id="listaCaixaGestor" class="card-body space-y-4"></div>
+      </div>
+    </div>
+  </main>
+
+  <script type="module" src="firebase-config.js"></script>
+  <script type="module" src="gestor.js"></script>
+  <script type="module" src="login.js"></script>
+  <script src="shared.js"></script>
+  <script>
+    if (window.initAbaGestor) {
+      window.initAbaGestor();
+    }
+  </script>
+</body>
+</html>

--- a/gestor.js
+++ b/gestor.js
@@ -1,0 +1,177 @@
+import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { getFirestore, collection, addDoc, updateDoc, doc, getDocs, query, where, onSnapshot, serverTimestamp } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { getStorage, ref, uploadBytes, getDownloadURL } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-storage.js';
+import { firebaseConfig } from './firebase-config.js';
+
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+const db = getFirestore(app);
+const auth = getAuth(app);
+const storage = getStorage(app);
+
+let currentUser = null;
+
+async function carregarGestoresDropdown() {
+  const select = document.getElementById('relGestores');
+  if (!select) return;
+  select.innerHTML = '';
+  const snap = await getDocs(query(collection(db, 'usuarios'), where('perfil', '==', 'Gestor')));
+  snap.forEach(docu => {
+    const opt = document.createElement('option');
+    opt.value = docu.id;
+    const d = docu.data();
+    opt.textContent = d.nome || d.email || docu.id;
+    select.appendChild(opt);
+  });
+}
+
+async function enviarRelatorio(e) {
+  e.preventDefault();
+  if (!currentUser) return;
+  const titulo = document.getElementById('relTitulo').value.trim();
+  const tipo = document.getElementById('relTipo').value.trim();
+  const inicio = document.getElementById('relInicio').value;
+  const fim = document.getElementById('relFim').value;
+  const gestores = Array.from(document.getElementById('relGestores').selectedOptions).map(o => o.value);
+  const mensagem = document.getElementById('relMensagem').value.trim();
+  const arquivos = document.getElementById('relArquivos').files;
+
+  const docRef = await addDoc(collection(db, 'relatorios'), {
+    titulo,
+    tipo,
+    inicio,
+    fim,
+    gestores,
+    mensagem,
+    status: 'enviado',
+    autorUid: currentUser.uid,
+    autorNome: currentUser.displayName || currentUser.email,
+    createdAt: serverTimestamp(),
+    anexos: []
+  });
+
+  const anexos = [];
+  for (const file of arquivos) {
+    const path = `reports/${currentUser.uid}/${docRef.id}/${file.name}`;
+    const storageRef = ref(storage, path);
+    await uploadBytes(storageRef, file);
+    const url = await getDownloadURL(storageRef);
+    anexos.push({ nome: file.name, url });
+  }
+  if (anexos.length) {
+    await updateDoc(docRef, { anexos });
+  }
+
+  document.getElementById('relTitulo').value = '';
+  document.getElementById('relTipo').value = '';
+  document.getElementById('relInicio').value = '';
+  document.getElementById('relFim').value = '';
+  document.getElementById('relMensagem').value = '';
+  document.getElementById('relArquivos').value = '';
+  Array.from(document.getElementById('relGestores').options).forEach(o => o.selected = false);
+}
+
+function renderRelatorioCard(id, data, isGestor) {
+  const statusColors = {
+    'enviado': 'bg-gray-400',
+    'em-analise': 'bg-yellow-500',
+    'aprovado': 'bg-green-500',
+    'reprovado': 'bg-red-500',
+    'ajustes': 'bg-purple-500'
+  };
+  const card = document.createElement('div');
+  card.className = 'card';
+  const anexosHtml = (data.anexos || []).map(a => `<a href="${a.url}" target="_blank" class="text-blue-500 underline block">${a.nome}</a>`).join('');
+  card.innerHTML = `
+    <div class="card-header flex justify-between items-center">
+      <h3 class="font-bold">${data.titulo || 'Sem título'}</h3>
+      <span class="text-white text-xs px-2 py-1 rounded ${statusColors[data.status] || 'bg-gray-300'}">${data.status}</span>
+    </div>
+    <div class="card-body space-y-2">
+      <p class="text-sm">Tipo: ${data.tipo || '-'}</p>
+      <p class="text-sm">Período: ${data.inicio || ''} - ${data.fim || ''}</p>
+      <p class="text-sm">${data.mensagem || ''}</p>
+      <div class="space-y-1">${anexosHtml}</div>
+      ${isGestor ? `
+      <div class="flex flex-wrap gap-2 mt-2">
+        <button class="btnStatus btn btn-secondary" data-id="${id}" data-s="em-analise">Em análise</button>
+        <button class="btnStatus btn btn-secondary" data-id="${id}" data-s="aprovado">Aprovado</button>
+        <button class="btnStatus btn btn-secondary" data-id="${id}" data-s="reprovado">Reprovado</button>
+        <button class="btnStatus btn btn-secondary" data-id="${id}" data-s="ajustes">Ajustes</button>
+      </div>
+      <div class="mt-2">
+        <textarea class="form-control mb-2" data-coment="${id}" placeholder="Comentário"></textarea>
+        <button class="enviarComent btn btn-primary" data-id="${id}">Enviar comentário</button>
+      </div>` : ''}
+    </div>
+  `;
+  return card;
+}
+
+function listenMinhasSubmissoes() {
+  const q = query(collection(db, 'relatorios'), where('autorUid', '==', currentUser.uid));
+  onSnapshot(q, snap => {
+    const list = document.getElementById('listaMeusRelatorios');
+    list.innerHTML = '';
+    snap.forEach(docSnap => {
+      list.appendChild(renderRelatorioCard(docSnap.id, docSnap.data(), false));
+    });
+  });
+}
+
+function listenCaixaGestor() {
+  if (!['gestor', 'adm'].includes((window.userPerfil || '').toLowerCase())) return;
+  const wrap = document.getElementById('caixaGestor');
+  wrap.classList.remove('hidden');
+  const q = query(collection(db, 'relatorios'), where('gestores', 'array-contains', currentUser.uid));
+  onSnapshot(q, snap => {
+    const list = document.getElementById('listaCaixaGestor');
+    list.innerHTML = '';
+    snap.forEach(docSnap => {
+      list.appendChild(renderRelatorioCard(docSnap.id, docSnap.data(), true));
+    });
+  });
+}
+
+async function atualizarStatus(id, status) {
+  await updateDoc(doc(db, 'relatorios', id), { status });
+}
+
+async function enviarComentario(id, texto) {
+  await addDoc(collection(db, 'relatorios', id, 'comentarios'), {
+    autorUid: currentUser.uid,
+    texto,
+    createdAt: serverTimestamp()
+  });
+}
+
+document.addEventListener('click', async e => {
+  const btn = e.target.closest('.btnStatus');
+  if (btn) {
+    await atualizarStatus(btn.dataset.id, btn.dataset.s);
+  }
+  const btnC = e.target.closest('.enviarComent');
+  if (btnC) {
+    const id = btnC.dataset.id;
+    const textarea = document.querySelector(`textarea[data-coment="${id}"]`);
+    const texto = textarea.value.trim();
+    if (texto) {
+      await enviarComentario(id, texto);
+      textarea.value = '';
+    }
+  }
+});
+
+function initAbaGestor() {
+  carregarGestoresDropdown();
+  document.getElementById('btnEnviarRelatorio').addEventListener('click', enviarRelatorio);
+  onAuthStateChanged(auth, async user => {
+    if (user) {
+      currentUser = user;
+      listenMinhasSubmissoes();
+      listenCaixaGestor();
+    }
+  });
+}
+
+window.initAbaGestor = initAbaGestor;

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -163,6 +163,11 @@
       <span class="link-text">Equipes</span>
     </a>
 
+    <a href="/VendedorPro/gestor.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestor">
+      <span class="mr-3">📂</span>
+      <span class="link-text">Gestor</span>
+    </a>
+
     <a href="/VendedorPro/manual.html" target="_blank" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-manual">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/>

--- a/storage.rules
+++ b/storage.rules
@@ -9,5 +9,14 @@ service firebase.storage {
       );
       allow write: if request.auth != null && ownerUid == request.auth.uid;
     }
+
+    match /reports/{autorUid}/{relatorioId}/{fileName} {
+      allow read: if request.auth != null && (
+        autorUid == request.auth.uid ||
+        (get(/databases/(default)/documents/relatorios/{relatorioId}).data.gestores != null && request.auth.uid in get(/databases/(default)/documents/relatorios/{relatorioId}).data.gestores) ||
+        get(/databases/(default)/documents/usuarios/$(request.auth.uid)).data.perfil in ['Gestor', 'ADM']
+      );
+      allow write: if request.auth != null && autorUid == request.auth.uid;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add Gestor tab where collaborators submit reports with attachments, managers review and comment
- register Gestor tab in sidebar and secure Firestore/Storage access rules

## Testing
- node -v
- npm test *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dc53d9600832abe1eb6e4173c3306