### PR TITLE
Destacar cards e separar KPIs no dashboard

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -1,12 +1,12 @@
 /* Consolidated component styles without Tailwind's @apply */
 .card {
   background-color: #f9f9f9;
-  border-radius: 0.75rem; /* rounded-xl */
-  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+  border-radius: 1rem; /* rounded-2xl */
+  box-shadow: 0 10px 15px rgba(0,0,0,0.1);
   transition: box-shadow .2s;
 }
 .card:hover {
-  box-shadow: 0 8px 12px rgba(0,0,0,0.1);
+  box-shadow: 0 15px 25px rgba(0,0,0,0.1);
 }
 .card-header {
   display: flex;

--- a/css/styles.css
+++ b/css/styles.css
@@ -1822,8 +1822,8 @@ body.dark .submenu a:hover {
 }
 .card {
   background: var(--card);
-  border-radius: 12px;
-  box-shadow: 0 4px 6px rgba(0,0,0,.05);
+  border-radius: 1rem;
+  box-shadow: 0 10px 15px rgba(0,0,0,.1);
   padding: 20px;
   border: 1px solid var(--border);
   margin-bottom: 1.5rem;
@@ -1832,7 +1832,7 @@ body.dark .submenu a:hover {
 }
 .card:hover {
   transform: translateY(-3px);
-  box-shadow: 0 6px 12px rgba(0,0,0,.1)
+  box-shadow: 0 15px 25px rgba(0,0,0,.1)
 }
 .dashboard-card {
   background: var(--card);

--- a/index.html
+++ b/index.html
@@ -46,6 +46,9 @@
       </div>
       
 
+      <!-- KPI Cards -->
+      <div id="kpiCards" class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6"></div>
+
       <!-- Cards Grid -->
       <div class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6 mb-8">
         <div id="resumoFaturamento"></div>
@@ -53,7 +56,7 @@
         <div class="card" id="topSkusCard" data-blur-id="topSkusCard">
           <div class="card-header">
            <div class="card-header-icon">
-              <i class="fas fa-trophy text-xl"></i>
+              <span class="text-2xl">📦</span>
             </div>
             <div>
               <h2 class="text-xl font-extrabold text-gray-800">Top 5 SKUs do Mês</h2>
@@ -92,7 +95,7 @@
         <div class="card" id="tarefasCard">
           <div class="card-header">
             <div class="card-header-icon">
-              <i class="fas fa-tasks text-xl"></i>
+              <span class="text-2xl">✅</span>
             </div>
             <div>
               <h2 class="text-xl font-extrabold">Tarefas do Dia</h2>

--- a/index.js
+++ b/index.js
@@ -93,8 +93,10 @@ function maybeStartTour() {
 
 async function carregarResumoFaturamento(uid, isAdmin) {
   const el = document.getElementById('resumoFaturamento');
+  const kpiEl = document.getElementById('kpiCards');
   if (!el) return;
   el.innerHTML = 'Carregando...';
+  if (kpiEl) kpiEl.innerHTML = 'Carregando...';
   const hoje = new Date();
   const mesAtual = hoje.toISOString().slice(0,7); // YYYY-MM
   let totalLiquido = 0;
@@ -139,10 +141,25 @@ async function carregarResumoFaturamento(uid, isAdmin) {
   }
   const labels = Object.keys(dias).sort((a,b)=>a.localeCompare(b));
   const valores = labels.map(d=>dias[d]);
+  const lucro = totalLiquido - totalBruto;
+  if (kpiEl) {
+    const kpis = [
+      { titulo: 'Lucro', valor: lucro, moeda: true },
+      { titulo: 'Receita Bruta', valor: totalBruto, moeda: true },
+      { titulo: 'Receita Líquida', valor: totalLiquido, moeda: true },
+      { titulo: 'Pedidos', valor: pedidos, moeda: false }
+    ];
+    kpiEl.innerHTML = kpis.map(k => `
+      <div class="bg-white rounded-2xl shadow-lg p-4 text-center">
+        <div class="text-sm text-gray-500">${k.titulo}</div>
+        <div class="text-2xl font-bold">${k.moeda ? 'R$ ' + k.valor.toLocaleString('pt-BR', { minimumFractionDigits: 2 }) : k.valor}</div>
+      </div>
+    `).join('');
+  }
   el.innerHTML = `
       <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=registroFaturamento" class="card block" id="resumoFaturamentoCard" data-blur-id="resumoFaturamentoCard">
         <div class="card-header">
-          <div class="card-header-icon"><i class="fas fa-wallet text-xl"></i></div>
+          <div class="card-header-icon"><span class="text-2xl">💰</span></div>
           <div>
             <h2 class="text-xl font-extrabold text-gray-800">Faturamento do Mês</h2>
             <p class="text-gray-600 text-sm">${pedidos} pedidos</p>


### PR DESCRIPTION
## Summary
- Aumenta bordas e sombra dos cards para destacar informações
- Substitui ícones por emojis e adiciona cards de KPI
## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a35164b5a0832aa26d229ce60dde43