### PR TITLE
feat: add role selection to login modal

### DIFF
--- a/login.js
+++ b/login.js
@@ -28,6 +28,7 @@ let authListenerRegistered = false;
 let explicitLogout = false;
 let isExpedicao = false;
 let notifUnsub = null;
+let selectedRole = null;
 
 
 function showToast(message, type = 'success') {
@@ -111,8 +112,19 @@ window.saveDisplayName = async () => {
 window.openModal = (id) => {
   const el = document.getElementById(id);
   if (el) {
+    if (id === 'loginModal') {
+      document.getElementById('roleSelection')?.classList.remove('hidden');
+      document.getElementById('loginForm')?.classList.add('hidden');
+      selectedRole = null;
+    }
     el.style.display = 'block';
   }
+};
+
+window.selectRole = (role) => {
+  selectedRole = role;
+  document.getElementById('roleSelection')?.classList.add('hidden');
+  document.getElementById('loginForm')?.classList.remove('hidden');
 };
 
 window.closeModal = (id) => {
@@ -142,7 +154,7 @@ window.login = () => {
       closeModal('loginModal');
       document.getElementById('loginPassphrase').value = '';
       const path = window.location.pathname.toLowerCase();
-      if (path.includes('login-gestor.html')) {
+      if (selectedRole === 'gestor' || path.includes('login-gestor.html')) {
         window.location.href = 'financeiro.html';
       }
     })

--- a/partials/auth-modals.html
+++ b/partials/auth-modals.html
@@ -10,7 +10,15 @@
       <p class="text-gray-600 mt-2">Insira suas credenciais para acessar as ferramentas</p>
     </div>
 
-    <div class="space-y-6">
+    <div id="roleSelection" class="space-y-6 text-center">
+      <p class="text-gray-600">Escolha o tipo de acesso</p>
+      <div class="flex justify-center space-x-4">
+        <button onclick="selectRole('usuario')" class="btn-primary px-4 py-2">Usuário</button>
+        <button onclick="selectRole('gestor')" class="btn-primary px-4 py-2">Gestor</button>
+      </div>
+    </div>
+
+    <div id="loginForm" class="space-y-6 hidden">
       <div>
         <label class="block text-sm font-medium mb-2 text-gray-700">E-mail</label>
         <div class="relative">
@@ -30,7 +38,7 @@
           <input type="password" id="loginPassword" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
         </div>
       </div>
-<div>
+      <div>
         <label class="block text-sm font-medium mb-2 text-gray-700">Senha de visualização</label>
         <div class="relative">
           <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">

--- a/public/login.js
+++ b/public/login.js
@@ -28,6 +28,7 @@ let authListenerRegistered = false;
 let explicitLogout = false;
 let isExpedicao = false;
 let notifUnsub = null;
+let selectedRole = null;
 
 
 function showToast(message, type = 'success') {
@@ -111,8 +112,19 @@ window.saveDisplayName = async () => {
 window.openModal = (id) => {
   const el = document.getElementById(id);
   if (el) {
+    if (id === 'loginModal') {
+      document.getElementById('roleSelection')?.classList.remove('hidden');
+      document.getElementById('loginForm')?.classList.add('hidden');
+      selectedRole = null;
+    }
     el.style.display = 'block';
   }
+};
+
+window.selectRole = (role) => {
+  selectedRole = role;
+  document.getElementById('roleSelection')?.classList.add('hidden');
+  document.getElementById('loginForm')?.classList.remove('hidden');
 };
 
 window.closeModal = (id) => {
@@ -141,6 +153,10 @@ window.login = () => {
       showUserArea(cred.user);
       closeModal('loginModal');
       document.getElementById('loginPassphrase').value = '';
+      const path = window.location.pathname.toLowerCase();
+      if (selectedRole === 'gestor' || path.includes('login-gestor.html')) {
+        window.location.href = 'financeiro.html';
+      }
     })
     .catch(err => showToast('Credenciais inválidas! ' + err.message, 'error'));
 };


### PR DESCRIPTION
## Summary
- add user or manager selection before showing login form
- adjust login script to handle role selection and redirect managers

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac805729b0832ab6bf864d5c386667