### PR TITLE
fix: show previous day sales

### DIFF
--- a/financeiro.js
+++ b/financeiro.js
@@ -382,13 +382,13 @@ function subscribeKPIs() {
     let vendasBruto = 0;
     const diarios = [];
     for (const d of snap.docs) {
-      if (mes && !d.id.includes(mes)) continue;
       const { liquido: totalDia, bruto: brutoDia } = await calcularFaturamentoDiaDetalhado(uid, d.id);
-      totalMes += totalDia;
       if (d.id === diaAnterior) {
         vendasLiquido = totalDia;
         vendasBruto = brutoDia;
       }
+      if (mes && !d.id.startsWith(mes)) continue;
+      totalMes += totalDia;
       diarios.push({ data: d.id, valor: totalDia });
     }
     brutoEl.textContent = `R$ ${vendasBruto.toLocaleString('pt-BR')}`;


### PR DESCRIPTION
## Summary
- ensure previous day's sales metrics are displayed even when month filter differs

## Testing
- `node --check financeiro.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a606e0ca28832aa46fcadf897c55d4