### PR TITLE
feat: add mentorado status management and messaging

### DIFF
--- a/mentoria.js
+++ b/mentoria.js
@@ -1,11 +1,12 @@
 import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
-import { getFirestore, collection, query, where, onSnapshot } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { getFirestore, collection, query, where, onSnapshot, doc, updateDoc, addDoc, serverTimestamp } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
 import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 import { firebaseConfig } from './firebase-config.js';
 
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app);
+let currentUser = null;
 
 function renderMentorado(id, data) {
   const card = document.createElement('div');
@@ -14,7 +15,11 @@ function renderMentorado(id, data) {
   card.innerHTML = `
     <div class="card-header flex justify-between items-center">
       <h3 class="font-bold">${data.nome || 'Sem nome'}</h3>
-      <span class="text-sm">${data.status || 'Sem status'}</span>
+      <select class="form-control w-40 status-select">
+        <option value="iniciante">Iniciante</option>
+        <option value="em progresso">Em progresso</option>
+        <option value="avancado">Avançado</option>
+      </select>
     </div>
     <div class="card-body space-y-2">
       <p class="text-sm">Último contato: ${data.ultimoContato || '-'}</p>
@@ -22,9 +27,35 @@ function renderMentorado(id, data) {
         <div class="bg-blue-500 h-2 rounded" style="width: ${progresso}%"></div>
       </div>
       <p class="text-xs text-gray-500">Progresso: ${progresso}%</p>
+      <button class="btn btn-primary enviar-msg">Enviar mensagem</button>
     </div>
   `;
+
+  const select = card.querySelector('.status-select');
+  select.value = data.status || 'iniciante';
+  select.addEventListener('change', e => atualizarStatus(id, e.target.value));
+
+  const msgBtn = card.querySelector('.enviar-msg');
+  msgBtn.addEventListener('click', () => enviarMensagem(id, data.nome || '')); 
+
   return card;
+}
+
+async function atualizarStatus(id, status) {
+  await updateDoc(doc(db, 'mentorados', id), { status });
+}
+
+async function enviarMensagem(mentoradoId, nome) {
+  if (!currentUser) return;
+  const texto = prompt(`Mensagem para ${nome}:`);
+  if (!texto) return;
+  await addDoc(collection(db, 'mensagens'), {
+    mentorUid: currentUser.uid,
+    mentoradoId,
+    mensagem: texto,
+    createdAt: serverTimestamp()
+  });
+  alert('Mensagem enviada!');
 }
 
 function carregarMentorados(user) {
@@ -45,6 +76,7 @@ function carregarMentorados(user) {
 function initMentoria() {
   onAuthStateChanged(auth, user => {
     if (user) {
+      currentUser = user;
       carregarMentorados(user);
     }
   });


### PR DESCRIPTION
## Summary
- allow mentors to set each mentee's status
- enable sending messages to mentees directly from the overview

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac52728d90832a9ce6b9abb40f78f0