### PR TITLE
Exibe projeção e meta do responsável financeiro

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -49,6 +49,9 @@
       <div class="card text-center p-4" id="kpiMetaCard">
         <h4 class="text-sm text-gray-500">Meta Atingida</h4>
         <div id="kpiMetaAtingida" class="text-3xl font-bold">-</div>
+        <div id="kpiMetaProjecao" class="text-sm text-gray-500">Projeção: -</div>
+        <div id="kpiMetaResponsavel" class="text-sm text-gray-500">Resp. Financeiro: -</div>
+        <div id="kpiMetaRespProjecao" class="text-sm text-gray-500">Proj. Resp.: -</div>
         <div id="kpiMetaProgressWrapper" class="progress mt-2 text-blue-600">
           <div id="kpiMetaProgress" class="progress-bar" style="width:0%"></div>
         </div>


### PR DESCRIPTION
## Summary
- Exibe percentual da meta atingida e projeção mensal no card de Meta Atingida
- Mostra também os dados de meta e projeção do responsável financeiro associado ao usuário

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a60625bc3c832abd3a488602cfdd98