### PR TITLE
Adicionar abas exclusivas para gestores

### DIFF
--- a/financeiro-inicio.html
+++ b/financeiro-inicio.html
@@ -17,7 +17,7 @@
     <h1 class="text-2xl font-bold">Área Financeira</h1>
     <p>Selecione uma opção no menu ao lado para acessar as ferramentas financeiras.</p>
   </main>
-  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-financeiro.html';</script>
+  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-gestor.html';</script>
   <script src="shared.js"></script>
 </body>
 </html>

--- a/financeiro.html
+++ b/financeiro.html
@@ -67,7 +67,7 @@
   </div>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="financeiro.js"></script>
-  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-financeiro.html';</script>
+  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-gestor.html';</script>
   <script src="shared.js"></script>
   </body>
 </html>

--- a/partials/sidebar-gestor.html
+++ b/partials/sidebar-gestor.html
@@ -10,25 +10,33 @@
     </div>
   </div>
   <div class="py-4">
-    <a href="/VendedorPro/gestor.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestor">
+    <a href="/VendedorPro/gestor.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao" data-perfil="gestor">
       <span class="mr-3">📂</span>
-      <span class="link-text">Gestor</span>
+      <span class="link-text">Gestão</span>
     </a>
-    <a href="/VendedorPro/mentoria.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-mentoria">
-      <span class="mr-3">🎓</span>
-      <span class="link-text">Mentoria</span>
-    </a>
-    <a href="/VendedorPro/financeiro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-financeiro">
+    <a href="/VendedorPro/financeiro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-financeiro" data-perfil="gestor">
       <span class="mr-3">💰</span>
       <span class="link-text">Financeiro</span>
     </a>
-    <a href="/VendedorPro/atualizacoes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-atualizacoes">
+    <a href="/VendedorPro/atualizacoes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-atualizacoes" data-perfil="gestor">
       <span class="mr-3">📎</span>
       <span class="link-text">Atualizações</span>
     </a>
-    <a href="/VendedorPro/equipes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-equipes">
+    <a href="/VendedorPro/saques.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-saques" data-perfil="gestor">
+      <span class="mr-3">💸</span>
+      <span class="link-text">Saques</span>
+    </a>
+    <a href="/VendedorPro/mentoria.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-mentoria" data-perfil="gestor">
+      <span class="mr-3">🎓</span>
+      <span class="link-text">Visão Geral do Mentor</span>
+    </a>
+    <a href="/VendedorPro/equipes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-equipes" data-perfil="gestor">
       <span class="mr-3">👥</span>
       <span class="link-text">Equipes</span>
+    </a>
+    <a href="/VendedorPro/desempenho.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-desempenho" data-perfil="gestor">
+      <span class="mr-3">📈</span>
+      <span class="link-text">Desempenho</span>
     </a>
   </div>
 </div>

--- a/saques.html
+++ b/saques.html
@@ -65,6 +65,7 @@
   </main>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="saques.js"></script>
+  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-gestor.html';</script>
   <script src="shared.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Exibir abas Gestão, Financeiro, Atualizações, Saques, Visão Geral do Mentor, Equipes e Desempenho somente para gestores
- Unificar sidebar das páginas financeiras e de saques com a versão de gestor

## Testing
- `npm test` *(falha: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4e3b578c832aa72e711948a3f3d9