### PR TITLE
Add monthly revenue goal management

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -24,6 +24,14 @@
       </div>
     </div>
 
+    <div id="metaSection" class="hidden flex flex-wrap gap-2 items-end">
+      <div>
+        <label for="metaValor" class="text-sm font-medium">Meta Mensal (R$)</label>
+        <input type="number" id="metaValor" class="border rounded p-2" placeholder="0" />
+      </div>
+      <button id="salvarMeta" class="btn btn-primary text-sm">Salvar Meta</button>
+    </div>
+
     <div class="card">
       <div class="card-header justify-between">
         <h2 class="text-xl font-bold">📊 Relatório de SKUs Vendidos</h2>


### PR DESCRIPTION
## Summary
- allow financial managers to define monthly revenue targets for selected users
- compute expected revenue based on days in month and compare with actual
- export detailed goal progress data

## Testing
- `node --check financeiro.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e89c4b9e8832a9c98e6604ee50db1