### PR TITLE
Add finance sidebar partial and improve sidebar loading

### DIFF
--- a/financeiro-inicio.html
+++ b/financeiro-inicio.html
@@ -17,7 +17,7 @@
     <h1 class="text-2xl font-bold">Área Financeira</h1>
     <p>Selecione uma opção no menu ao lado para acessar as ferramentas financeiras.</p>
   </main>
-  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-gestor.html';</script>
+  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-financeiro.html';</script>
   <script src="shared.js"></script>
 </body>
 </html>

--- a/financeiro.html
+++ b/financeiro.html
@@ -67,7 +67,7 @@
   </div>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="financeiro.js"></script>
-  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-gestor.html';</script>
+  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-financeiro.html';</script>
   <script src="shared.js"></script>
   </body>
 </html>

--- a/partials/sidebar-financeiro.html
+++ b/partials/sidebar-financeiro.html
@@ -1,0 +1,34 @@
+<div id="sidebar" class="sidebar w-64 h-screen overflow-y-auto fixed left-0 top-0 z-50 text-gray-100">
+  <div class="sidebar-logo p-4">
+    <div class="flex items-center">
+      <div class="bg-white w-10 h-10 rounded-lg flex items-center justify-center mr-3">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-orange-500">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z" />
+        </svg>
+      </div>
+      <span class="font-bold text-xl text-white">VendedorPro</span>
+    </div>
+  </div>
+  <div class="py-4">
+    <a href="/VendedorPro/financeiro-inicio.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-inicio">
+      <span class="mr-3">🏠</span>
+      <span class="link-text">Início</span>
+    </a>
+    <a href="/VendedorPro/financeiro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-financeiro">
+      <span class="mr-3">💰</span>
+      <span class="link-text">Visão Geral</span>
+    </a>
+    <a href="/VendedorPro/saques.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-saques">
+      <span class="mr-3">💸</span>
+      <span class="link-text">Saques</span>
+    </a>
+  </div>
+  <div class="flex items-center justify-between px-4 mt-6">
+    <span class="text-sm text-gray-300">Modo Escuro</span>
+    <label class="relative inline-flex items-center cursor-pointer">
+      <input type="checkbox" id="darkModeToggle" class="sr-only peer">
+      <div class="w-11 h-6 bg-gray-300 peer-focus:outline-none rounded-full peer peer-checked:bg-orange-500 transition"></div>
+      <div class="absolute left-1 top-1 bg-white w-4 h-4 rounded-full transition peer-checked:translate-x-full"></div>
+    </label>
+  </div>
+</div>

--- a/shared.js
+++ b/shared.js
@@ -69,7 +69,17 @@
     containerId = containerId || 'sidebar-container';
     sidebarPath = sidebarPath || 'partials/sidebar.html';
     return fetch(BASE_PATH + sidebarPath)
-      .then(function(res) { return res.text(); })
+      .then(function(res) {
+        if (!res.ok) throw new Error('Sidebar not found');
+        return res.text();
+      })
+      .catch(function(err) {
+        console.warn('Falha ao carregar sidebar personalizada:', err);
+        return fetch(BASE_PATH + 'partials/sidebar.html').then(function(res) {
+          if (!res.ok) throw new Error('Sidebar padrão não encontrada');
+          return res.text();
+        });
+      })
       .then(function(html) {
         var container = document.getElementById(containerId);
         if (container) {
@@ -77,6 +87,9 @@
           var event = new CustomEvent('sidebarLoaded', { detail: { containerId: containerId } });
           document.dispatchEvent(event);
         }
+      })
+      .catch(function(err) {
+        console.error('Erro ao carregar sidebar:', err);
       });
   };
 // Load navbar HTML into placeholder


### PR DESCRIPTION
## Summary
- add dedicated finance sidebar partial
- use finance sidebar on finance pages
- add error handling and fallback when loading sidebar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac45226ab0832a9f0427e1671e7a1d