### PR TITLE
fix: improve mobile sidebar text readability

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -408,6 +408,7 @@ body.dark .card-header {
 }
 .sidebar {
   background-color: var(--secondary);
+  color: #1f2937;
   height: 100vh;
   overflow-y: auto;
   padding: 20px 0;
@@ -416,13 +417,13 @@ body.dark .card-header {
 .sidebar-logo {
   text-align: center;
   padding: 0 20px 20px;
-  border-bottom: 1px solid rgba(255,255,255,.1);
+  border-bottom: 1px solid rgba(0,0,0,.1);
   margin-bottom: 20px
 }
 .sidebar-logo h2 {
   font-family: Inter,sans-serif;
   font-size: 1.4rem;
-  color: #fff;
+  color: #1f2937;
   margin-top: 10px
 }
 .sidebar-menu {
@@ -435,16 +436,22 @@ body.dark .card-header {
 .sidebar-menu a {
   display: flex;
   align-items: center;
- padding: 12px 15px;
-  color: rgba(255,255,255,.8);
+  padding: 12px 15px;
+  color: #1f2937;
   text-decoration: none;
   border-radius: 8px;
   transition: .2s
 }
 .sidebar-menu a.active,
 .sidebar-menu a:hover {
+  background-color: rgba(0,0,0,.1);
+  color: #1f2937
+}
+
+body.dark .sidebar-menu a.active,
+body.dark .sidebar-menu a:hover {
   background-color: rgba(255,255,255,.1);
-  color: #fff
+  color: #fff;
 }
 .sidebar-menu a i {
   font-size: 1.2rem;

--- a/partials/sidebar-financeiro.html
+++ b/partials/sidebar-financeiro.html
@@ -1,4 +1,4 @@
-<div id="sidebar" class="sidebar w-64 h-screen overflow-y-auto fixed left-0 top-0 z-50 text-gray-100">
+<div id="sidebar" class="sidebar w-64 h-screen overflow-y-auto fixed left-0 top-0 z-50 text-gray-800">
   <div class="sidebar-logo p-4">
     <div class="flex items-center">
       <div class="bg-white w-10 h-10 rounded-lg flex items-center justify-center mr-3">
@@ -6,7 +6,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z" />
         </svg>
       </div>
-      <span class="font-bold text-xl text-white">VendedorPro</span>
+      <span class="font-bold text-xl text-gray-800">VendedorPro</span>
     </div>
   </div>
   <div class="py-4">

--- a/partials/sidebar-gestor.html
+++ b/partials/sidebar-gestor.html
@@ -1,4 +1,4 @@
-<div id="sidebar" class="sidebar w-64 h-screen overflow-y-auto fixed left-0 top-0 z-50 text-gray-100">
+<div id="sidebar" class="sidebar w-64 h-screen overflow-y-auto fixed left-0 top-0 z-50 text-gray-800">
   <div class="sidebar-logo p-4">
     <div class="flex items-center">
       <div class="bg-white w-10 h-10 rounded-lg flex items-center justify-center mr-3">
@@ -6,7 +6,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.981 14.981 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z" />
         </svg>
       </div>
-      <span class="font-bold text-xl text-white">VendedorPro</span>
+      <span class="font-bold text-xl text-gray-800">VendedorPro</span>
     </div>
   </div>
   <div class="py-4">

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -1,4 +1,4 @@
-<div id="sidebar" class="sidebar w-64 h-screen overflow-y-auto fixed left-0 top-0 z-50 text-gray-100">
+<div id="sidebar" class="sidebar w-64 h-screen overflow-y-auto fixed left-0 top-0 z-50 text-gray-800">
   <div class="sidebar-logo p-4">
     <div class="flex items-center">
       <div class="bg-white w-10 h-10 rounded-lg flex items-center justify-center mr-3">
@@ -6,7 +6,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"/>
         </svg>
       </div>
-      <span class="font-bold text-xl text-white">VendedorPro</span>
+      <span class="font-bold text-xl text-gray-800">VendedorPro</span>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- darken sidebar text and hover states for better contrast
- update sidebar partials to use darker text

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5555de00832aada925e40ec4325a