### PR TITLE
Allow contasfechamento uploads

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -35,5 +35,9 @@ service cloud.firestore {
         );
       }
     }
+
+    match /contasfechamento/{docId} {
+      allow read, write: if request.auth != null;
+    }
   }
 }

--- a/storage.rules
+++ b/storage.rules
@@ -18,5 +18,9 @@ service firebase.storage {
       );
       allow write: if request.auth != null && autorUid == request.auth.uid;
     }
+
+    match /contasfechamento/{fileName} {
+      allow read, write: if request.auth != null;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- permit authenticated storage access to `contasfechamento` folder
- allow Firestore reads and writes to `contasfechamento` collection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e128f4f30832abe842ebe82273c8d