### PR TITLE
feat: add Financeiro tab and financial contact

### DIFF
--- a/email-expedicao.html
+++ b/email-expedicao.html
@@ -18,6 +18,7 @@
     <h1 class="text-2xl font-bold mb-4">E-mails do Responsável pela Expedição</h1>
     <form id="emailForm" class="space-y-4 max-w-lg">
       <input type="text" id="emailExpedicao" placeholder="email@empresa.com, outro@empresa.com" class="w-full p-2 border rounded">
+      <input type="email" id="emailFinanceiro" placeholder="financeiro@empresa.com" class="w-full p-2 border rounded">
       <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Salvar</button>
     </form>
     <p id="status" class="mt-4 text-green-600 hidden"></p>
@@ -43,6 +44,7 @@
     const db = firebase.firestore();
     let currentUser = null;
     const input = document.getElementById('emailExpedicao');
+    const financeInput = document.getElementById('emailFinanceiro');
     const statusEl = document.getElementById('status');
     const teamForm = document.getElementById('teamMemberForm');
     const teamMembersList = document.getElementById('teamMembersList');
@@ -56,9 +58,10 @@
       currentUser = user;
       try {
         const doc = await db.collection('uid').doc(user.uid).get();
-       const data = doc.data() || {};
+        const data = doc.data() || {};
         const emails = data.gestoresExpedicaoEmails || data.responsavelExpedicaoEmail || '';
         input.value = Array.isArray(emails) ? emails.join(', ') : emails;
+        financeInput.value = data.responsavelFinanceiroEmail || '';
       } catch (e) {
         console.error('Erro ao carregar e-mail:', e);
       }
@@ -79,11 +82,18 @@
       statusEl.classList.add('hidden');
       const emailsRaw = input.value.trim();
       const emails = emailsRaw.split(',').map(e => e.trim()).filter(e => e);
+      const emailFinanceiro = financeInput.value.trim();
       try {
         await db.collection('uid').doc(currentUser.uid).set({
-responsavelExpedicaoEmail: emails[0] || null,
+          responsavelExpedicaoEmail: emails[0] || null,
           gestoresExpedicaoEmails: emails,
+          responsavelFinanceiroEmail: emailFinanceiro || null,
           uid: currentUser.uid,
+          email: currentUser.email
+        }, { merge: true });
+        await db.collection('usuarios').doc(currentUser.uid).set({
+          responsavelFinanceiroEmail: emailFinanceiro || null,
+          gestoresExpedicaoEmails: emails,
           email: currentUser.email
         }, { merge: true });
         statusEl.textContent = 'E-mail salvo com sucesso!';

--- a/financeiro.html
+++ b/financeiro.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Financeiro</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="css/components.css">
+</head>
+<body class="bg-gray-100 text-gray-800">
+  <div id="sidebar-container"></div>
+  <div id="navbar-container"></div>
+  <main class="main-content p-4 space-y-4">
+    <div class="card">
+      <div class="card-header">
+        <h2 class="text-xl font-bold">📊 Relatório de SKUs Vendidos</h2>
+      </div>
+      <div class="card-body" id="resumoSkus">Carregando...</div>
+    </div>
+    <div class="card">
+      <div class="card-header">
+        <h2 class="text-xl font-bold">💸 Saques e Comissões</h2>
+      </div>
+      <div class="card-body" id="resumoSaques">Carregando...</div>
+    </div>
+  </main>
+  <script type="module" src="firebase-config.js"></script>
+  <script type="module" src="financeiro.js"></script>
+  <script src="shared.js"></script>
+</body>
+</html>

--- a/financeiro.js
+++ b/financeiro.js
@@ -1,0 +1,79 @@
+import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { getFirestore, collection, getDocs, query, where } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { loadSecureDoc } from './secure-firestore.js';
+import { firebaseConfig, getPassphrase } from './firebase-config.js';
+
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+const db = getFirestore(app);
+const auth = getAuth(app);
+
+onAuthStateChanged(auth, async user => {
+  if (!user) {
+    window.location.href = 'index.html?login=1';
+    return;
+  }
+  let targetUid = user.uid;
+  try {
+    const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email)));
+    if (!snap.empty) {
+      targetUid = snap.docs[0].id;
+    }
+  } catch (err) {
+    console.error('Erro ao verificar acesso financeiro:', err);
+  }
+  await carregarSkus(targetUid);
+  await carregarSaques(targetUid);
+});
+
+async function carregarSkus(uid) {
+  const container = document.getElementById('resumoSkus');
+  if (!container) return;
+  container.innerHTML = 'Carregando...';
+  const snap = await getDocs(collection(db, `uid/${uid}/skuimpressos`));
+  const resumo = {};
+  snap.forEach(doc => {
+    const dados = doc.data();
+    const sku = dados.sku || 'sem-sku';
+    const qtd = Number(dados.quantidade) || 0;
+    resumo[sku] = (resumo[sku] || 0) + qtd;
+  });
+  container.innerHTML = '';
+  if (!Object.keys(resumo).length) {
+    container.innerHTML = '<p class="text-gray-500">Nenhum SKU encontrado.</p>';
+    return;
+  }
+  const ul = document.createElement('ul');
+  ul.className = 'list-disc pl-4 space-y-1';
+  Object.entries(resumo).forEach(([sku, qtd]) => {
+    const li = document.createElement('li');
+    li.textContent = `${sku}: ${qtd}`;
+    ul.appendChild(li);
+  });
+  container.appendChild(ul);
+}
+
+async function carregarSaques(uid) {
+  const container = document.getElementById('resumoSaques');
+  if (!container) return;
+  container.innerHTML = 'Carregando...';
+  const pass = getPassphrase() || `chave-${uid}`;
+  const snap = await getDocs(collection(db, `uid/${uid}/saques`));
+  let total = 0;
+  let totalComissao = 0;
+  for (const docSnap of snap.docs) {
+    const dados = await loadSecureDoc(db, `uid/${uid}/saques`, docSnap.id, pass);
+    if (!dados) continue;
+    total += dados.valorTotal || 0;
+    const lojasSnap = await getDocs(collection(db, `uid/${uid}/saques/${docSnap.id}/lojas`));
+    for (const lojaDoc of lojasSnap.docs) {
+      const lojaDados = await loadSecureDoc(db, `uid/${uid}/saques/${docSnap.id}/lojas`, lojaDoc.id, pass);
+      if (!lojaDados) continue;
+      const valor = lojaDados.valor || 0;
+      const comissao = lojaDados.comissao || 0;
+      totalComissao += valor * (comissao / 100);
+    }
+  }
+  container.innerHTML = `<p>Total de Saques: <strong>R$ ${total.toLocaleString('pt-BR')}</strong></p>
+<p>Total de Comissões: <strong>R$ ${totalComissao.toLocaleString('pt-BR')}</strong></p>`;
+}

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -129,6 +129,11 @@
       <a href="/VendedorPro/etiquetas-ocr.html" class="sidebar-link block py-2 px-4 transition-colors">Etiquetas OCR</a>
     </div>
 
+    <a href="/VendedorPro/financeiro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-financeiro">
+      <span class="mr-3">💰</span>
+      <span class="link-text">Financeiro</span>
+    </a>
+
     <!-- Configurações -->
     <div class="sidebar-item flex items-center justify-between">
       <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-configuracoes">


### PR DESCRIPTION
## Summary
- add Financeiro page showing SKU and withdrawal summaries
- allow storing financial contact in expedição email settings
- link Financeiro in the sidebar navigation

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check financeiro.js`

------
https://chatgpt.com/codex/tasks/task_e_689e1265f080832a86b38fcf0ee2bae5