### PR TITLE
Add finance landing page with restricted sidebar

### DIFF
--- a/atualizacoes.html
+++ b/atualizacoes.html
@@ -33,6 +33,7 @@
   </main>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="atualizacoes.js"></script>
+  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-financeiro.html';</script>
   <script src="shared.js"></script>
 </body>
 </html>

--- a/financeiro-inicio.html
+++ b/financeiro-inicio.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <title>Início Financeiro</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/styles.css" />
+  <link rel="stylesheet" href="css/components.css" />
+</head>
+<body class="bg-gray-100 text-gray-800">
+  <div id="sidebar-container"></div>
+  <div id="navbar-container"></div>
+  <main class="main-content p-4 space-y-4">
+    <h1 class="text-2xl font-bold">Área Financeira</h1>
+    <p>Selecione uma opção no menu ao lado para acessar as ferramentas financeiras.</p>
+  </main>
+  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-financeiro.html';</script>
+  <script src="shared.js"></script>
+</body>
+</html>

--- a/financeiro.html
+++ b/financeiro.html
@@ -44,6 +44,7 @@
   </main>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="financeiro.js"></script>
+  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-financeiro.html';</script>
   <script src="shared.js"></script>
-</body>
+  </body>
 </html>

--- a/partials/sidebar-financeiro.html
+++ b/partials/sidebar-financeiro.html
@@ -1,0 +1,22 @@
+<div id="sidebar" class="sidebar w-64 h-screen overflow-y-auto fixed left-0 top-0 z-50 text-gray-100">
+  <div class="sidebar-logo p-4">
+    <div class="flex items-center">
+      <div class="bg-white w-10 h-10 rounded-lg flex items-center justify-center mr-3">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-orange-500">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.981 14.981 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z" />
+        </svg>
+      </div>
+      <span class="font-bold text-xl text-white">VendedorPro</span>
+    </div>
+  </div>
+  <div class="py-4">
+    <a href="/VendedorPro/financeiro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-financeiro">
+      <span class="mr-3">💰</span>
+      <span class="link-text">Financeiro</span>
+    </a>
+    <a href="/VendedorPro/atualizacoes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-atualizacoes">
+      <span class="mr-3">📎</span>
+      <span class="link-text">Atualizações</span>
+    </a>
+  </div>
+</div>

--- a/shared.js
+++ b/shared.js
@@ -65,9 +65,10 @@
     });
   }
 // Load sidebar HTML into placeholder
-  window.loadSidebar = function(containerId) {
+  window.loadSidebar = function(containerId, sidebarPath) {
     containerId = containerId || 'sidebar-container';
-    return fetch(BASE_PATH + 'partials/sidebar.html')
+    sidebarPath = sidebarPath || 'partials/sidebar.html';
+    return fetch(BASE_PATH + sidebarPath)
       .then(function(res) { return res.text(); })
       .then(function(html) {
         var container = document.getElementById(containerId);
@@ -172,7 +173,7 @@
 
 document.addEventListener('DOMContentLoaded', function () {
   loadTailwind().then(function () {
-    window.loadSidebar().then(function () {
+    window.loadSidebar(null, window.CUSTOM_SIDEBAR_PATH).then(function () {
       window.initDarkMode();
     });
     window.loadNavbar();


### PR DESCRIPTION
## Summary
- allow loading custom sidebar files via shared script
- add finance-only landing page and sidebar with links to Financeiro and Atualizações
- use restricted sidebar on Financeiro and Atualizações pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a25290f4cc832abe71efc52ed2d9cf