### PR TITLE
feat: show previous day sales metrics

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -41,16 +41,29 @@
       <button id="salvarMeta" class="btn btn-primary text-sm">Salvar Meta</button>
     </div>
 
-    <div id="kpiDashboard" class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-      <div class="card text-center p-4">
-        <h4 class="text-sm text-gray-500">Vendas do Dia</h4>
-        <div id="kpiVendasDia" class="text-3xl font-bold">-</div>
-      </div>
-      <div class="card text-center p-4" id="kpiMetaCard">
-        <h4 class="text-sm text-gray-500">Meta Atingida</h4>
-        <div id="kpiMetaAtingida" class="text-3xl font-bold">-</div>
-        <div id="kpiMetaProgressWrapper" class="progress mt-2 text-blue-600">
-          <div id="kpiMetaProgress" class="progress-bar" style="width:0%"></div>
+      <div id="kpiDashboard" class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div class="card text-center p-4">
+          <h4 class="text-sm text-gray-500 mb-2">Vendas do Dia Anterior</h4>
+          <div id="kpiVendasDia" class="grid grid-cols-3 gap-2">
+            <div>
+              <div id="kpiVendasBruto" class="text-2xl font-bold">-</div>
+              <div class="text-xs text-gray-500">Bruto</div>
+            </div>
+            <div>
+              <div id="kpiVendasLiquido" class="text-2xl font-bold">-</div>
+              <div class="text-xs text-gray-500">Líquido</div>
+            </div>
+            <div>
+              <div id="kpiVendasSkus" class="text-2xl font-bold">-</div>
+              <div class="text-xs text-gray-500">SKUs</div>
+            </div>
+          </div>
+        </div>
+        <div class="card text-center p-4" id="kpiMetaCard">
+          <h4 class="text-sm text-gray-500">Meta Atingida</h4>
+          <div id="kpiMetaAtingida" class="text-3xl font-bold">-</div>
+          <div id="kpiMetaProgressWrapper" class="progress mt-2 text-blue-600">
+            <div id="kpiMetaProgress" class="progress-bar" style="width:0%"></div>
         </div>
       </div>
       <div class="card text-center p-4">


### PR DESCRIPTION
## Summary
- display previous-day gross, net and SKU count in "Vendas do Dia"
- compute detailed daily revenue and update KPI subscription

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check financeiro.js`


------
https://chatgpt.com/codex/tasks/task_e_68a604c419e4832a9498e3d94cf5e69c