### PR TITLE
Exibe data atual na aba Financeiro

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -32,6 +32,7 @@
     </div>
 
     <h3 id="contexto" class="text-sm text-gray-500"></h3>
+    <h3 id="dataAtual" class="text-sm text-gray-500"></h3>
 
     <div id="metaSection" class="hidden flex flex-wrap gap-2 items-end">
       <div>

--- a/financeiro.js
+++ b/financeiro.js
@@ -127,16 +127,21 @@ async function carregar() {
 
 function atualizarContexto() {
   const contextoEl = document.getElementById('contexto');
+  const dataEl = document.getElementById('dataAtual');
   const mes = document.getElementById('mesFiltro')?.value;
   const uid = document.getElementById('usuarioFiltro')?.value;
-  if (!contextoEl) return;
-  const mesTxt = mes ? new Date(mes + '-01').toLocaleDateString('pt-BR', { month: 'long', year: 'numeric' }) : '';
-  let usuarioTxt = 'Todos os usuários';
-  if (uid && uid !== 'todos') {
-    const u = usuariosCache.find(x => x.uid === uid);
-    usuarioTxt = u ? u.nome : uid;
+  if (contextoEl) {
+    const mesTxt = mes ? new Date(mes + '-01').toLocaleDateString('pt-BR', { month: 'long', year: 'numeric' }) : '';
+    let usuarioTxt = 'Todos os usuários';
+    if (uid && uid !== 'todos') {
+      const u = usuariosCache.find(x => x.uid === uid);
+      usuarioTxt = u ? u.nome : uid;
+    }
+    contextoEl.textContent = `${mesTxt} – ${usuarioTxt}`;
   }
-  contextoEl.textContent = `${mesTxt} – ${usuarioTxt}`;
+  if (dataEl) {
+    dataEl.textContent = `Hoje: ${new Date().toLocaleDateString('pt-BR')}`;
+  }
 }
 
 async function carregarSkus(usuarios, mes) {


### PR DESCRIPTION
## Resumo
- mostra a data atual na tela de Financeiro
- atualiza contexto para exibir "Hoje" junto com os filtros

## Testes
- `npm test` (falhou: não foi encontrado package.json)
- `cd functions && npm test` (falhou: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a85c61d6dc832ab4bcde8b41e9cfaf