### PR TITLE
feat: allow card or list view on expedition page

### DIFF
--- a/expedicao.html
+++ b/expedicao.html
@@ -34,6 +34,10 @@
       <button class="filter-btn px-4 py-2 rounded-full bg-gray-100 text-gray-700 text-sm font-medium hover:bg-gray-200 transition" data-status="impresso">Impresso</button>
       <button class="filter-btn px-4 py-2 rounded-full bg-gray-100 text-gray-700 text-sm font-medium hover:bg-gray-200 transition" data-status="concluido">Concluído</button>
     </div>
+    <div id="viewToggle" class="flex gap-2 mb-4">
+      <button class="view-btn px-4 py-2 rounded-full bg-indigo-600 text-white text-sm font-medium" data-view="cards" title="Exibição em cartões"><i class="fas fa-th"></i></button>
+      <button class="view-btn px-4 py-2 rounded-full bg-gray-100 text-gray-700 text-sm font-medium hover:bg-gray-200 transition" data-view="list" title="Exibição em lista"><i class="fas fa-list"></i></button>
+    </div>
     <div id="labelsList" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"></div>
   </div>
 
@@ -55,6 +59,7 @@
     const storage = firebase.storage();
     let currentUser = null;
     let currentFilter = 'all';
+    let viewMode = 'cards';
     let diaDocRef = null;
     let isResponsavel = false;
     const userNameCache = {};
@@ -76,6 +81,19 @@
         btn.classList.remove('bg-gray-100','text-gray-700');
         btn.classList.add('bg-indigo-600','text-white');
         currentFilter = btn.dataset.status;
+        carregarEtiquetas();
+      });
+    });
+
+    document.querySelectorAll('.view-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.view-btn').forEach(b => {
+          b.classList.remove('bg-indigo-600','text-white');
+          b.classList.add('bg-gray-100','text-gray-700');
+        });
+        btn.classList.remove('bg-gray-100','text-gray-700');
+        btn.classList.add('bg-indigo-600','text-white');
+        viewMode = btn.dataset.view;
         carregarEtiquetas();
       });
     });
@@ -135,6 +153,9 @@
     async function carregarEtiquetas() {
       const list = document.getElementById('labelsList');
       list.innerHTML = '';
+      list.className = viewMode === 'cards'
+        ? 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'
+        : 'flex flex-col gap-4';
       const filter = currentFilter;
       const snap = await db
         .collection('pdfDocs')
@@ -149,8 +170,8 @@
         const status = data.status || 'nao_impresso';
         if (filter !== 'all' && status !== filter) continue;
         const ownerName = await getOwnerName(data.ownerUid, data.ownerEmail);
-        const card = createPdfCard(doc, ownerName);
-        list.appendChild(card);
+        const item = viewMode === 'cards' ? createPdfCard(doc, ownerName) : createPdfListItem(doc, ownerName);
+        list.appendChild(item);
       }
       if (!list.hasChildNodes()) {
         list.innerHTML = '<p class="text-gray-500">Nenhuma etiqueta encontrada.</p>';
@@ -340,6 +361,49 @@
             <i class="fas fa-pen absolute left-3 top-3 text-gray-400"></i>
             <textarea class="border rounded-md p-2 pl-8 w-full h-10 focus:h-24 transition-all text-sm" placeholder="Observação" onblur="salvarObservacao('${doc.id}', this.value)">${observacao}</textarea>
           </div>
+      <button class="w-full bg-green-600 text-white px-3 py-2 rounded-md text-sm hover:bg-green-700 transition" onclick="marcarConcluido('${doc.id}', this.closest('.pdf-card'))">Concluir</button>
+        </div>`;
+      return div;
+    }
+
+    function createPdfListItem(doc, ownerName) {
+      const data = doc.data();
+      const status = data.status || 'nao_impresso';
+      const attention = data.attention || false;
+      const observacao = data.observacao || '';
+      const name = data.name || 'PDF';
+      const url = data.url;
+      const owner = ownerName || 'Desconhecido';
+      const createdAt = data.createdAt && data.createdAt.toDate
+        ? data.createdAt.toDate().toLocaleString('pt-BR')
+        : 'Data desconhecida';
+      const statusClass = status === 'impresso'
+        ? 'bg-green-100'
+        : status === 'nao_impresso'
+          ? 'bg-yellow-100'
+          : 'bg-white';
+      const div = document.createElement('div');
+      div.className = `pdf-card flex flex-col md:flex-row md:items-center md:justify-between p-4 rounded-md shadow ${statusClass}` + (attention ? ' border-2 border-red-500' : '');
+      div.innerHTML = `
+        <div class="flex-1">
+          <p class="font-semibold text-gray-800">${name}</p>
+          <p class="text-sm text-gray-500">Criado por: ${owner} em ${createdAt}</p>
+          <div class="mt-2 flex flex-wrap gap-2">
+            <button class="text-indigo-600 hover:text-indigo-800" onclick="visualizar('${url}')" title="Visualizar"><i class="fas fa-eye"></i></button>
+            <button class="text-indigo-600 hover:text-indigo-800" onclick="imprimir('${url}')" title="Imprimir"><i class="fas fa-print"></i></button>
+            <a class="text-indigo-600 hover:text-indigo-800" href="${url}" download="${name}" title="Baixar"><i class="fas fa-download"></i></a>
+          </div>
+        </div>
+        <div class="mt-3 md:mt-0 flex flex-col gap-2 w-full md:w-1/3">
+          <label class="cursor-pointer">
+            <input type="checkbox" class="peer sr-only" ${status === 'impresso' ? 'checked' : ''} onchange="toggleImpresso('${doc.id}', this, this.closest('.pdf-card'))">
+            <span class="px-2 py-1 rounded-full text-xs font-medium border border-gray-300 text-gray-600 peer-checked:bg-green-500 peer-checked:border-green-500 peer-checked:text-white flex items-center gap-1"><i class="fas fa-check"></i><span>Impresso</span></span>
+          </label>
+          <label class="cursor-pointer">
+            <input type="checkbox" class="peer sr-only" ${attention ? 'checked' : ''} onchange="toggleAtencao('${doc.id}', this, this.closest('.pdf-card'))">
+            <span class="px-2 py-1 rounded-full text-xs font-medium border border-gray-300 text-gray-600 peer-checked:bg-red-500 peer-checked:border-red-500 peer-checked:text-white flex items-center gap-1"><i class="fas fa-exclamation-triangle"></i><span>Atenção</span></span>
+          </label>
+          <textarea class="border rounded-md p-2 w-full text-sm" placeholder="Observação" onblur="salvarObservacao('${doc.id}', this.value)">${observacao}</textarea>
           <button class="w-full bg-green-600 text-white px-3 py-2 rounded-md text-sm hover:bg-green-700 transition" onclick="marcarConcluido('${doc.id}', this.closest('.pdf-card'))">Concluir</button>
         </div>`;
       return div;


### PR DESCRIPTION
## Summary
- add buttons to switch expedition orders between card and list layouts
- render labels according to selected view mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f113b0b7c832aab85e66c07289120