### PR TITLE
Create manager-only navigation menu

### DIFF
--- a/atualizacoes.html
+++ b/atualizacoes.html
@@ -37,7 +37,7 @@
   </main>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="atualizacoes.js"></script>
-  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-financeiro.html';</script>
+  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-gestor.html';</script>
   <script src="shared.js"></script>
 </body>
 </html>

--- a/desempenho.html
+++ b/desempenho.html
@@ -69,7 +69,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="desempenho.js"></script>
-  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-financeiro.html';</script>
+  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-gestor.html';</script>
   <script src="shared.js"></script>
 </body>
 </html>

--- a/equipes.html
+++ b/equipes.html
@@ -910,6 +910,7 @@
     </div>
 
     <!-- Script para Firebase e funcionalidades da UI -->
+    <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-gestor.html';</script>
     <script src="shared.js"></script>
     <script type="module" src="firebase-config.js"></script>
 

--- a/financeiro-inicio.html
+++ b/financeiro-inicio.html
@@ -17,7 +17,7 @@
     <h1 class="text-2xl font-bold">Área Financeira</h1>
     <p>Selecione uma opção no menu ao lado para acessar as ferramentas financeiras.</p>
   </main>
-  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-financeiro.html';</script>
+  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-gestor.html';</script>
   <script src="shared.js"></script>
 </body>
 </html>

--- a/financeiro.html
+++ b/financeiro.html
@@ -67,7 +67,7 @@
   </div>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="financeiro.js"></script>
-  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-financeiro.html';</script>
+  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-gestor.html';</script>
   <script src="shared.js"></script>
   </body>
 </html>

--- a/gestor.html
+++ b/gestor.html
@@ -59,6 +59,7 @@
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="gestor.js"></script>
   <script type="module" src="login.js"></script>
+  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-gestor.html';</script>
   <script src="shared.js"></script>
   <script>
     if (window.initAbaGestor) {

--- a/partials/sidebar-gestor.html
+++ b/partials/sidebar-gestor.html
@@ -10,23 +10,21 @@
     </div>
   </div>
   <div class="py-4">
-    <a href="/VendedorPro/index.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-inicio">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-        <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/>
-      </svg>
-      <span class="link-text">Início</span>
+    <a href="/VendedorPro/gestor.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestor">
+      <span class="mr-3">📂</span>
+      <span class="link-text">Gestor</span>
     </a>
     <a href="/VendedorPro/financeiro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-financeiro">
       <span class="mr-3">💰</span>
       <span class="link-text">Financeiro</span>
     </a>
-    <a href="/VendedorPro/desempenho.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-desempenho">
-      <span class="mr-3">📊</span>
-      <span class="link-text">Desempenho</span>
-    </a>
     <a href="/VendedorPro/atualizacoes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-atualizacoes">
       <span class="mr-3">📎</span>
       <span class="link-text">Atualizações</span>
+    </a>
+    <a href="/VendedorPro/equipes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-equipes">
+      <span class="mr-3">👥</span>
+      <span class="link-text">Equipes</span>
     </a>
   </div>
 </div>

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -130,28 +130,6 @@
       <a href="/VendedorPro/expedicao-historico.html" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a>
     </div>
 
-    <!-- Gestor -->
-    <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/gestor.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestor">
-        <span class="mr-3">📂</span>
-        <span class="link-text">Gestor</span>
-      </a>
-      <button class="submenu-toggle p-2" onclick="toggleMenu('menuGestor')">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
-        </svg>
-      </button>
-    </div>
-    <div id="menuGestor" class="pl-8 space-y-1 max-h-0 overflow-hidden transition-all duration-300">
-      <a href="/VendedorPro/financeiro.html" class="sidebar-link block py-2 px-4 transition-colors">Financeiro</a>
-      <a href="/VendedorPro/atualizacoes.html" class="sidebar-link block py-2 px-4 transition-colors">Atualizações</a>
-      <a href="/VendedorPro/equipes.html" class="sidebar-link block py-2 px-4 transition-colors">Equipes</a>
-      <a href="/VendedorPro/desempenho.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-desempenho">
-      <span class="mr-3">📊</span>
-      <span class="link-text">Desempenho</span>
-    </a>
-    </div>
-
     <!-- Gestão Contas -->
     <div class="sidebar-item flex items-center justify-between">
       <a href="/VendedorPro/gestao-contas.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao-contas">


### PR DESCRIPTION
## Summary
- Add new `sidebar-gestor.html` with links for Gestor, Financeiro, Atualizações and Equipes
- Load manager sidebar on gestor, equipes, financeiro and related pages
- Remove Gestor section from default sidebar to keep menu exclusive to managers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac40ff0d8c832aa1daafa781ca609d