### PR TITLE
Fix Financeiro PWA paths for GitHub Pages

### DIFF
--- a/financeiro-manifest.json
+++ b/financeiro-manifest.json
@@ -1,18 +1,18 @@
 {
   "name": "VendedorPro Financeiro",
   "short_name": "Financeiro",
-  "start_url": "/financeiro.html",
+  "start_url": "financeiro.html",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#2196f3",
   "icons": [
     {
-      "src": "/icons/icon-192.png",
+      "src": "icons/icon-192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/icons/icon-512.png",
+      "src": "icons/icon-512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/financeiro.js
+++ b/financeiro.js
@@ -750,7 +750,10 @@ function exportarCSV(dados, campos, nome) {
 
 // PWA install handling
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('/service-worker.js').catch(err => console.error('SW registration failed', err));
+  // Use a relative path so GitHub Pages serves the correct file when hosted in a subdirectory
+  navigator.serviceWorker
+    .register('service-worker.js')
+    .catch(err => console.error('SW registration failed', err));
 }
 
 let deferredPrompt;

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,11 +1,11 @@
 const CACHE_NAME = 'financeiro-cache-v1';
 const URLS_TO_CACHE = [
-  '/financeiro.html',
-  '/financeiro.js',
-  '/css/styles.css',
-  '/css/components.css',
-  '/icons/icon-192.png',
-  '/icons/icon-512.png'
+  'financeiro.html',
+  'financeiro.js',
+  'css/styles.css',
+  'css/components.css',
+  'icons/icon-192.png',
+  'icons/icon-512.png'
 ];
 
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
## Summary
- use relative path when registering the service worker
- fix paths in Financeiro manifest and service worker cache list so assets load on GitHub Pages

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a87988a7a0832ab9ba7b0ce3dd0aa8