### PR TITLE
Add basic product management tab for gestores

### DIFF
--- a/gestao-produtos.html
+++ b/gestao-produtos.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Gestão de Produtos</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="css/components.css">
+</head>
+<body class="bg-gray-100 text-gray-800">
+  <div id="sidebar-container"></div>
+  <div id="navbar-container"></div>
+  <main class="main-content p-4 space-y-4">
+    <!-- Cadastro de Produto -->
+    <div class="card">
+      <div class="card-header"><h2 class="text-xl font-bold">📦 Cadastrar Produto</h2></div>
+      <div class="card-body space-y-4">
+        <div class="form-row">
+          <input id="produtoNome" class="form-control" placeholder="Nome" />
+          <input id="produtoSku" class="form-control" placeholder="SKU" />
+          <input id="produtoEstoque" type="number" class="form-control" placeholder="Estoque" />
+          <input id="produtoVendas" type="number" class="form-control" placeholder="Vendas" />
+          <input id="margemIdeal" type="number" class="form-control" placeholder="Margem ideal (%)" />
+          <input id="margemMinima" type="number" class="form-control" placeholder="Margem mínima (%)" />
+          <input id="margemPraticada" type="number" class="form-control" placeholder="Margem praticada (%)" />
+          <button id="btnAdicionarProduto" class="btn btn-primary">Adicionar</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Produtos cadastrados/ativos -->
+    <div class="card">
+      <div class="card-header"><h3 class="text-lg font-bold">Produtos cadastrados/ativos</h3></div>
+      <div class="card-body overflow-x-auto">
+        <table id="tabelaProdutos" class="min-w-full text-sm text-left"></table>
+      </div>
+    </div>
+
+    <!-- Anúncios mais vendidos -->
+    <div class="card">
+      <div class="card-header"><h3 class="text-lg font-bold">Anúncios mais vendidos</h3></div>
+      <div id="maisVendidos" class="card-body overflow-x-auto text-sm"></div>
+    </div>
+
+    <!-- Produtos com baixo giro / estoque parado -->
+    <div class="card">
+      <div class="card-header"><h3 class="text-lg font-bold">Produtos com baixo giro / estoque parado</h3></div>
+      <div id="baixoGiro" class="card-body overflow-x-auto text-sm"></div>
+    </div>
+
+    <!-- Margem por produto -->
+    <div class="card">
+      <div class="card-header"><h3 class="text-lg font-bold">Margem por produto</h3></div>
+      <div id="margemProdutos" class="card-body overflow-x-auto text-sm"></div>
+    </div>
+  </main>
+  <script type="module" src="firebase-config.js"></script>
+  <script type="module" src="gestao-produtos.js"></script>
+  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar-gestor.html';</script>
+  <script src="shared.js"></script>
+</body>
+</html>

--- a/gestao-produtos.js
+++ b/gestao-produtos.js
@@ -1,0 +1,89 @@
+// Gestão de Produtos - simples gerenciamento no navegador
+let produtos = JSON.parse(localStorage.getItem('gestaoProdutos') || '[]');
+
+function salvar() {
+  localStorage.setItem('gestaoProdutos', JSON.stringify(produtos));
+}
+
+function adicionarProduto() {
+  const nome = document.getElementById('produtoNome').value.trim();
+  const sku = document.getElementById('produtoSku').value.trim();
+  if (!nome || !sku) return;
+  const estoque = Number(document.getElementById('produtoEstoque').value) || 0;
+  const vendas = Number(document.getElementById('produtoVendas').value) || 0;
+  const margemIdeal = Number(document.getElementById('margemIdeal').value) || 0;
+  const margemMinima = Number(document.getElementById('margemMinima').value) || 0;
+  const margemPraticada = Number(document.getElementById('margemPraticada').value) || 0;
+  produtos.push({ nome, sku, estoque, vendas, margemIdeal, margemMinima, margemPraticada });
+  salvar();
+  limparFormulario();
+  renderTudo();
+}
+
+function limparFormulario() {
+  ['produtoNome','produtoSku','produtoEstoque','produtoVendas','margemIdeal','margemMinima','margemPraticada'].forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.value = '';
+  });
+}
+
+function criarTabela(colunas, dados) {
+  let html = '<table class="min-w-full text-left"><thead><tr>' +
+    colunas.map(c => `<th class="px-2 py-1 border-b">${c.label}</th>`).join('') +
+    '</tr></thead><tbody>';
+  html += dados.map(d => '<tr>' +
+    colunas.map(c => `<td class="px-2 py-1 border-b">${d[c.key] ?? ''}</td>`).join('') +
+    '</tr>').join('');
+  html += '</tbody></table>';
+  return html;
+}
+
+function renderProdutos() {
+  const colunas = [
+    { key: 'nome', label: 'Nome' },
+    { key: 'sku', label: 'SKU' },
+    { key: 'estoque', label: 'Estoque' },
+    { key: 'vendas', label: 'Vendas' }
+  ];
+  document.getElementById('tabelaProdutos').innerHTML = criarTabela(colunas, produtos);
+}
+
+function renderMaisVendidos() {
+  const dados = [...produtos].sort((a,b) => b.vendas - a.vendas);
+  const colunas = [
+    { key: 'nome', label: 'Nome' },
+    { key: 'vendas', label: 'Vendas' }
+  ];
+  document.getElementById('maisVendidos').innerHTML = criarTabela(colunas, dados);
+}
+
+function renderBaixoGiro() {
+  const dados = produtos.filter(p => p.estoque > 0 && p.vendas === 0);
+  const colunas = [
+    { key: 'nome', label: 'Nome' },
+    { key: 'estoque', label: 'Estoque' },
+    { key: 'vendas', label: 'Vendas' }
+  ];
+  document.getElementById('baixoGiro').innerHTML = criarTabela(colunas, dados);
+}
+
+function renderMargens() {
+  const colunas = [
+    { key: 'nome', label: 'Nome' },
+    { key: 'margemIdeal', label: 'Margem ideal (%)' },
+    { key: 'margemMinima', label: 'Margem mínima (%)' },
+    { key: 'margemPraticada', label: 'Margem praticada (%)' }
+  ];
+  document.getElementById('margemProdutos').innerHTML = criarTabela(colunas, produtos);
+}
+
+function renderTudo() {
+  renderProdutos();
+  renderMaisVendidos();
+  renderBaixoGiro();
+  renderMargens();
+}
+
+document.getElementById('btnAdicionarProduto')?.addEventListener('click', adicionarProduto);
+
+renderTudo();

--- a/partials/sidebar-gestor.html
+++ b/partials/sidebar-gestor.html
@@ -38,6 +38,10 @@
       <span class="mr-3">👥</span>
       <span class="link-text">Equipes</span>
     </a>
+    <a href="/VendedorPro/gestao-produtos.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-produtos" data-perfil="gestor">
+      <span class="mr-3">📦</span>
+      <span class="link-text">Gestão de Produtos</span>
+    </a>
     <a href="/VendedorPro/desempenho.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-desempenho" data-perfil="gestor">
       <span class="mr-3">📈</span>
       <span class="link-text">Desempenho</span>


### PR DESCRIPTION
## Summary
- add "Gestão de Produtos" page for gestores to register and track products
- show product lists for active items, best sellers, low turnover, and margins
- link new page in gestor sidebar navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac58c89fe0832a8c3979730f3e7a1b