### PR TITLE
Add mentor overview tab for gestor

### DIFF
--- a/mentoria.html
+++ b/mentoria.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mentoria</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="css/components.css">
+</head>
+<body class="bg-gray-100 text-gray-800">
+  <div id="sidebar-container"></div>
+  <div id="navbar-container"></div>
+  <main class="main-content p-4 space-y-6">
+    <div class="card">
+      <div class="card-header"><h2 class="text-xl font-bold">Visão Geral do Mentor</h2></div>
+      <div id="mentoradosList" class="card-body space-y-4"></div>
+    </div>
+  </main>
+  <script type="module" src="firebase-config.js"></script>
+  <script type="module" src="mentoria.js"></script>
+  <script type="module" src="login.js"></script>
+  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-gestor.html';</script>
+  <script src="shared.js"></script>
+  <script>
+    if (window.initMentoria) {
+      window.initMentoria();
+    }
+  </script>
+</body>
+</html>

--- a/mentoria.js
+++ b/mentoria.js
@@ -1,0 +1,53 @@
+import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { getFirestore, collection, query, where, onSnapshot } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { firebaseConfig } from './firebase-config.js';
+
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+const db = getFirestore(app);
+const auth = getAuth(app);
+
+function renderMentorado(id, data) {
+  const card = document.createElement('div');
+  card.className = 'card';
+  const progresso = data.progresso || 0;
+  card.innerHTML = `
+    <div class="card-header flex justify-between items-center">
+      <h3 class="font-bold">${data.nome || 'Sem nome'}</h3>
+      <span class="text-sm">${data.status || 'Sem status'}</span>
+    </div>
+    <div class="card-body space-y-2">
+      <p class="text-sm">Último contato: ${data.ultimoContato || '-'}</p>
+      <div class="w-full bg-gray-200 rounded h-2">
+        <div class="bg-blue-500 h-2 rounded" style="width: ${progresso}%"></div>
+      </div>
+      <p class="text-xs text-gray-500">Progresso: ${progresso}%</p>
+    </div>
+  `;
+  return card;
+}
+
+function carregarMentorados(user) {
+  const list = document.getElementById('mentoradosList');
+  const q = query(collection(db, 'mentorados'), where('mentorUid', '==', user.uid));
+  onSnapshot(q, snap => {
+    list.innerHTML = '';
+    if (snap.empty) {
+      list.innerHTML = '<p class="text-sm text-gray-500">Nenhum mentorado encontrado.</p>';
+      return;
+    }
+    snap.forEach(docSnap => {
+      list.appendChild(renderMentorado(docSnap.id, docSnap.data()));
+    });
+  });
+}
+
+function initMentoria() {
+  onAuthStateChanged(auth, user => {
+    if (user) {
+      carregarMentorados(user);
+    }
+  });
+}
+
+window.initMentoria = initMentoria;

--- a/partials/sidebar-gestor.html
+++ b/partials/sidebar-gestor.html
@@ -14,6 +14,10 @@
       <span class="mr-3">📂</span>
       <span class="link-text">Gestor</span>
     </a>
+    <a href="/VendedorPro/mentoria.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-mentoria">
+      <span class="mr-3">🎓</span>
+      <span class="link-text">Mentoria</span>
+    </a>
     <a href="/VendedorPro/financeiro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-financeiro">
       <span class="mr-3">💰</span>
       <span class="link-text">Financeiro</span>


### PR DESCRIPTION
## Summary
- Add Mentoria page to Gestor section for mentor overview
- Display mentorados with status, last contact and progress
- Link Mentoria page from Gestor sidebar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4b27eb78832a846ac7357393021d