### PR TITLE
Improve gestor sidebar responsiveness

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -342,7 +342,7 @@ input:checked + .dark-mode-slider:before {
     transform: translateY(0)
   }
 }
-@media (max-width:1024px) {
+  @media (max-width:768px) {
   .sidebar {
     width: 70px
   }
@@ -352,7 +352,7 @@ input:checked + .dark-mode-slider:before {
   .sidebar-link {
     justify-content: center
   }
-  .sidebar-link i {
+  .sidebar-link .mr-3 {
     margin-right: 0
   }
   .top-navbar {

--- a/partials/sidebar-gestor.html
+++ b/partials/sidebar-gestor.html
@@ -11,39 +11,39 @@
   </div>
   <div class="py-4">
     <a href="/VendedorPro/gestor.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao" data-perfil="gestor">
-      <span class="mr-3">📂</span>
+      <span class="mr-3"><i class="fas fa-clipboard-list"></i></span>
       <span class="link-text">Gestão</span>
     </a>
     <a href="/VendedorPro/financeiro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-financeiro" data-perfil="gestor">
-      <span class="mr-3">💰</span>
+      <span class="mr-3"><i class="fas fa-dollar-sign"></i></span>
       <span class="link-text">Financeiro</span>
     </a>
     <a href="/VendedorPro/atualizacoes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-atualizacoes" data-perfil="gestor">
-      <span class="mr-3">📎</span>
+      <span class="mr-3"><i class="fas fa-paperclip"></i></span>
       <span class="link-text">Atualizações</span>
     </a>
     <a href="/VendedorPro/saques.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-saques" data-perfil="gestor">
-      <span class="mr-3">💸</span>
+      <span class="mr-3"><i class="fas fa-money-bill-wave"></i></span>
       <span class="link-text">Saques</span>
     </a>
     <a href="/VendedorPro/mentoria.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-mentoria" data-perfil="gestor">
-      <span class="mr-3">🎓</span>
+      <span class="mr-3"><i class="fas fa-chalkboard-teacher"></i></span>
       <span class="link-text">Visão Geral do Mentor</span>
     </a>
     <a href="/VendedorPro/perfil-mentorado.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-perfil-mentorado" data-perfil="gestor">
-      <span class="mr-3">📝</span>
+      <span class="mr-3"><i class="fas fa-id-card"></i></span>
       <span class="link-text">Perfil do Mentorado</span>
     </a>
     <a href="/VendedorPro/equipes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-equipes" data-perfil="gestor">
-      <span class="mr-3">👥</span>
+      <span class="mr-3"><i class="fas fa-users"></i></span>
       <span class="link-text">Equipes</span>
     </a>
     <a href="/VendedorPro/gestao-produtos.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-produtos" data-perfil="gestor">
-      <span class="mr-3">📦</span>
+      <span class="mr-3"><i class="fas fa-box-open"></i></span>
       <span class="link-text">Gestão de Produtos</span>
     </a>
     <a href="/VendedorPro/desempenho.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-desempenho" data-perfil="gestor">
-      <span class="mr-3">📈</span>
+      <span class="mr-3"><i class="fas fa-chart-line"></i></span>
       <span class="link-text">Desempenho</span>
     </a>
   </div>


### PR DESCRIPTION
## Summary
- replace emoji with Font Awesome icons in gestor sidebar
- reduce breakpoint for hiding sidebar text to 768px
- ensure icon container loses margin in collapsed sidebar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6474c18c832aac0a54cf1487fcd6