### PR TITLE
Pull in expedition team members on boards page

### DIFF
--- a/equipes.html
+++ b/equipes.html
@@ -916,7 +916,7 @@
         import { firebaseConfig as defaultFirebaseConfig } from './firebase-config.js';
 
         // Variáveis globais fornecidas pelo ambiente
-        const appId = typeof __app_id !== 'undefined' ? __app_id : 'default-app-id';
+        const appId = typeof __app_id !== 'undefined' ? __app_id : 'equipes';
                 const firebaseConfig = window.firebaseConfig || JSON.parse(typeof __firebase_config !== 'undefined' ? __firebase_config : '{}');
 
         const initialAuthToken = typeof __initial_auth_token !== 'undefined' ? __initial_auth_token : null;


### PR DESCRIPTION
## Summary
- default TeamFlow app ID to `equipes` so expedition team members saved via email-expedicao appear in the teams view

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dda437190832a8835871cd68eabb6