### PR TITLE
refactor: modernize dashboard styling

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -1,13 +1,12 @@
 /* Consolidated component styles without Tailwind's @apply */
 .card {
   background-color: #fff;
-  border: 1px solid var(--border, #e5e7eb);
   border-radius: 0.75rem; /* rounded-xl */
-  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
   transition: box-shadow .2s;
 }
 .card:hover {
-  box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -2px rgba(0,0,0,0.05);
+  box-shadow: 0 8px 12px rgba(0,0,0,0.1);
 }
 .card-header {
   display: flex;
@@ -18,8 +17,6 @@
 .card-body {
   padding: 1.25rem; /* p-5 */
 }
- filter: blur(4px);
-}
 .btn {
   display: inline-flex;
   align-items: center;
@@ -29,14 +26,45 @@
   padding: 0.5rem 1rem; /* px-4 py-2 */
   font-weight: 500; /* font-medium */
   transition: background-color .2s, color .2s, box-shadow .2s;
+  border: none;
+  cursor: pointer;
 }
 .btn-primary {
-  background-color: var(--primary, #f97316);
+  background-color: var(--primary);
   color: #fff;
   box-shadow: 0 1px 2px rgba(0,0,0,0.05);
 }
 .btn-primary:hover {
-  background-color: var(--primary-dark, #ea580c);
+  background-color: var(--primary-hover);
+}
+
+.btn-secondary {
+  background-color: transparent;
+  border: 2px solid var(--primary);
+  color: var(--primary);
+}
+.btn-secondary:hover {
+  background-color: var(--primary);
+  color: #fff;
+}
+
+.btn-ghost {
+  background-color: transparent;
+  color: var(--primary);
+}
+.btn-ghost:hover {
+  background-color: rgba(255,112,67,0.1);
+}
+
+.action-link {
+  color: var(--primary);
+  font-weight: 500;
+  text-decoration: none;
+  transition: color .2s;
+}
+.action-link:hover {
+  text-decoration: underline;
+  color: var(--primary-hover);
 }
 .data-table {
   width: 100%;

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,32 +1,32 @@
 
 :root {
-  /* Adjusted primary palette for a softer orange tone */
-  --primary: #f97316;
-  --primary-hover: #fb923c;
-  --primary-dark: #c2410c;
-  --primary-light: #fde68a;
-  --brand: #f97316;
-  --hover: #fb923c;
+  /* Modern orange & purple palette */
+  --primary: #FF7043;
+  --primary-hover: #FF8A65;
+  --primary-dark: #E64A19;
+  --primary-light: #FFE0B2;
+  --brand: #FF7043;
+  --hover: #FF8A65;
   --dark: #1C2B36;
-  --secondary: #273746;
-  --nav-bg: #1e3a8a;
+  --secondary: #7E57C2;
+  --nav-bg: #7E57C2;
   --success: #4CAF50;
   --error: #F44336;
   --danger: #F44336;
   --bg-light: #F5F7FA;
-  --background: #FFFFFF;
-  --bg: #FFFFFF;
-  --border: #E5E7EB;
+  --background: #FAFAFA;
+  --bg: #FAFAFA;
+  --border: #E0E0E0;
   --card: #FFFFFF;
   --card-bg: #FFFFFF;
-  --card-shadow: 0 4px 10px rgba(0,0,0,0.05);
+  --card-shadow: 0 4px 6px rgba(0,0,0,0.1);
   --gray: #6B7280;
-  --text: #1F2937;
-  --text-dark: #111827;
-  --text-light: #6B7280;
+  --text: #616161;
+  --text-dark: #424242;
+  --text-light: #9E9E9E;
   --transition: all 0.3s ease;
-  --navbar-height: 70px;
-  --sidebar-width: 16rem
+  --navbar-height: 60px;
+  --sidebar-width: 16rem;
 }
     
   
@@ -35,14 +35,14 @@
   top: 0;
   right: 0;
   left: var(--sidebar-width);
-  height: 70px;
+  height: 60px;
   background-color: var(--nav-bg);
   box-shadow: 0 2px 10px rgba(0,0,0,.05);
   z-index: 30;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 30px;
+  padding: 0 20px;
 transition: .3s;
   color: #fff
 
@@ -51,7 +51,7 @@ transition: .3s;
 .content-wrapper {
   flex: 1;
   margin-left: var(--sidebar-width);
-  margin-top: 70px;
+  margin-top: 60px;
   padding: 30px
 }
 
@@ -77,7 +77,7 @@ transition: .3s;
   align-items: center;
  justify-content: center;
   margin-right: 15px;
-  background-color: rgba(249,115,22,0.1); /* subtle highlight */
+  background-color: rgba(255,112,67,0.1); /* subtle highlight */
   color: var(--primary);
 }
 
@@ -232,7 +232,7 @@ input:checked + .dark-mode-slider:before {
 }
 
 #tarefasCard .card-header-icon {
-  background-color: rgba(249,115,22,0.1);
+  background-color: rgba(255,112,67,0.1);
   color: var(--primary);
 }
 
@@ -260,26 +260,25 @@ input:checked + .dark-mode-slider:before {
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1rem;
-  border: 1px solid var(--border);
   border-radius: 0.5rem;
   background-color: #fff;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+  box-shadow: 0 4px 6px rgba(0,0,0,0.05);
   transition: background-color .2s, box-shadow .2s, transform .2s;
 }
 
 #tarefasCard .task-item:hover {
   background-color: #f3f4f6;
-  box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+  box-shadow: 0 6px 8px rgba(0,0,0,0.08);
   transform: translateY(-2px);
 }
 
 #tarefasCard .task-item.completed {
-  background-color: #ecfdf5;
+  background-color: rgba(126,87,194,0.1);
 }
 
 #tarefasCard .task-text.completed {
   text-decoration: line-through;
