### PR TITLE
Exibe registros de faturamento diário do dia anterior

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -43,9 +43,12 @@
     </div>
 
       <div id="kpiDashboard" class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <div class="card text-center p-4">
-          <h4 class="text-sm text-gray-500 mb-2">Vendas do Dia Anterior</h4>
-          <div id="kpiVendasDia" class="grid grid-cols-3 gap-2">
+        <div class="card p-4">
+          <div class="flex justify-between items-center mb-2">
+            <h4 class="text-sm text-gray-500">Vendas do Dia Anterior</h4>
+            <button id="kpiVendasDetalhes" class="btn btn-secondary text-xs">Registros</button>
+          </div>
+          <div id="kpiVendasDia" class="grid grid-cols-3 gap-2 text-center">
             <div>
               <div id="kpiVendasBruto" class="text-2xl font-bold">-</div>
               <div class="text-xs text-gray-500">Bruto</div>


### PR DESCRIPTION
## Summary
- Adiciona botão de registros ao card "Vendas do Dia Anterior" no Financeiro
- Implementa consulta e exibição dos registros de faturamento do dia anterior

## Testing
- `npm test` *(falha: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a85dd4f53c832aa21690bc8f540953