### PR TITLE
Evita erro de login quando botão de logout não existe

### DIFF
--- a/login.js
+++ b/login.js
@@ -173,7 +173,8 @@ async function showUserArea(user) {
     if (input) input.value = nameEl.textContent;
     openModal('displayNameModal');
   };
-  document.getElementById('logoutBtn').classList.remove('hidden');
+  // Exibe o botão de logout apenas se estiver presente na navbar
+  document.getElementById('logoutBtn')?.classList.remove('hidden');
 
   window.sistema = window.sistema || {};
   window.sistema.uid = user.uid;
@@ -223,7 +224,8 @@ function hideUserArea() {
   const nameEl = document.getElementById('currentUser');
   nameEl.textContent = 'Usuário';
   nameEl.onclick = null;
-  document.getElementById('logoutBtn').classList.add('hidden');
+  // Oculta o botão de logout apenas se ele existir
+  document.getElementById('logoutBtn')?.classList.add('hidden');
   if (window.sistema) delete window.sistema.uid;
 
   // ⚠️ Reseta para mostrar o modal novamente no próximo login
@@ -368,7 +370,8 @@ function checkLogin() {
 
 document.addEventListener('navbarLoaded', () => {
   document.getElementById('loginBtn')?.addEventListener('click', () => openModal('loginModal'));
-  document.getElementById('logoutBtn').addEventListener('click', logout);
+  // Garante que o evento de logout só seja registrado se o botão existir
+  document.getElementById('logoutBtn')?.addEventListener('click', logout);
 
   if (window.location.search.includes('login=1')) {
   // Espera o estado do Firebase para decidir se deve abrir

--- a/public/login.js
+++ b/public/login.js
@@ -173,7 +173,8 @@ async function showUserArea(user) {
     if (input) input.value = nameEl.textContent;
     openModal('displayNameModal');
   };
-  document.getElementById('logoutBtn').classList.remove('hidden');
+  // Exibe o botão de logout apenas se estiver presente na navbar
+  document.getElementById('logoutBtn')?.classList.remove('hidden');
 
   window.sistema = window.sistema || {};
   window.sistema.uid = user.uid;
@@ -223,7 +224,8 @@ function hideUserArea() {
   const nameEl = document.getElementById('currentUser');
   nameEl.textContent = 'Usuário';
   nameEl.onclick = null;
-  document.getElementById('logoutBtn').classList.add('hidden');
+  // Oculta o botão de logout apenas se ele existir
+  document.getElementById('logoutBtn')?.classList.add('hidden');
   if (window.sistema) delete window.sistema.uid;
 
   // ⚠️ Reseta para mostrar o modal novamente no próximo login
@@ -368,7 +370,8 @@ function checkLogin() {
 
 document.addEventListener('navbarLoaded', () => {
   document.getElementById('loginBtn')?.addEventListener('click', () => openModal('loginModal'));
-  document.getElementById('logoutBtn').addEventListener('click', logout);
+  // Garante que o evento de logout só seja registrado se o botão existir
+  document.getElementById('logoutBtn')?.addEventListener('click', logout);
 
   if (window.location.search.includes('login=1')) {
   // Espera o estado do Firebase para decidir se deve abrir


### PR DESCRIPTION
## Summary
- Protege referências ao botão de logout quando a navbar ainda não carregou
- Registra o evento de logout somente se o botão estiver presente

## Testing
- `node --check login.js`
- `node --check public/login.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a76cb15bd0832a871cf6c9b7d0a4b8