### PR TITLE
Add sidebar card for daily revenue updates

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -42,6 +42,12 @@
 
     <div id="cardsContainer" class="space-y-6"></div>
   </main>
+  <div id="faturamentoUpdatesCard" class="card card-orange fixed top-20 right-4 w-72 max-h-96 overflow-y-auto hidden">
+    <div class="card-header">
+      <h2 class="text-lg font-bold flex items-center gap-2"><i class="fa fa-chart-line"></i> Faturamento Diário</h2>
+    </div>
+    <div class="card-body space-y-2" id="faturamentoFeed"></div>
+  </div>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="financeiro.js"></script>
   <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-financeiro.html';</script>


### PR DESCRIPTION
## Summary
- Add fixed sidebar card on financeiro page to list daily revenue updates
- Listen for faturamento collection changes and populate card in real time

## Testing
- `node --check financeiro.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a306435be0832a8aa96c5fea29ffb3