### PR TITLE
Enable CORS for GitHub Pages requests

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -11,7 +11,7 @@ import { tinyTestToken, pesquisarPedidos, obterPedido, pesquisarProdutos } from 
 const DEEPSEEK_API_KEY = defineSecret("DEEPSEEK_API_KEY");
 const SHOPEE_CLIENT_ID = defineSecret("SHOPEE_CLIENT_ID");
 const SHOPEE_CLIENT_SECRET = defineSecret("SHOPEE_CLIENT_SECRET");
-const cors = corsModule({ origin: true });
+const cors = corsModule({ origin: ["https://mferraretto.github.io"] });
 
 initializeApp();
 const db = getFirestore();


### PR DESCRIPTION
## Summary
- allow Cloud Functions to accept requests from GitHub Pages by specifying CORS origin

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a465949018832a8be73617d71ffa20