### PR TITLE
Add Perfil do Mentorado tab for mentor profiles

### DIFF
--- a/partials/sidebar-gestor.html
+++ b/partials/sidebar-gestor.html
@@ -30,6 +30,10 @@
       <span class="mr-3">🎓</span>
       <span class="link-text">Visão Geral do Mentor</span>
     </a>
+    <a href="/VendedorPro/perfil-mentorado.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-perfil-mentorado" data-perfil="gestor">
+      <span class="mr-3">📝</span>
+      <span class="link-text">Perfil do Mentorado</span>
+    </a>
     <a href="/VendedorPro/equipes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-equipes" data-perfil="gestor">
       <span class="mr-3">👥</span>
       <span class="link-text">Equipes</span>

--- a/perfil-mentorado.html
+++ b/perfil-mentorado.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Perfil do Mentorado</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="css/components.css">
+</head>
+<body class="bg-gray-100 text-gray-800">
+  <div id="sidebar-container"></div>
+  <div id="navbar-container"></div>
+  <main class="main-content p-4 space-y-6">
+    <div class="card">
+      <div class="card-header"><h2 class="text-xl font-bold">Perfil do Mentorado</h2></div>
+      <div id="perfilMentoradoList" class="card-body space-y-4"></div>
+    </div>
+  </main>
+  <script type="module" src="firebase-config.js"></script>
+  <script type="module" src="perfil-mentorado.js"></script>
+  <script type="module" src="login.js"></script>
+  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-gestor.html';</script>
+  <script src="shared.js"></script>
+  <script>
+    if (window.initPerfilMentorado) {
+      window.initPerfilMentorado();
+    }
+  </script>
+</body>
+</html>

--- a/perfil-mentorado.js
+++ b/perfil-mentorado.js
@@ -1,0 +1,82 @@
+import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { getFirestore, collection, query, where, getDocs, doc, getDoc, setDoc } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { firebaseConfig } from './firebase-config.js';
+
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+const db = getFirestore(app);
+const auth = getAuth(app);
+
+function createPerfilCard(uid, email, data = {}) {
+  const card = document.createElement('div');
+  card.className = 'border p-4 rounded space-y-2';
+  card.innerHTML = `
+    <h3 class="font-bold">${email}</h3>
+    <input class="form-control" placeholder="Nome" value="${data.nome || ''}" data-field="nome">
+    <input class="form-control" placeholder="Loja" value="${data.loja || ''}" data-field="loja">
+    <input class="form-control" placeholder="Segmento" value="${data.segmento || ''}" data-field="segmento">
+    <input class="form-control" placeholder="Tempo de operação" value="${data.tempoOperacao || ''}" data-field="tempoOperacao">
+    <input class="form-control" placeholder="Link Shopee" value="${data.links?.shopee || ''}" data-field="shopee">
+    <input class="form-control" placeholder="Link Mercado Livre" value="${data.links?.mercadoLivre || ''}" data-field="mercadoLivre">
+    <input class="form-control" placeholder="Site próprio" value="${data.links?.site || ''}" data-field="site">
+    <input class="form-control" placeholder="Instagram" value="${data.links?.instagram || ''}" data-field="instagram">
+    <textarea class="form-control" placeholder="Objetivos">${data.objetivos || ''}</textarea>
+    <button class="btn btn-primary salvar">Salvar</button>
+  `;
+
+  card.querySelector('.salvar').addEventListener('click', async () => {
+    const getVal = (field) => card.querySelector(`[data-field="${field}"]`).value.trim();
+    const payload = {
+      nome: getVal('nome'),
+      loja: getVal('loja'),
+      segmento: getVal('segmento'),
+      tempoOperacao: getVal('tempoOperacao'),
+      links: {
+        shopee: getVal('shopee'),
+        mercadoLivre: getVal('mercadoLivre'),
+        site: getVal('site'),
+        instagram: getVal('instagram')
+      },
+      objetivos: card.querySelector('textarea').value.trim()
+    };
+    try {
+      await setDoc(doc(db, 'perfilMentorado', uid), payload, { merge: true });
+      alert('Perfil salvo!');
+    } catch (e) {
+      console.error('Erro ao salvar perfil:', e);
+      alert('Erro ao salvar.');
+    }
+  });
+  return card;
+}
+
+async function carregarPerfis() {
+  const list = document.getElementById('perfilMentoradoList');
+  list.innerHTML = '';
+  const q = query(collection(db, 'usuarios'), where('perfil', '==', 'Gestor'));
+  const snap = await getDocs(q);
+  for (const docSnap of snap.docs) {
+    const uid = docSnap.id;
+    const email = docSnap.data().email || uid;
+    let perfilData = {};
+    try {
+      const perfilSnap = await getDoc(doc(db, 'perfilMentorado', uid));
+      if (perfilSnap.exists()) {
+        perfilData = perfilSnap.data();
+      }
+    } catch (e) {
+      console.error('Erro ao carregar perfil do mentorado:', e);
+    }
+    list.appendChild(createPerfilCard(uid, email, perfilData));
+  }
+}
+
+function initPerfilMentorado() {
+  onAuthStateChanged(auth, user => {
+    if (user) {
+      carregarPerfis();
+    }
+  });
+}
+
+window.initPerfilMentorado = initPerfilMentorado;


### PR DESCRIPTION
## Summary
- add Perfil do Mentorado page for gestores to fill mentee information
- implement Firestore-backed script to list gestores and save profiles
- link the new page in the gestor sidebar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac537373a4832ab6435f998c7937b7