### PR TITLE
feat: add profile configuration page

### DIFF
--- a/configuracao-perfil.html
+++ b/configuracao-perfil.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Configuração de Perfil</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="css/components.css">
+</head>
+<body class="bg-gray-100 text-gray-800">
+  <button class="mobile-menu-btn" onclick="toggleSidebar()" aria-label="Abrir menu" aria-expanded="false">☰</button>
+  <div id="sidebar-container"></div>
+  <div id="navbar-container"></div>
+  <main class="main-content p-4 space-y-6">
+    <div class="card">
+      <div class="card-header"><h2 class="text-xl font-bold">Configuração do Perfil</h2></div>
+      <form id="profileForm" class="card-body space-y-4">
+        <div id="lojasContainer" class="space-y-2"></div>
+        <button type="button" id="addStoreBtn" class="btn btn-secondary">Adicionar Loja</button>
+        <input id="plataformas" class="form-control" placeholder="Plataformas em que vende (ex: Shopee, Mercado Livre)">
+        <textarea id="infoPessoal" class="form-control" placeholder="Informações pessoais"></textarea>
+        <button type="submit" class="btn btn-primary">Salvar</button>
+      </form>
+    </div>
+  </main>
+  <script src="shared.js"></script>
+  <script type="module" src="firebase-config.js"></script>
+  <script type="module" src="configuracao-perfil.js"></script>
+  <script type="module" src="login.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      if (window.initConfiguracaoPerfil) {
+        window.initConfiguracaoPerfil();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/configuracao-perfil.js
+++ b/configuracao-perfil.js
@@ -1,0 +1,81 @@
+import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { getFirestore, doc, getDoc, setDoc } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { firebaseConfig } from './firebase-config.js';
+
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+const db = getFirestore(app);
+const auth = getAuth(app);
+
+function addStoreRow(data = {}) {
+  const container = document.getElementById('lojasContainer');
+  const row = document.createElement('div');
+  row.className = 'store-row flex space-x-2';
+  row.innerHTML = `
+    <input class="form-control flex-1" placeholder="Nome da loja" value="${data.nome || ''}" data-field="nome">
+    <input class="form-control flex-1" placeholder="Link da loja" value="${data.link || ''}" data-field="link">
+    <button type="button" class="btn btn-danger remover">✕</button>
+  `;
+  row.querySelector('.remover').addEventListener('click', () => row.remove());
+  container.appendChild(row);
+}
+
+function renderStores(stores = []) {
+  const container = document.getElementById('lojasContainer');
+  container.innerHTML = '';
+  if (!stores.length) {
+    addStoreRow();
+    return;
+  }
+  stores.forEach(s => addStoreRow(s));
+}
+
+async function loadProfile(uid) {
+  try {
+    const snap = await getDoc(doc(db, 'perfil', uid));
+    if (snap.exists()) {
+      const data = snap.data();
+      renderStores(data.lojas || []);
+      document.getElementById('plataformas').value = data.plataformas || '';
+      document.getElementById('infoPessoal').value = data.infoPessoal || '';
+    } else {
+      renderStores();
+    }
+  } catch (e) {
+    console.error('Erro ao carregar perfil:', e);
+    renderStores();
+  }
+}
+
+async function saveProfile(uid) {
+  const stores = Array.from(document.querySelectorAll('#lojasContainer .store-row')).map(row => ({
+    nome: row.querySelector('[data-field="nome"]').value.trim(),
+    link: row.querySelector('[data-field="link"]').value.trim()
+  })).filter(s => s.nome || s.link);
+  const plataformas = document.getElementById('plataformas').value.trim();
+  const infoPessoal = document.getElementById('infoPessoal').value.trim();
+  try {
+    await setDoc(doc(db, 'perfil', uid), { lojas: stores, plataformas, infoPessoal }, { merge: true });
+    alert('Perfil salvo com sucesso!');
+  } catch (e) {
+    console.error('Erro ao salvar perfil:', e);
+    alert('Erro ao salvar perfil');
+  }
+}
+
+function initConfiguracaoPerfil() {
+  const form = document.getElementById('profileForm');
+  const addBtn = document.getElementById('addStoreBtn');
+  addBtn.addEventListener('click', () => addStoreRow());
+
+  onAuthStateChanged(auth, user => {
+    if (!user) return;
+    loadProfile(user.uid);
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      saveProfile(user.uid);
+    });
+  });
+}
+
+window.initConfiguracaoPerfil = initConfiguracaoPerfil;

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -171,6 +171,7 @@
       <a href="https://matheus-35023.web.app" class="sidebar-link block py-2 px-4 transition-colors" target="_blank">Tiny</a>
       <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=configuracoes" class="sidebar-link block py-2 px-4 transition-colors">Configurações</a>
       <a href="painel-usuarios.html" class="sidebar-link block py-2 px-4 transition-colors">Painel Usuários</a>
+      <a href="/VendedorPro/configuracao-perfil.html" class="sidebar-link block py-2 px-4 transition-colors">Configuração Perfil</a>
       <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a>
       <a href="/VendedorPro/email-expedicao.html" class="sidebar-link block py-2 px-4 transition-colors">E-mail Expedição</a>
     </div>


### PR DESCRIPTION
## Summary
- add profile configuration page and script allowing users to record store links, platforms, and personal info in Firebase
- link new profile configuration tab in the sidebar

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7b8872cc832a8abdf8fcbe2c337c