### PR TITLE
Default finance tab to current month

### DIFF
--- a/financeiro.js
+++ b/financeiro.js
@@ -105,7 +105,12 @@ async function salvarMeta() {
 }
 
 async function carregar() {
-  const mes = document.getElementById('mesFiltro')?.value || '';
+  const mesSel = document.getElementById('mesFiltro');
+  let mes = mesSel?.value;
+  if (!mes) {
+    mes = new Date().toISOString().slice(0,7);
+    if (mesSel) mesSel.value = mes;
+  }
   const uid = document.getElementById('usuarioFiltro')?.value || 'todos';
   const listaUsuarios = uid === 'todos' ? usuariosCache : usuariosCache.filter(u => u.uid === uid);
   atualizarContexto();


### PR DESCRIPTION
## Summary
- Default finance tab to show current month data when no month filter is selected

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm test --prefix functions` *(fails: Missing script "test"*

------
https://chatgpt.com/codex/tasks/task_e_68a30c076160832a8dd8b081be6046c0