### PR TITLE
feat: add kanban board for daily tasks

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -259,6 +259,7 @@ input:checked + .dark-mode-slider:before {
 #tarefasCard .task-item {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 0.5rem;
   padding: 0.75rem 1rem;
   border-radius: 0.5rem;
@@ -282,8 +283,27 @@ input:checked + .dark-mode-slider:before {
   color: var(--text-light);
 }
 
-#tarefasCard input[type="checkbox"] {
-  accent-color: var(--primary);
+#tarefasCard .task-text {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+#tarefasCard .task-actions {
+  display: flex;
+  gap: 0.25rem;
+  margin-left: auto;
+}
+
+#tarefasCard .task-actions button {
+  background-color: #e5e7eb;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  transition: background-color .2s;
+}
+
+#tarefasCard .task-actions button:hover {
+  background-color: #d1d5db;
 }
 @keyframes skeleton-loading {
   0%,

--- a/index.html
+++ b/index.html
@@ -105,13 +105,19 @@
             <div class="progress-wrapper">
               <div id="tarefasProgressBar" class="progress-bar"></div>
             </div>
-            <div>
-              <h3 class="font-semibold mb-2">Pendentes</h3>
-              <ul id="listaTarefas" class="space-y-2"></ul>
-            </div>
-            <div>
-              <h3 class="font-semibold mb-2">Concluídas</h3>
-              <ul id="listaTarefasFeitas" class="space-y-2 text-gray-600"></ul>
+            <div class="kanban-board grid gap-4 md:grid-cols-3">
+              <div>
+                <h3 class="font-semibold mb-2">Pendentes</h3>
+                <ul id="listaTarefasPendentes" class="space-y-2"></ul>
+              </div>
+              <div>
+                <h3 class="font-semibold mb-2">Em andamento</h3>
+                <ul id="listaTarefasAndamento" class="space-y-2"></ul>
+              </div>
+              <div>
+                <h3 class="font-semibold mb-2">Concluídas</h3>
+                <ul id="listaTarefasFeitas" class="space-y-2 text-gray-600"></ul>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- transform daily task list into kanban with Pending, In progress and Completed columns
- show status icons and navigation buttons aligned to the right of each task
- adjust task item styles for clearer layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a356ef3934832a802e758214e3afba