### PR TITLE
Fix gestor sidebar visibility for mentor pages

### DIFF
--- a/partials/sidebar-gestor.html
+++ b/partials/sidebar-gestor.html
@@ -10,39 +10,39 @@
     </div>
   </div>
   <div class="py-4">
-    <a href="/VendedorPro/gestor.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao" data-perfil="gestor">
+    <a href="/VendedorPro/gestor.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao" data-perfil="gestor,mentor">
       <span class="mr-3"><i class="fas fa-clipboard-list"></i></span>
       <span class="link-text">Gestão</span>
     </a>
-    <a href="/VendedorPro/financeiro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-financeiro" data-perfil="gestor">
+    <a href="/VendedorPro/financeiro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-financeiro" data-perfil="gestor,mentor">
       <span class="mr-3"><i class="fas fa-dollar-sign"></i></span>
       <span class="link-text">Financeiro</span>
     </a>
-    <a href="/VendedorPro/atualizacoes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-atualizacoes" data-perfil="gestor">
+    <a href="/VendedorPro/atualizacoes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-atualizacoes" data-perfil="gestor,mentor">
       <span class="mr-3"><i class="fas fa-paperclip"></i></span>
       <span class="link-text">Atualizações</span>
     </a>
-    <a href="/VendedorPro/saques.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-saques" data-perfil="gestor">
+    <a href="/VendedorPro/saques.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-saques" data-perfil="gestor,mentor">
       <span class="mr-3"><i class="fas fa-money-bill-wave"></i></span>
       <span class="link-text">Saques</span>
     </a>
-    <a href="/VendedorPro/mentoria.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-mentoria" data-perfil="gestor">
+    <a href="/VendedorPro/mentoria.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-mentoria" data-perfil="gestor,mentor">
       <span class="mr-3"><i class="fas fa-chalkboard-teacher"></i></span>
       <span class="link-text">Visão Geral do Mentor</span>
     </a>
-    <a href="/VendedorPro/perfil-mentorado.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-perfil-mentorado" data-perfil="gestor">
+    <a href="/VendedorPro/perfil-mentorado.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-perfil-mentorado" data-perfil="gestor,mentor">
       <span class="mr-3"><i class="fas fa-id-card"></i></span>
       <span class="link-text">Perfil do Mentorado</span>
     </a>
-    <a href="/VendedorPro/equipes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-equipes" data-perfil="gestor">
+    <a href="/VendedorPro/equipes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-equipes" data-perfil="gestor,mentor">
       <span class="mr-3"><i class="fas fa-users"></i></span>
       <span class="link-text">Equipes</span>
     </a>
-    <a href="/VendedorPro/gestao-produtos.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-produtos" data-perfil="gestor">
+    <a href="/VendedorPro/gestao-produtos.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-produtos" data-perfil="gestor,mentor">
       <span class="mr-3"><i class="fas fa-box-open"></i></span>
       <span class="link-text">Gestão de Produtos</span>
     </a>
-    <a href="/VendedorPro/desempenho.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-desempenho" data-perfil="gestor">
+    <a href="/VendedorPro/desempenho.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-desempenho" data-perfil="gestor,mentor">
       <span class="mr-3"><i class="fas fa-chart-line"></i></span>
       <span class="link-text">Desempenho</span>
     </a>


### PR DESCRIPTION
## Summary
- show gestor sidebar for mentor role by allowing `mentor` profile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac668603c4832abb6ece082713dc4f