### PR TITLE
Exibir vendedores lado a lado no histórico de faturamento

### DIFF
--- a/atualizacoes.html
+++ b/atualizacoes.html
@@ -20,7 +20,7 @@
     </div>
     <div id="historicoFaturamentoCard" class="card p-4 hidden">
       <h2 class="font-medium mb-2">Histórico de Faturamento (3 dias)</h2>
-      <div id="historicoFaturamento" class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm"></div>
+      <div id="historicoFaturamento" class="flex flex-nowrap gap-4 overflow-x-auto text-sm"></div>
     </div>
     <form id="formAtualizacao" class="card p-4 space-y-4">
       <div>

--- a/atualizacoes.js
+++ b/atualizacoes.js
@@ -143,6 +143,7 @@ async function carregarHistoricoFaturamento() {
     const dias = fatSnap.docs.map(d => d.id).sort().slice(-3);
     let ultimoLiquido = 0;
     const col = document.createElement('div');
+    col.className = 'min-w-[200px]';
     col.innerHTML = `<h3 class="font-bold">${u.nome}</h3><div class="text-xs text-gray-500 mb-2">META LIQUIDA R$ ${metaDiaria.toLocaleString('pt-BR')}</div>`;
     for (const dia of dias) {
       const { liquido, bruto } = await calcularFaturamentoDiaDetalhado(u.uid, dia);


### PR DESCRIPTION
## Resumo
- Organiza o histórico de faturamento com layout horizontal para mostrar vendedores lado a lado.
- Garante largura mínima para cada coluna de vendedor.

## Testes
- `npm test` *(falhou: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4fffa2b8832a9f5791504b96f831