### PR TITLE
Enable expedition team reports to show for managers and senders

### DIFF
--- a/gestor.html
+++ b/gestor.html
@@ -36,11 +36,11 @@
       <div id="listaMeusRelatorios" class="card-body space-y-4"></div>
     </div>
 
-    <!-- Caixa do Gestor -->
+    <!-- Recebidos -->
     <div id="caixaGestor" class="hidden space-y-6">
       <div class="card">
         <div class="card-header flex flex-wrap items-center gap-2">
-          <h2 class="text-xl font-bold flex-1">Caixa do Gestor</h2>
+          <h2 class="text-xl font-bold flex-1">Recebidos</h2>
           <select id="filtroStatus" class="form-control w-40">
             <option value="">Status</option>
             <option value="enviado">Enviado</option>


### PR DESCRIPTION
## Summary
- load expedition managers from team and saved emails into report dropdown
- include sender in report recipients so both sides see reports
- expose 'Recebidos' inbox to any user, with status controls for managers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ddd7d0ee4832a93cfe8280c8e16d9