### PR TITLE
Add quick access buttons for finance, expedition and ZPL pages

### DIFF
--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -7,7 +7,21 @@
       </div>
       
       <div class="flex items-center space-x-5">
-        <!-- Dark mode toggle -->
+        <!-- Atalhos de navegação -->
+        <a href="financeiro.html" class="btn btn-primary">
+          <i class="fa-solid fa-dollar-sign"></i>
+          Financeiro
+        </a>
+        <a href="expedicao.html" class="btn btn-primary">
+          <i class="fa-solid fa-truck"></i>
+          Expedição
+        </a>
+        <a href="zpl-import.html" class="btn btn-primary">
+          <i class="fa-solid fa-barcode"></i>
+          Etiquetas ZPL
+        </a>
+
+        <!-- Botão de login -->
         <button id="loginBtn" onclick="openModal('loginModal')" class="bg-orange-500 text-white p-2 rounded hover:bg-orange-600 transition">
           <i class="fa-solid fa-user"></i>
         </button>


### PR DESCRIPTION
## Summary
- add header buttons linking to Financeiro, Expedição and ZPL labels pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e74ee34d4832a80cb76f85ba38559