### PR TITLE
fix: enable responsive layout on finance pages

### DIFF
--- a/financeiro-inicio.html
+++ b/financeiro-inicio.html
@@ -2,6 +2,7 @@
 <html lang="pt-BR">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Início Financeiro</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />

--- a/financeiro.html
+++ b/financeiro.html
@@ -2,6 +2,7 @@
 <html lang="pt-BR">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Financeiro</title>
     <link rel="manifest" href="financeiro-manifest.json">
   <meta name="theme-color" content="#2196f3">


### PR DESCRIPTION
## Summary
- ensure Financeiro pages scale correctly on mobile by adding the standard viewport meta tag

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a87889e8c4832aa9815aca975e6def