### PR TITLE
feat: show financial mentees on mentor overview

### DIFF
--- a/mentoria.html
+++ b/mentoria.html
@@ -16,7 +16,20 @@
   <main class="main-content p-4 space-y-6">
     <div class="card">
       <div class="card-header"><h2 class="text-xl font-bold">Visão Geral do Mentor</h2></div>
-      <div id="mentoradosList" class="card-body space-y-4"></div>
+      <div class="card-body overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead>
+            <tr class="text-left">
+              <th class="p-2">Email</th>
+              <th class="p-2">Início</th>
+              <th class="p-2">Status</th>
+              <th class="p-2">Meta</th>
+              <th class="p-2">Nome</th>
+            </tr>
+          </thead>
+          <tbody id="mentoradosList"></tbody>
+        </table>
+      </div>
     </div>
   </main>
   <script type="module" src="firebase-config.js"></script>


### PR DESCRIPTION
## Summary
- display table of users where the mentor is set as financial manager
- fetch each user's start date, status and monthly goal for mentor overview

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5ac382bc832a88dfce78b8ac8a74