### PR TITLE
fix: restore sidebar on mentor and finance pages

### DIFF
--- a/financeiro-inicio.html
+++ b/financeiro-inicio.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="css/components.css" />
 </head>
 <body class="bg-gray-100 text-gray-800">
+  <button class="mobile-menu-btn" onclick="toggleSidebar()" aria-label="Abrir menu" aria-expanded="false">☰</button>
   <div id="sidebar-container"></div>
   <div id="navbar-container"></div>
   <main class="main-content p-4 space-y-4">

--- a/financeiro.html
+++ b/financeiro.html
@@ -14,6 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="bg-gray-100 text-gray-800">
+  <button class="mobile-menu-btn" onclick="toggleSidebar()" aria-label="Abrir menu" aria-expanded="false">☰</button>
   <div id="sidebar-container"></div>
   <div id="navbar-container"></div>
   <main class="main-content p-4 space-y-4">

--- a/mentoria.html
+++ b/mentoria.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="css/components.css">
 </head>
 <body class="bg-gray-100 text-gray-800">
+  <button class="mobile-menu-btn" onclick="toggleSidebar()" aria-label="Abrir menu" aria-expanded="false">☰</button>
   <div id="sidebar-container"></div>
   <div id="navbar-container"></div>
   <main class="main-content p-4 space-y-6">

--- a/perfil-mentorado.html
+++ b/perfil-mentorado.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="css/components.css">
 </head>
 <body class="bg-gray-100 text-gray-800">
+  <button class="mobile-menu-btn" onclick="toggleSidebar()" aria-label="Abrir menu" aria-expanded="false">☰</button>
   <div id="sidebar-container"></div>
   <div id="navbar-container"></div>
   <main class="main-content p-4 space-y-6">

--- a/shared.js
+++ b/shared.js
@@ -33,6 +33,17 @@
       el.classList.remove('max-h-screen');
     }
   };
+
+  // Toggle sidebar visibility on mobile
+  window.toggleSidebar = function() {
+    var sidebar = document.getElementById('sidebar') || document.querySelector('.sidebar');
+    if (!sidebar) return;
+    var isActive = sidebar.classList.toggle('active');
+    var btn = document.querySelector('.mobile-menu-btn');
+    if (btn) {
+      btn.setAttribute('aria-expanded', isActive ? 'true' : 'false');
+    }
+  };
   
   // Toggle visibility of the Importar Produtos card on the precificação page
   window.toggleImportCard = function() {


### PR DESCRIPTION
## Summary
- add global `toggleSidebar` helper
- include mobile sidebar button on mentor, mentee and finance pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5a0fef08832ab2ab49b971549496