### PR TITLE
Ensure sidebar loads even if Tailwind fails

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -185,11 +185,15 @@
   };
 
 function initShared() {
-  loadTailwind().then(function () {
+  function start() {
     window.loadSidebar(null, window.CUSTOM_SIDEBAR_PATH).then(function () {
       window.initDarkMode();
     });
     window.loadNavbar();
+  }
+
+  loadTailwind().then(start).catch(function () {
+    start();
   });
 
   // ✅ Só carrega os modais de login se estiver na index.html


### PR DESCRIPTION
## Summary
- prevent missing sidebar by running sidebar and navbar loading even if Tailwind CSS fails

## Testing
- `node --check shared.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5a0fef08832ab2ab49b971549496