### PR TITLE
refactor: reorganize sobra controls layout

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -873,15 +873,17 @@ let consulta;
     function processarPlanilha() {
       const fileInput = document.getElementById('inputExcel');
       const file = fileInput.files[0];
-      
+      const feedback = document.getElementById('feedbackImportacao');
+      feedback.innerHTML = '';
+
       if (!file) {
-        mostrarErro('Por favor, selecione um arquivo antes de processar.');
+        feedback.innerHTML = '<span class="badge badge-warning">⚠️ Selecione um arquivo</span>';
         return;
       }
-      
+
       try {
         toggleLoading(document.getElementById('btnProcessar'), 'Processar Planilha');
-        
+
         const reader = new FileReader();
         reader.onload = function(e) {
           try {
@@ -889,24 +891,25 @@ let consulta;
             const wb = XLSX.read(data, { type: 'array' });
             const sheet = wb.Sheets[wb.SheetNames[0]];
             const pedidos = XLSX.utils.sheet_to_json(sheet);
-            
+
             processarPedidos(pedidos);
+            feedback.innerHTML = '<span class="badge badge-success">✔️ Importado com sucesso</span>';
           } catch (error) {
-            mostrarErro(`Erro ao ler o arquivo: ${error.message}`);
+            feedback.innerHTML = '<span class="badge badge-danger">⚠️ Erro no arquivo</span>';
             console.error("Erro ao ler arquivo:", error);
           } finally {
             toggleLoading(document.getElementById('btnProcessar'), 'Processar Planilha');
           }
         };
-        
+
         reader.onerror = function() {
-          mostrarErro('Erro ao ler o arquivo. Por favor, tente novamente.');
+          feedback.innerHTML = '<span class="badge badge-danger">⚠️ Erro no arquivo</span>';
           toggleLoading(document.getElementById('btnProcessar'), 'Processar Planilha');
         };
-        
+
         reader.readAsArrayBuffer(file);
       } catch (error) {
-        mostrarErro(`Erro ao processar o arquivo: ${error.message}`);
+        feedback.innerHTML = '<span class="badge badge-danger">⚠️ Erro no arquivo</span>';
         console.error("Erro ao processar arquivo:", error);
         toggleLoading(document.getElementById('btnProcessar'), 'Processar Planilha');
       }
@@ -951,29 +954,33 @@ let consulta;
 
         const tr = document.createElement('tr');
         
-        // Determinar classe CSS baseada no desempenho
-        let statusClass = '';
+        // Determinar status e ícones
         let statusText = '';
-        
+        let statusIcon = '';
+        let rowClass = '';
+
         if (meta) {
           if (percentual <= -10) {
-            statusClass = 'danger';
             statusText = 'Crítico';
+            statusIcon = '❌';
+            rowClass = 'status-critico';
           } else if (percentual <= -5) {
-            statusClass = 'warning';
             statusText = 'Atenção';
+            statusIcon = '⚠️';
           } else if (percentual >= 5) {
-            statusClass = 'success';
             statusText = 'Bom';
+            statusIcon = '✔️';
+            rowClass = 'status-correto';
           } else {
-            statusClass = 'info';
             statusText = 'Normal';
+            statusIcon = '✔️';
           }
         } else {
-          statusClass = 'secondary';
           statusText = 'Sem meta';
+          statusIcon = '⚠️';
         }
 
+        tr.className = rowClass;
         tr.innerHTML = `
           <td>${id}</td>
           <td>${sku}</td>
@@ -984,7 +991,7 @@ let consulta;
           <td>R$ ${servico.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</td>
           <td><strong>R$ ${sobra.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</strong><br><small>Meta: R$ ${meta.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</small></td>
           <td>${percentual.toFixed(2)}%</td>
-          <td><span class="badge badge-${statusClass}">${statusText}</span></td>
+          <td class="status-only" data-status="${statusText}">${statusIcon} ${statusText}</td>
         `;
         
         tbody.appendChild(tr);
@@ -1122,6 +1129,11 @@ document.getElementById("dadosSobrasIA").value = sobras.map(s => {
 
         const tr = document.createElement('tr');
         tr.dataset.status = statusLinha;
+
+        const progresso = (item.status === 'postado' ? 1 : 0) + (item.checklist.itens ? 1 : 0) + (item.checklist.etiqueta ? 1 : 0) + (item.checklist.lacre ? 1 : 0);
+        const progressoPercent = (progresso / 4) * 100;
+        const corProgresso = progressoPercent === 100 ? 'var(--success)' : (progressoPercent >= 50 ? '#f59e0b' : 'var(--danger)');
+
         tr.innerHTML = `
           <td>${p.id}</td>
           <td class="${statusLinha !== 'postado' ? 'text-red-600 font-bold' : ''}">
@@ -1136,6 +1148,7 @@ document.getElementById("dadosSobrasIA").value = sobras.map(s => {
             <label><input type="checkbox" onchange="atualizarChecklist('${p.id}','etiqueta', this.checked)" ${item.checklist.etiqueta ? 'checked' : ''}/> Etiqueta</label><br>
             <label><input type="checkbox" onchange="atualizarChecklist('${p.id}','lacre', this.checked)" ${item.checklist.lacre ? 'checked' : ''}/> Lacre</label>
           </td>
+          <td><div class="progress-wrapper"><div class="progress-bar" style="width:${progressoPercent}%; background:${corProgresso};"></div></div></td>
           <td>${postadoPrazo === null ? '-' : postadoPrazo ? 'Sim' : 'Não'}</td>
         `;
         tbody.appendChild(tr);
@@ -1594,6 +1607,22 @@ await db
     // =============================================
     // FUNÇÕES DE EXPORTAÇÃO
     // =============================================
+
+    function toggleExportMenu() {
+      const menu = document.getElementById('exportMenu');
+      if (menu) {
+        menu.classList.toggle('show');
+      }
+    }
+
+    document.addEventListener('click', function(e) {
+      const menu = document.getElementById('exportMenu');
+      const btn = document.getElementById('btnExportar');
+      if (!menu || !btn) return;
+      if (!btn.contains(e.target) && !menu.contains(e.target)) {
+        menu.classList.remove('show');
+      }
+    });
     
     function exportarCSV() {
       if (pedidosProcessados.length === 0) {
@@ -2491,7 +2520,7 @@ function filtrarPorSKU() {
 
   linhas.forEach(linha => {
     const sku = linha.children[1].textContent.toLowerCase();
-    const status = linha.children[9].textContent.trim().toLowerCase();
+    const status = linha.querySelector('.status-only')?.dataset.status.toLowerCase() || '';
 
     let corresponde = false;
 
@@ -2522,6 +2551,7 @@ window.mostrarDetalhesSobra = mostrarDetalhesSobra;
 window.mostrarDetalhesFaturamento = mostrarDetalhesFaturamento;
 window.excluirFaturamento = excluirFaturamento;
 window.analisarSobrasIA = analisarSobrasIA;
+window.exportarCSV = exportarCSV;
 window.exportarJSON = exportarJSON;
 window.verificarConexao = verificarConexao;
 window.editarMeta = editarMeta;
@@ -2532,6 +2562,7 @@ window.atualizarRastreio = atualizarRastreio;
 window.atualizarChecklist = atualizarChecklist;
 window.aplicarFiltroLogistica = aplicarFiltroLogistica;
   window.processarPlanilha = processarPlanilha;
+window.toggleExportMenu = toggleExportMenu;
 
 </script>
 <script src="shared.js"></script>

--- a/css/components.css
+++ b/css/components.css
@@ -7,6 +7,7 @@
 }
 .card:hover {
   box-shadow: 0 15px 25px rgba(0,0,0,0.1);
+  transform: translateY(-2px);
 }
 .card-header {
   display: flex;
@@ -30,6 +31,14 @@
   transition: background-color .2s, color .2s, box-shadow .2s;
   border: none;
   cursor: pointer;
+}
+.btn:hover {
+  box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+  transform: translateY(-2px);
+}
+.btn-lg {
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
 }
 .btn-primary {
   background-color: var(--primary);
@@ -56,6 +65,32 @@
 }
 .btn-ghost:hover {
   background-color: rgba(255,112,67,0.1);
+}
+
+.dropdown {
+  position: relative;
+}
+.dropdown-menu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: #fff;
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 0.5rem;
+  min-width: 150px;
+  z-index: 100;
+}
+.dropdown-menu.show {
+  display: block;
+}
+.dropdown-item {
+  padding: 0.5rem 1rem;
+  display: block;
+  cursor: pointer;
+}
+.dropdown-item:hover {
+  background: #f3f4f6;
 }
 
 .action-link {
@@ -163,6 +198,15 @@
   width: 0%;
   background: var(--primary);
   transition: width 0.3s ease;
+}
+
+body.dark-mode .card {
+  background-color: #2d2d2d;
+  color: #eee;
+}
+body.dark-mode .dropdown-menu {
+  background: #333;
+  border-color: #555;
 }
 
 body.dark-mode .card-header {

--- a/css/styles.css
+++ b/css/styles.css
@@ -1216,6 +1216,32 @@ tr:hover {
   min-width: 200px;
   margin-bottom: 0
 }
+.form-row .form-group.compact {
+  flex: 0 0 150px;
+  min-width: 150px;
+}
+.form-row button.compact {
+  flex: 0 0 auto;
+}
+
+.actions-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+.status-critico {
+  background-color: #ffebee;
+  color: #b71c1c;
+  font-weight: bold;
+}
+
+.status-correto {
+  background-color: #e8f5e9;
+  color: #1b5e20;
+}
 .input-with-icon {
   position: relative
 }

--- a/sobras-tabs/importar.html
+++ b/sobras-tabs/importar.html
@@ -1,127 +1,128 @@
-    <div class="card">
-          <div class="card-header">
-            <i class="fas fa-file-import"></i>
-            <h3>Importar Planilha</h3>
-             <span class="tooltip tooltip-lg ml-2" data-tooltip="Importe o relatório de pedidos da Shopee para calcular automaticamente as sobras e comparar com suas metas cadastradas. Para conferir pedidos, exporte a planilha da Shopee acessando Home > Meus Pedidos > Todos > Exportar e escolhendo o período desejado. Importe esse arquivo para preencher a tabela.">
-              <i class="fas fa-question-circle text-blue-600"></i>
-            </span>
-          </div>
-          <div class="form-row">
-            <div class="form-group">
-              <input type="file" id="inputExcel" accept=".xlsx, .xls" class="form-control" />
-            </div>
-            <button onclick="processarPlanilha()" class="btn btn-primary" id="btnProcessar">
-              <span id="btnProcessarText"><i class="fas fa-cogs"></i> Processar Planilha</span>
-            </button>
-          </div>
-        </div>
-        
-        <div class="card">
-          <div class="card-header">
-            <i class="fas fa-filter"></i>
-            <h3>Filtrar Resultados</h3>
-          </div>
-          <div class="form-row">
-            <div class="form-group">
-              <select id="tipoFiltro" class="form-control">
-                <option value="exata">Correspondência Exata</option>
-                <option value="comeca">Começa com</option>
-                <option value="contem">Contém</option>
-              </select>
-            </div>
-            <div class="form-group input-with-icon">
-              <i class="fas fa-search"></i>
-              <input type="text" id="filtroSKU" placeholder="Digite o SKU..." class="form-control" />
-            </div>
-            <div class="form-group">
-   <select id="filtroStatus" class="form-control">
-      <option value="">Todos os Status</option>
-      <option value="Crítico">Crítico</option>
-      <option value="Atenção">Atenção</option>
-      <option value="Bom">Bom</option>
-      <option value="Normal">Normal</option>
-      <option value="Sem meta">Sem meta</option>
-    </select>
+<div class="card import-card">
+  <div class="card-header">
+    <i class="fas fa-file-import"></i>
+    <h3>Importar Planilha</h3>
+    <span class="tooltip tooltip-lg ml-2" data-tooltip="Importe o relatório de pedidos da Shopee para calcular automaticamente as sobras e comparar com suas metas cadastradas. Para conferir pedidos, exporte a planilha da Shopee acessando Home &gt; Meus Pedidos &gt; Todos &gt; Exportar e escolhendo o período desejado. Importe esse arquivo para preencher a tabela.">
+      <i class="fas fa-question-circle text-blue-600"></i>
+    </span>
   </div>
+  <div class="form-row">
+    <div class="form-group">
+      <input type="file" id="inputExcel" accept=".xlsx, .xls" class="form-control" />
+    </div>
+    <button onclick="processarPlanilha()" class="btn btn-success btn-lg" id="btnProcessar" style="margin-left:auto;">
+      <span id="btnProcessarText"><i class="fas fa-upload"></i> Processar Planilha</span>
+    </button>
+  </div>
+  <div id="feedbackImportacao" class="mt-2"></div>
+</div>
 
+<div class="card filtros-resultados-card">
+  <div class="card-header">
+    <i class="fas fa-filter"></i>
+    <h3>Filtros e Resultados</h3>
+  </div>
+  <div class="form-row">
+    <div class="form-group compact">
+      <select id="tipoFiltro" class="form-control">
+        <option value="exata">Correspondência Exata</option>
+        <option value="comeca">Começa com</option>
+        <option value="contem">Contém</option>
+      </select>
+    </div>
+    <div class="form-group input-with-icon">
+      <i class="fas fa-search"></i>
+      <input type="text" id="filtroSKU" placeholder="Digite o SKU..." class="form-control" />
+    </div>
+    <div class="form-group compact">
+      <select id="filtroStatus" class="form-control">
+        <option value="">Todos os Status</option>
+        <option value="Crítico">Crítico</option>
+        <option value="Atenção">Atenção</option>
+        <option value="Bom">Bom</option>
+        <option value="Normal">Normal</option>
+        <option value="Sem meta">Sem meta</option>
+      </select>
+    </div>
+    <button onclick="limparFiltros()" class="btn btn-outline compact">
+      <i class="fas fa-times"></i> Limpar
+    </button>
+  </div>
+  <div class="table-container">
+    <table id="resultado" class="data-table">
+      <thead>
+        <tr>
+          <th>ID do Pedido</th>
+          <th>SKU</th>
+          <th>Subtotal</th>
+          <th>Reembolso</th>
+          <th>Cupom</th>
+          <th>Comissão</th>
+          <th>Serviço</th>
+          <th>Sobra</th>
+          <th>% vs Meta</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+  <div id="totalSobra" style="margin-top: 1.5rem;"></div>
+</div>
 
-            <button onclick="limparFiltros()" class="btn btn-outline">
-              <i class="fas fa-times"></i> Limpar Filtros
-            </button>
-          </div>
-        </div>
-        
-        <div class="card">
-          <div class="card-header">
-            <i class="fas fa-table"></i>
-            <h3>Resultados da Conferência</h3>
-          </div>
-          <div class="table-container">
-            <table id="resultado">
-              <thead>
-                <tr>
-                  <th>ID do Pedido</th>
-                  <th>SKU</th>
-                  <th>Subtotal</th>
-                  <th>Reembolso</th>
-                  <th>Cupom</th>
-                  <th>Comissão</th>
-                  <th>Serviço</th>
-                  <th>Sobra</th>
-                  <th>% vs Meta</th>
-                  <th>Status</th>
-                </tr>
-              </thead>
-              <tbody></tbody>
-            </table>
-          </div>
-          <div class="mt-4">
-            <button onclick="analisarSobrasIA()" class="btn btn-primary">
-              <i class="fas fa-robot"></i> Analisar Sobras com IA
-            </button>
-            <input type="hidden" id="dadosSobrasIA">
-            <div id="resultadoIA" class="bg-gray-100 border border-gray-300 rounded p-3 mt-3 whitespace-pre-wrap"></div>
-          </div>
-          <div id="totalSobra" style="margin-top: 1.5rem;"></div>
-          
-          <div style="margin-top: 1.5rem; display: flex; gap: 1rem;">
-            <button onclick="exportarCSV()" class="btn btn-primary">
-              <i class="fas fa-file-export"></i> Exportar CSV
-            </button>
-            <button onclick="exportarJSON()" class="btn btn-outline">
-              <i class="fas fa-file-code"></i> Exportar JSON
-            </button>
-          </div>
-        </div>
+<div class="card acoes-card">
+  <div class="card-header">
+    <i class="fas fa-bolt"></i>
+    <h3>Ações</h3>
+  </div>
+  <div class="actions-row">
+    <div class="dropdown">
+      <button class="btn btn-primary btn-lg" onclick="toggleExportMenu()" id="btnExportar">
+        <i class="fas fa-file-export"></i> Exportar como...
+      </button>
+      <div class="dropdown-menu" id="exportMenu">
+        <a class="dropdown-item" onclick="exportarCSV()">CSV</a>
+        <a class="dropdown-item" onclick="exportarJSON()">JSON</a>
+      </div>
+    </div>
+    <button onclick="analisarSobrasIA()" class="btn btn-secondary btn-lg">
+      <i class="fas fa-robot"></i> Analisar com IA
+    </button>
+  </div>
+  <input type="hidden" id="dadosSobrasIA">
+  <div id="resultadoIA" class="bg-gray-100 border border-gray-300 rounded p-3 mt-3 whitespace-pre-wrap"></div>
+</div>
 
-        <div class="card" id="controleLogistico">
-          <div class="card-header">
-            <i class="fas fa-truck"></i>
-            <h3>Controle Logístico</h3>
-            <span id="alertasLogistica" class="ml-4 text-red-600 font-semibold"></span>
-          </div>
-          <div class="form-row">
-            <div class="form-group">
-              <select id="filtroStatusLogistica" class="form-control" onchange="aplicarFiltroLogistica()">
-                <option value="">Todos os Status</option>
-                <option value="pendente">Pendente</option>
-                <option value="prazo">Prazo Próximo</option>
-                <option value="postado">Postado</option>
-              </select>
-            </div>
-          </div>
-          <div class="table-container">
-            <table id="tabelaLogistica">
-              <thead>
-                <tr>
-                  <th>Pedido</th>
-                  <th>Status</th>
-                  <th>Código de Rastreio</th>
-                  <th>Checklist</th>
-                  <th>Postado no Prazo</th>
-                </tr>
-              </thead>
-              <tbody></tbody>
-            </table>
-          </div>
-        </div>
+<div class="card" id="controleLogistico">
+  <div class="card-header">
+    <i class="fas fa-truck"></i>
+    <h3>Controle Logístico</h3>
+    <span id="alertasLogistica" class="ml-4 text-red-600 font-semibold"></span>
+  </div>
+  <div class="form-row">
+    <div class="form-group">
+      <select id="filtroStatusLogistica" class="form-control" onchange="aplicarFiltroLogistica()">
+        <option value="">Todos os Status</option>
+        <option value="pendente">Pendente</option>
+        <option value="prazo">Prazo Próximo</option>
+        <option value="postado">Postado</option>
+      </select>
+    </div>
+  </div>
+  <div class="table-container">
+    <table id="tabelaLogistica">
+      <thead>
+        <tr>
+          <th>Pedido</th>
+          <th>Status</th>
+          <th>Código de Rastreio</th>
+          <th>Checklist</th>
+          <th>Progresso</th>
+          <th>Postado no Prazo</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+</div>
+


### PR DESCRIPTION
## Summary
- restructure sobra controls into import, filter/results, and actions blocks
- show processing feedback with badges and export dropdown
- add status icons, logistic progress bars, and dark-mode aware styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3611bba14832a91e3133daa60d4f0