### PR TITLE
Organize financial overview cards in two rows

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -47,7 +47,7 @@
       <button id="salvarMeta" class="btn btn-primary text-sm">Salvar Meta</button>
     </div>
 
-    <div id="overviewCards" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4"></div>
+    <div id="overviewCards" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
 
     <h4 class="text-sm text-gray-500">Vendas do Dia Anterior</h4>
     <div id="vendasDiaAnterior" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>


### PR DESCRIPTION
## Summary
- Limit overview grid to three columns so the first five finance cards wrap into two rows

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3e5266bc832a9b42b3c387828ace