### PR TITLE
Add revenue vs goal card and group financial data by user

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -45,6 +45,17 @@
       </div>
       <div class="card-body" id="resumoSaques">Carregando...</div>
     </div>
+
+    <div class="card">
+      <div class="card-header justify-between">
+        <h2 class="text-xl font-bold">📈 Faturamento x Meta</h2>
+        <div class="flex items-center gap-2">
+          <button id="exportFaturamento" class="btn btn-primary text-sm">Exportar Excel</button>
+          <button class="toggle-btn" data-target="resumoFaturamento"><i class="fa fa-eye-slash"></i></button>
+        </div>
+      </div>
+      <div class="card-body" id="resumoFaturamento">Carregando...</div>
+    </div>
   </main>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="financeiro.js"></script>


### PR DESCRIPTION
## Summary
- Display a new **Faturamento x Meta** card on the finance page with export support
- Group withdrawal and commission summaries by user for financial managers
- Load and export user revenue versus goals per month

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e73b05d8c832a9979d494980e6bb3