### PR TITLE
Handle Tiny connection CORS preflight

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -130,6 +130,12 @@ export const shopeeAuthCallback = onRequest(
 export const connectTiny = onRequest({ region: "southamerica-east1", timeoutSeconds: 30 }, (req, res) => {
   cors(req, res, async () => {
     try {
+      if (req.method === "OPTIONS") {
+        res.set("Access-Control-Allow-Origin", "https://mferraretto.github.io");
+        res.set("Access-Control-Allow-Headers", "Authorization, Content-Type");
+        res.set("Access-Control-Allow-Methods", "POST");
+        return res.status(204).send("");
+      }
       if (req.method !== "POST") return res.status(405).json({ error: "Use POST" });
       const uid = await requireAuth(req);
 


### PR DESCRIPTION
## Summary
- Ensure Tiny API connect function handles preflight `OPTIONS` requests
- Add CORS headers so browser requests from GitHub Pages succeed

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4675b4254832a95d6ddc4914b4b38