### PR TITLE
Add label deletion option to expedition

### DIFF
--- a/expedicao.html
+++ b/expedicao.html
@@ -499,6 +499,7 @@
           <button class="flex items-center gap-1 px-3 py-2 rounded-md bg-indigo-600 text-white text-sm hover:bg-indigo-700 transition" onclick="visualizar('${url}')" title="Visualizar"><i class="fas fa-eye"></i><span>Ver</span></button>
           <button class="flex items-center gap-1 px-3 py-2 rounded-md bg-indigo-600 text-white text-sm hover:bg-indigo-700 transition" onclick="imprimir('${url}')" title="Imprimir"><i class="fas fa-print"></i><span>Imprimir</span></button>
           <a class="flex items-center gap-1 px-3 py-2 rounded-md bg-indigo-600 text-white text-sm hover:bg-indigo-700 transition" href="${url}" download="${name}" title="Baixar"><i class="fas fa-download"></i><span>Baixar</span></a>
+          <button class="flex items-center gap-1 px-3 py-2 rounded-md bg-red-600 text-white text-sm hover:bg-red-700 transition" onclick="excluirEtiqueta('${doc.id}', this.closest('.pdf-card'))" title="Excluir"><i class="fas fa-trash"></i><span>Excluir</span></button>
         </div>
         <div class="mt-3 space-y-2">
           <label class="cursor-pointer">
@@ -544,6 +545,7 @@
             <button class="text-indigo-600 hover:text-indigo-800" onclick="visualizar('${url}')" title="Visualizar"><i class="fas fa-eye"></i></button>
             <button class="text-indigo-600 hover:text-indigo-800" onclick="imprimir('${url}')" title="Imprimir"><i class="fas fa-print"></i></button>
             <a class="text-indigo-600 hover:text-indigo-800" href="${url}" download="${name}" title="Baixar"><i class="fas fa-download"></i></a>
+            <button class="text-red-600 hover:text-red-800" onclick="excluirEtiqueta('${doc.id}', this.closest('.pdf-card'))" title="Excluir"><i class="fas fa-trash"></i></button>
           </div>
         </div>
         <div class="mt-3 md:mt-0 flex flex-col gap-2 w-full md:w-1/3">
@@ -651,6 +653,29 @@
       }
     }
     window.marcarConcluido = marcarConcluido;
+
+    async function excluirEtiqueta(id, card) {
+      if (!confirm('Deseja excluir esta etiqueta?')) return;
+      try {
+        const docRef = db.collection('pdfDocs').doc(id);
+        const snap = await docRef.get();
+        const data = snap.data() || {};
+        if (data.storagePath) {
+          try {
+            await storage.ref(data.storagePath).delete();
+          } catch (e) {
+            console.error('Erro ao excluir do Storage:', e);
+          }
+        }
+        await docRef.delete();
+        if (card) card.remove();
+        showToast('Etiqueta excluída');
+      } catch (e) {
+        console.error('Erro ao excluir etiqueta:', e);
+        alert('Erro ao excluir etiqueta');
+      }
+    }
+    window.excluirEtiqueta = excluirEtiqueta;
 
     async function toggleAtencao(id, checkbox, card) {
       const checked = checkbox.checked;


### PR DESCRIPTION
## Summary
- add delete button for each expedition label
- implement label removal from Firestore and Storage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a35ed8b550832a908893f879dd79c1