-  color: #6b7280;
+  color: var(--text-light);
 }
 
 #tarefasCard input[type="checkbox"] {

--- a/index.js
+++ b/index.js
@@ -8,6 +8,22 @@ import { firebaseConfig } from './firebase-config.js';
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app);
+
+function getPalette() {
+  const styles = getComputedStyle(document.documentElement);
+  return {
+    primary: styles.getPropertyValue('--primary').trim(),
+    secondary: styles.getPropertyValue('--secondary').trim()
+  };
+}
+
+function hexToRgba(hex, opacity) {
+  const bigint = parseInt(hex.replace('#', ''), 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgba(${r},${g},${b},${opacity})`;
+}
 function toggleBlur(cardId) {
   const card = document.getElementById(cardId);
   if (!card) return;
@@ -135,11 +151,11 @@ let totalLiquido = 0;
       <div class="card-body space-y-4">
         <div>
           <div class="text-sm text-gray-500">Líquido</div>
-          <div class="text-4xl font-extrabold text-green-600">R$ ${totalLiquido.toLocaleString('pt-BR', {minimumFractionDigits:2})}</div>
+          <div class="text-4xl font-extrabold" style="color: var(--primary)">R$ ${totalLiquido.toLocaleString('pt-BR', {minimumFractionDigits:2})}</div>
         </div>
         <div>
           <div class="text-sm text-gray-500">Bruto</div>
-          <div class="text-2xl font-bold text-blue-600">R$ ${totalBruto.toLocaleString('pt-BR', {minimumFractionDigits:2})}</div>
+          <div class="text-2xl font-bold" style="color: var(--secondary)">R$ ${totalBruto.toLocaleString('pt-BR', {minimumFractionDigits:2})}</div>
         </div>
       </div>
     </a>`;
@@ -194,10 +210,10 @@ async function carregarTarefas(uid, isAdmin) {
   listaFeitas.innerHTML = '';
 
   const tarefas = [
-    '<a href="https://seller.shopee.com.br/portal/sale/order" target="_blank" rel="noopener">Baixar planilha vendas Shopee</a>',
-    '<a href="https://mferraretto.github.io/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento" target="_blank" rel="noopener">Registrar no sistema - Fechamento dia anterior</a>',
-    '<a href="https://seller.shopee.com.br/portal/sale/mass/ship?mass_shipment_tab=201&filter.shipping_method=91003&filter.order_item_filter_type=item0&filter.order_process_status=1&filter.sort.sort_type=1&filter.sort.ascending=true&filter.pre_order=2&filter.shipping_urgency_filter.current_time=1755177333&filter.shipping_urgency_filter.shipping_urgency=1" target="_blank" rel="noopener">Organizar coleta e imprimir etiquetas + lista de empacotamento ZPL</a>',
-    '<a href="https://mferraretto.github.io/VendedorPro/zpl-import.html" target="_blank" rel="noopener">Importar o arquivo ZPL para o sistema e aguardar a impressão das etiquetas do dia</a>'
+    '<a class="action-link" href="https://seller.shopee.com.br/portal/sale/order" target="_blank" rel="noopener">Baixar planilha vendas Shopee</a>',
+    '<a class="action-link" href="https://mferraretto.github.io/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento" target="_blank" rel="noopener">Registrar no sistema - Fechamento dia anterior</a>',
+    '<a class="action-link" href="https://seller.shopee.com.br/portal/sale/mass/ship?mass_shipment_tab=201&filter.shipping_method=91003&filter.order_item_filter_type=item0&filter.order_process_status=1&filter.sort.sort_type=1&filter.sort.ascending=true&filter.pre_order=2&filter.shipping_urgency_filter.current_time=1755177333&filter.shipping_urgency_filter.shipping_urgency=1" target="_blank" rel="noopener">Organizar coleta e imprimir etiquetas + lista de empacotamento ZPL</a>',
+    '<a class="action-link" href="https://mferraretto.github.io/VendedorPro/zpl-import.html" target="_blank" rel="noopener">Importar o arquivo ZPL para o sistema e aguardar a impressão das etiquetas do dia</a>'
   ];
   const hoje = new Date();
   const storageKey = `tarefasFeitas_${hoje.toISOString().slice(0,10)}`;
@@ -315,6 +331,7 @@ async function carregarGraficoFaturamento(uid, isAdmin) {
   const canvasLinha = document.getElementById('chartFaturamentoMeta');
   if (!canvasLinha || typeof Chart === 'undefined') return;
   const ctxLinha = canvasLinha.getContext('2d');
+  const { primary, secondary } = getPalette();
 
   const filtro = document.getElementById('filtroMesFaturamento');
   const mesFiltro = filtro?.value || new Date().toISOString().slice(0, 7);
@@ -371,8 +388,8 @@ async function carregarGraficoFaturamento(uid, isAdmin) {
       datasets: [{
         label: 'Líquido',
         data: valores,
-        borderColor: '#34D399',
-        backgroundColor: 'rgba(52,211,153,0.2)',
+        borderColor: primary,
+        backgroundColor: hexToRgba(primary, 0.2),
         tension: 0.1,
         fill: true
       }]
@@ -405,7 +422,7 @@ async function carregarGraficoFaturamento(uid, isAdmin) {
         labels: ['Faturado', 'Meta'],
         datasets: [{
           data: [totalLiquido, meta],
-          backgroundColor: ['#34D399', '#F87171']
+          backgroundColor: [primary, secondary]
         }]
       },
       options: {


### PR DESCRIPTION
## Summary
- apply orange and purple design palette
- unify card and button styles with soft shadows
- refresh dashboard charts and tasks visuals

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f1c90be98832a95048ec0bbee4deb