### PR TITLE
Fix sidebar visibility when user profile missing

### DIFF
--- a/login.js
+++ b/login.js
@@ -261,7 +261,8 @@ function restoreSidebar() {
   });
 }
 function applyPerfilRestrictions(perfil) {
-  const currentPerfil = (perfil || '').toLowerCase();
+  const currentPerfil = (perfil || '').toLowerCase().trim();
+  if (!currentPerfil) return;
   document.querySelectorAll('[data-perfil]').forEach(el => {
     const allowed = (el.getAttribute('data-perfil') || '')
       .toLowerCase()


### PR DESCRIPTION
## Summary
- prevent sidebar options from disappearing when user profile is undefined or empty

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac668603c4832abb6ece082713dc4f