### PR TITLE
Ensure sidebar loads on mentor and finance pages

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -184,7 +184,7 @@
       .start();
   };
 
-document.addEventListener('DOMContentLoaded', function () {
+function initShared() {
   loadTailwind().then(function () {
     window.loadSidebar(null, window.CUSTOM_SIDEBAR_PATH).then(function () {
       window.initDarkMode();
@@ -200,7 +200,13 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   window.checkColorContrast();
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initShared);
+} else {
+  initShared();
+}
 
 // Handle mobile sidebar toggle after navbar loads
 document.addEventListener('navbarLoaded', function () {


### PR DESCRIPTION
## Summary
- Initialize common UI elements immediately if the DOM is already ready, preventing the sidebar from disappearing on some pages.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac51f5119c832a9ccb0b49d11f44c7