### PR TITLE
fix: correct faturamento date parsing

### DIFF
--- a/financeiro.js
+++ b/financeiro.js
@@ -453,6 +453,17 @@ function createFaturamentoCard(u) {
 }
 
 function formatarData(str) {
+  // Evita problemas de fuso horário ao converter datas (ex.: "2024-05-01" 
+  // sendo interpretado como 30/04 em localidades UTC-3). Quando a string
+  // está no formato YYYY-MM-DD construímos a data utilizando o construtor
+  // `new Date(ano, mesIndex, dia)` que considera o fuso local sem deslocar
+  // para UTC.
+  const match = /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/.exec(str);
+  if (match) {
+    const [_, a, m, d] = match;
+    const data = new Date(Number(a), Number(m) - 1, Number(d));
+    return data.toLocaleDateString('pt-BR');
+  }
   const d = new Date(str);
   return isNaN(d) ? str : d.toLocaleDateString('pt-BR');
 }


### PR DESCRIPTION
## Summary
- prevent timezone shifts when formatting daily faturamento dates

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a30ee4015c832aaa6b41d4f2c03494