### PR TITLE
Add login type selection dropdown

### DIFF
--- a/login.js
+++ b/login.js
@@ -372,21 +372,45 @@ function checkLogin() {
   });
 }
 
-document.addEventListener('navbarLoaded', () => {
-  document.getElementById('loginBtn')?.addEventListener('click', () => openModal('loginModal'));
-  // Garante que o evento de logout só seja registrado se o botão existir
-  document.getElementById('logoutBtn')?.addEventListener('click', logout);
+  document.addEventListener('navbarLoaded', () => {
+    const loginMenu = document.getElementById('loginMenu');
+    const loginDropdown = document.getElementById('loginDropdown');
+    const loginBtn = document.getElementById('loginBtn');
+    const loginUsuarioBtn = document.getElementById('loginUsuarioBtn');
+    const loginGestorBtn = document.getElementById('loginGestorBtn');
 
-  if (window.location.search.includes('login=1')) {
-  // Espera o estado do Firebase para decidir se deve abrir
-  onAuthStateChanged(auth, (user) => {
-    if (!user) {
+    loginBtn?.addEventListener('click', () => {
+      loginDropdown?.classList.toggle('hidden');
+    });
+
+    loginUsuarioBtn?.addEventListener('click', () => {
+      loginDropdown?.classList.add('hidden');
       openModal('loginModal');
+    });
+
+    loginGestorBtn?.addEventListener('click', () => {
+      window.location.href = 'login-gestor.html';
+    });
+
+    document.addEventListener('click', (e) => {
+      if (!loginMenu?.contains(e.target)) {
+        loginDropdown?.classList.add('hidden');
+      }
+    });
+
+    // Garante que o evento de logout só seja registrado se o botão existir
+    document.getElementById('logoutBtn')?.addEventListener('click', logout);
+
+    if (window.location.search.includes('login=1')) {
+      // Espera o estado do Firebase para decidir se deve abrir
+      onAuthStateChanged(auth, (user) => {
+        if (!user) {
+          openModal('loginModal');
+        }
+      });
     }
+    checkLogin();
   });
-}
-  checkLogin();
-});
 
 document.addEventListener('sidebarLoaded', () => {
   if (window.userPerfil) applyPerfilRestrictions(window.userPerfil);

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -30,10 +30,18 @@
           <i class="fa-solid fa-user-plus"></i>
           Cadastre-se
         </a>
-        
-        <button id="loginBtn" onclick="openModal('loginModal')" class="bg-orange-500 text-white p-2 rounded hover:bg-orange-600 transition">
-          <i class="fa-solid fa-user"></i>
-        </button>
+
+        <!-- Login dropdown -->
+        <div class="relative" id="loginMenu">
+          <button id="loginBtn" class="bg-orange-500 text-white p-2 rounded hover:bg-orange-600 transition flex items-center">
+            <i class="fa-solid fa-user"></i>
+            <i class="fa-solid fa-chevron-down ml-1 text-sm"></i>
+          </button>
+          <div id="loginDropdown" class="hidden absolute right-0 mt-2 w-40 bg-white text-gray-700 rounded shadow-lg z-20">
+            <button id="loginUsuarioBtn" class="w-full text-left px-4 py-2 hover:bg-gray-100">Vendedor</button>
+            <button id="loginGestorBtn" class="w-full text-left px-4 py-2 hover:bg-gray-100">Gestor</button>
+          </div>
+        </div>
 
         <!-- Notificações -->
         <div id="notificationWrapper" class="relative tooltip" data-tooltip="Notificações">

--- a/public/login.js
+++ b/public/login.js
@@ -368,21 +368,45 @@ function checkLogin() {
   });
 }
 
-document.addEventListener('navbarLoaded', () => {
-  document.getElementById('loginBtn')?.addEventListener('click', () => openModal('loginModal'));
-  // Garante que o evento de logout só seja registrado se o botão existir
-  document.getElementById('logoutBtn')?.addEventListener('click', logout);
+  document.addEventListener('navbarLoaded', () => {
+    const loginMenu = document.getElementById('loginMenu');
+    const loginDropdown = document.getElementById('loginDropdown');
+    const loginBtn = document.getElementById('loginBtn');
+    const loginUsuarioBtn = document.getElementById('loginUsuarioBtn');
+    const loginGestorBtn = document.getElementById('loginGestorBtn');
 
-  if (window.location.search.includes('login=1')) {
-  // Espera o estado do Firebase para decidir se deve abrir
-  onAuthStateChanged(auth, (user) => {
-    if (!user) {
+    loginBtn?.addEventListener('click', () => {
+      loginDropdown?.classList.toggle('hidden');
+    });
+
+    loginUsuarioBtn?.addEventListener('click', () => {
+      loginDropdown?.classList.add('hidden');
       openModal('loginModal');
+    });
+
+    loginGestorBtn?.addEventListener('click', () => {
+      window.location.href = 'login-gestor.html';
+    });
+
+    document.addEventListener('click', (e) => {
+      if (!loginMenu?.contains(e.target)) {
+        loginDropdown?.classList.add('hidden');
+      }
+    });
+
+    // Garante que o evento de logout só seja registrado se o botão existir
+    document.getElementById('logoutBtn')?.addEventListener('click', logout);
+
+    if (window.location.search.includes('login=1')) {
+      // Espera o estado do Firebase para decidir se deve abrir
+      onAuthStateChanged(auth, (user) => {
+        if (!user) {
+          openModal('loginModal');
+        }
+      });
     }
+    checkLogin();
   });
-}
-  checkLogin();
-});
 
 document.addEventListener('sidebarLoaded', () => {
   if (window.userPerfil) applyPerfilRestrictions(window.userPerfil);


### PR DESCRIPTION
## Summary
- add login dropdown with options for Vendedor and Gestor
- wire up login script to handle dropdown and redirect to gestor login page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4328acc4832a9d5ec7bda86131d4