### PR TITLE
Fix mobile sidebar toggle and improve accessibility

### DIFF
--- a/SISTEMA DE CUSTEIO DE PRODUÇÃO E PRODUTOS.html
+++ b/SISTEMA DE CUSTEIO DE PRODUÇÃO E PRODUTOS.html
@@ -21,7 +21,7 @@
  <!-- Sidebar -->
   <div id="sidebar-container"></div>
  <!-- Botão de menu mobile -->
-  <button class="mobile-menu-btn" onclick="toggleSidebar()">☰</button>
+  <button class="mobile-menu-btn" onclick="toggleSidebar()" aria-label="Abrir menu" aria-expanded="false">☰</button>
   <div id="navbar-container"></div>
 
   <script>

--- a/all_navbars.html
+++ b/all_navbars.html
@@ -11,7 +11,7 @@
   <!-- Top Navbar from index.html -->
   <div class="top-navbar">
     <div class="flex items-center">
-      <button class="mobile-menu-btn mr-4 text-gray-600 hidden">
+      <button class="mobile-menu-btn mr-4 text-gray-600 md:hidden" aria-label="Abrir menu" aria-expanded="false">
         <i class="fas fa-bars text-xl"></i>
       </button>
       <h2 class="text-lg font-semibold text-gray-800">Dashboard</h2>

--- a/css/styles.css
+++ b/css/styles.css
@@ -366,7 +366,7 @@ input:checked + .dark-mode-slider:before {
   .sidebar {
     transform: translateX(-100%)
   }
-  .sidebar.open {
+  .sidebar.active {
     transform: translateX(0)
   }
   .top-navbar {

--- a/custeio.js
+++ b/custeio.js
@@ -4,7 +4,11 @@ function toggleSidebar() {
      const sidebar = document.getElementById('sidebar') ||
                   document.querySelector('.sidebar');
   if (sidebar) {
-    sidebar.classList.toggle('active');
+    const isActive = sidebar.classList.toggle('active');
+    const btn = document.querySelector('.mobile-menu-btn');
+    if (btn) {
+      btn.setAttribute('aria-expanded', isActive ? 'true' : 'false');
+    }
   }
 }
     

--- a/layout.html
+++ b/layout.html
@@ -46,7 +46,7 @@
   </script>
 
   <!-- Botão de menu mobile -->
-  <button class="mobile-menu-btn" onclick="toggleSidebar()">☰</button>
+  <button class="mobile-menu-btn" onclick="toggleSidebar()" aria-label="Abrir menu" aria-expanded="false">☰</button>
 
   <!-- Sidebar -->
    <div id="sidebar-container"></div>

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,6 +1,6 @@
  <div class="top-navbar">
       <div class="flex items-center">
-        <button class="mobile-menu-btn mr-4 text-gray-200 md:hidden">
+        <button class="mobile-menu-btn mr-4 text-gray-200 md:hidden" aria-label="Abrir menu" aria-expanded="false">
           <i class="fa-solid fa-bars text-2xl"></i>
         </button>
         <h2 class="text-lg font-semibold text-white">Dashboard</h2>

--- a/public/shared.js
+++ b/public/shared.js
@@ -193,10 +193,12 @@ document.addEventListener('DOMContentLoaded', function () {
 document.addEventListener('navbarLoaded', function () {
   var btn = document.querySelector('.mobile-menu-btn');
   if (!btn) return;
+  btn.setAttribute('aria-expanded', 'false');
   btn.addEventListener('click', function () {
     var sidebar = document.querySelector('.sidebar');
     if (sidebar) {
-      sidebar.classList.toggle('active');
+      var isActive = sidebar.classList.toggle('active');
+      btn.setAttribute('aria-expanded', isActive ? 'true' : 'false');
     }
   });
 });

--- a/shared.js
+++ b/shared.js
@@ -193,10 +193,12 @@ document.addEventListener('DOMContentLoaded', function () {
 document.addEventListener('navbarLoaded', function () {
   var btn = document.querySelector('.mobile-menu-btn');
   if (!btn) return;
+  btn.setAttribute('aria-expanded', 'false');
   btn.addEventListener('click', function () {
     var sidebar = document.querySelector('.sidebar');
     if (sidebar) {
-      sidebar.classList.toggle('active');
+      var isActive = sidebar.classList.toggle('active');
+      btn.setAttribute('aria-expanded', isActive ? 'true' : 'false');
     }
   });
 });


### PR DESCRIPTION
## Summary
- Align sidebar CSS class with JavaScript to show mobile menu
- Add accessible mobile menu buttons with aria attributes
- Update JS togglers to manage `aria-expanded`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3e854de0832a9384cfaa6c149d53