### PR TITLE
Exibe usuários vinculados ao responsável financeiro na aba Atualizações

### DIFF
--- a/atualizacoes.html
+++ b/atualizacoes.html
@@ -14,6 +14,10 @@
   <div id="navbar-container"></div>
   <main class="main-content p-4 space-y-4">
     <h1 class="text-2xl font-bold">Atualizações</h1>
+    <div id="usuariosResponsaveisCard" class="card p-4 hidden">
+      <h2 class="font-medium mb-2">Usuários vinculados</h2>
+      <ul id="usuariosResponsaveisLista" class="list-disc pl-5 space-y-1"></ul>
+    </div>
     <form id="formAtualizacao" class="card p-4 space-y-4">
       <div>
         <label for="descricao" class="text-sm font-medium">Descrição</label>

--- a/atualizacoes.js
+++ b/atualizacoes.js
@@ -41,15 +41,31 @@ onAuthStateChanged(auth, async user => {
 
 async function carregarUsuarios() {
   const select = document.getElementById('destinatarios');
-  if (!select) return;
-  select.innerHTML = '';
+  const card = document.getElementById('usuariosResponsaveisCard');
+  const lista = document.getElementById('usuariosResponsaveisLista');
+  if (select) select.innerHTML = '';
+  if (lista) lista.innerHTML = '';
   try {
     const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', currentUser.email)));
+    if (snap.empty) {
+      card?.classList.add('hidden');
+      return;
+    }
+    card?.classList.remove('hidden');
     snap.forEach(d => {
-      const opt = document.createElement('option');
-      opt.value = d.id;
-      opt.textContent = d.data().nome || d.id;
-      select.appendChild(opt);
+      const dados = d.data();
+      const nome = dados.nome || dados.email || d.id;
+      if (select) {
+        const opt = document.createElement('option');
+        opt.value = d.id;
+        opt.textContent = nome;
+        select.appendChild(opt);
+      }
+      if (lista) {
+        const li = document.createElement('li');
+        li.textContent = `${nome} - ${dados.email || ''}`;
+        lista.appendChild(li);
+      }
     });
   } catch (err) {
     console.error('Erro ao carregar usuários:', err);


### PR DESCRIPTION
## Summary
- Mostrar card com usuários que apontaram o e-mail logado como responsável financeiro
- Listar nome e e-mail de cada usuário vinculado

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a85fc0eef4832a998de83970ea5e3f