### PR TITLE
Handle notification index errors and add Firestore indexes

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -6,7 +6,22 @@
       "fields": [
         { "fieldPath": "destinatarios", "arrayConfig": "CONTAINS" },
         { "fieldPath": "tipo", "order": "ASCENDING" },
-        { "fieldPath": "createdAt", "order": "DESCENDING" }
+        { "fieldPath": "createdAt", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "faturamento",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "__name__", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "skusVendidos",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "__name__", "order": "ASCENDING" }
       ]
     }
   ],

--- a/login.js
+++ b/login.js
@@ -329,6 +329,8 @@ function initNotificationListener(uid) {
     } else {
       badge.classList.add('hidden');
     }
+  }, err => {
+    console.error('Erro no listener de notificações:', err);
   });
   btn.addEventListener('click', () => {
     list.classList.toggle('hidden');


### PR DESCRIPTION
## Summary
- log snapshot listener errors in notification handler
- configure Firestore indexes for notifications, faturamento, and sku sales

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a368506ca8832a84b312be29b9325a