### PR TITLE
feat: expand profile configuration with detailed user info

### DIFF
--- a/configuracao-perfil.html
+++ b/configuracao-perfil.html
@@ -17,9 +17,81 @@
   <main class="main-content p-4 space-y-6">
     <div class="card">
       <div class="card-header"><h2 class="text-xl font-bold">Configuração do Perfil</h2></div>
-      <form id="profileForm" class="card-body space-y-4">
-        <div id="lojasContainer" class="space-y-2"></div>
-        <button type="button" id="addStoreBtn" class="btn btn-secondary">Adicionar Loja</button>
+      <form id="profileForm" class="card-body space-y-6">
+        <section class="space-y-2">
+          <h3 class="text-lg font-semibold">🧑‍💼 Dados pessoais</h3>
+          <div class="flex items-center space-x-4">
+            <img id="fotoPreview" class="w-24 h-24 rounded-full object-cover" alt="Foto de perfil">
+            <input type="file" id="fotoPerfil" accept="image/*">
+          </div>
+          <input id="nomeCompleto" class="form-control" placeholder="Nome completo">
+          <input id="nomeExibicao" class="form-control" placeholder="Nome de exibição">
+          <input id="dataNascimento" type="date" class="form-control">
+          <select id="genero" class="form-control">
+            <option value="">Gênero</option>
+            <option value="masculino">Masculino</option>
+            <option value="feminino">Feminino</option>
+            <option value="outro">Outro</option>
+          </select>
+        </section>
+
+        <section class="space-y-2">
+          <h3 class="text-lg font-semibold">📞 Contato</h3>
+          <input id="email" type="email" class="form-control" placeholder="E-mail">
+          <input id="telefone" class="form-control" placeholder="Telefone / WhatsApp">
+          <input id="endRua" class="form-control" placeholder="Rua">
+          <input id="endNumero" class="form-control" placeholder="Número">
+          <input id="endBairro" class="form-control" placeholder="Bairro">
+          <input id="endCidade" class="form-control" placeholder="Cidade">
+          <input id="endEstado" class="form-control" placeholder="Estado">
+          <input id="endCEP" class="form-control" placeholder="CEP">
+          <input id="endPais" class="form-control" placeholder="País">
+        </section>
+
+        <section class="space-y-2">
+          <h3 class="text-lg font-semibold">🔑 Credenciais de acesso</h3>
+          <input id="login" class="form-control" placeholder="Usuário / Login">
+          <div class="flex items-center space-x-2">
+            <input type="password" id="senha" class="form-control" placeholder="Senha" disabled>
+            <button type="button" id="resetPasswordBtn" class="btn btn-secondary">Redefinir Senha</button>
+          </div>
+          <select id="perfilFuncao" class="form-control">
+            <option value="">Perfil / Função</option>
+            <option value="ADM">ADM</option>
+            <option value="Gestor">Gestor</option>
+            <option value="Editor">Editor</option>
+            <option value="Cliente">Cliente</option>
+          </select>
+        </section>
+
+        <section class="space-y-2">
+          <h3 class="text-lg font-semibold">🏢 Profissional / Negócio (se aplicável)</h3>
+          <input id="empresa" class="form-control" placeholder="Nome da empresa / loja">
+          <input id="documento" class="form-control" placeholder="CNPJ ou CPF">
+          <input id="cargo" class="form-control" placeholder="Cargo / função">
+          <input id="areaAtuacao" class="form-control" placeholder="Área de atuação">
+          <div id="lojasContainer" class="space-y-2"></div>
+          <button type="button" id="addStoreBtn" class="btn btn-secondary">Adicionar Loja</button>
+        </section>
+
+        <section class="space-y-2">
+          <h3 class="text-lg font-semibold">⚙️ Preferências</h3>
+          <select id="idioma" class="form-control">
+            <option value="pt">Português</option>
+            <option value="en">Inglês</option>
+          </select>
+          <div class="flex space-x-4">
+            <label class="flex items-center"><input id="notifEmail" type="checkbox" class="mr-2">E-mail</label>
+            <label class="flex items-center"><input id="notifWhats" type="checkbox" class="mr-2">WhatsApp</label>
+            <label class="flex items-center"><input id="notifPush" type="checkbox" class="mr-2">Push</label>
+          </div>
+          <select id="tema" class="form-control">
+            <option value="claro">Tema claro</option>
+            <option value="escuro">Tema escuro</option>
+          </select>
+          <input id="permissoes" class="form-control" placeholder="Permissões">
+        </section>
+
         <input id="plataformas" class="form-control" placeholder="Plataformas em que vende (ex: Shopee, Mercado Livre)">
         <textarea id="infoPessoal" class="form-control" placeholder="Informações pessoais"></textarea>
         <button type="submit" class="btn btn-primary">Salvar</button>

--- a/configuracao-perfil.js
+++ b/configuracao-perfil.js
@@ -1,11 +1,21 @@
 import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
 import { getFirestore, doc, getDoc, setDoc } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
-import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { getAuth, onAuthStateChanged, sendPasswordResetEmail } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 import { firebaseConfig } from './firebase-config.js';
 
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app);
+let fotoPerfilData = '';
+
+function readFileAsDataURL(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
 
 function addStoreRow(data = {}) {
   const container = document.getElementById('lojasContainer');
@@ -35,11 +45,53 @@ async function loadProfile(uid) {
     const snap = await getDoc(doc(db, 'perfil', uid));
     if (snap.exists()) {
       const data = snap.data();
+      fotoPerfilData = data.fotoPerfil || '';
+      if (fotoPerfilData) {
+        document.getElementById('fotoPreview').src = fotoPerfilData;
+      }
+      document.getElementById('nomeCompleto').value = data.nomeCompleto || '';
+      document.getElementById('nomeExibicao').value = data.nomeExibicao || '';
+      document.getElementById('dataNascimento').value = data.dataNascimento || '';
+      document.getElementById('genero').value = data.genero || '';
+
+      document.getElementById('email').value = data.email || auth.currentUser?.email || '';
+      document.getElementById('telefone').value = data.telefone || '';
+      const end = data.endereco || {};
+      document.getElementById('endRua').value = end.rua || '';
+      document.getElementById('endNumero').value = end.numero || '';
+      document.getElementById('endBairro').value = end.bairro || '';
+      document.getElementById('endCidade').value = end.cidade || '';
+      document.getElementById('endEstado').value = end.estado || '';
+      document.getElementById('endCEP').value = end.cep || '';
+      document.getElementById('endPais').value = end.pais || '';
+
+      document.getElementById('login').value = data.login || '';
+      document.getElementById('perfilFuncao').value = data.perfilFuncao || '';
+
+      document.getElementById('empresa').value = data.empresa || '';
+      document.getElementById('documento').value = data.documento || '';
+      document.getElementById('cargo').value = data.cargo || '';
+      document.getElementById('areaAtuacao').value = data.areaAtuacao || '';
+
       renderStores(data.lojas || []);
+
+      document.getElementById('idioma').value = data.idioma || 'pt';
+      const notif = data.notificacoes || {};
+      document.getElementById('notifEmail').checked = !!notif.email;
+      document.getElementById('notifWhats').checked = !!notif.whatsapp;
+      document.getElementById('notifPush').checked = !!notif.push;
+      document.getElementById('tema').value = data.tema || 'claro';
+      document.getElementById('permissoes').value = data.permissoes || '';
+
       document.getElementById('plataformas').value = data.plataformas || '';
       document.getElementById('infoPessoal').value = data.infoPessoal || '';
     } else {
       renderStores();
+      document.getElementById('idioma').value = 'pt';
+      document.getElementById('tema').value = 'claro';
+      if (auth.currentUser?.email) {
+        document.getElementById('email').value = auth.currentUser.email;
+      }
     }
   } catch (e) {
     console.error('Erro ao carregar perfil:', e);
@@ -54,8 +106,56 @@ async function saveProfile(uid) {
   })).filter(s => s.nome || s.link);
   const plataformas = document.getElementById('plataformas').value.trim();
   const infoPessoal = document.getElementById('infoPessoal').value.trim();
+
+  const fotoFile = document.getElementById('fotoPerfil').files[0];
+  let fotoPerfil = fotoPerfilData;
+  if (fotoFile) {
+    try {
+      fotoPerfil = await readFileAsDataURL(fotoFile);
+    } catch (err) {
+      console.error('Erro ao ler foto de perfil:', err);
+    }
+  }
+
+  const profileData = {
+    lojas: stores,
+    plataformas,
+    infoPessoal,
+    fotoPerfil,
+    nomeCompleto: document.getElementById('nomeCompleto').value.trim(),
+    nomeExibicao: document.getElementById('nomeExibicao').value.trim(),
+    dataNascimento: document.getElementById('dataNascimento').value,
+    genero: document.getElementById('genero').value,
+    email: document.getElementById('email').value.trim(),
+    telefone: document.getElementById('telefone').value.trim(),
+    endereco: {
+      rua: document.getElementById('endRua').value.trim(),
+      numero: document.getElementById('endNumero').value.trim(),
+      bairro: document.getElementById('endBairro').value.trim(),
+      cidade: document.getElementById('endCidade').value.trim(),
+      estado: document.getElementById('endEstado').value.trim(),
+      cep: document.getElementById('endCEP').value.trim(),
+      pais: document.getElementById('endPais').value.trim()
+    },
+    login: document.getElementById('login').value.trim(),
+    perfilFuncao: document.getElementById('perfilFuncao').value,
+    empresa: document.getElementById('empresa').value.trim(),
+    documento: document.getElementById('documento').value.trim(),
+    cargo: document.getElementById('cargo').value.trim(),
+    areaAtuacao: document.getElementById('areaAtuacao').value.trim(),
+    idioma: document.getElementById('idioma').value,
+    notificacoes: {
+      email: document.getElementById('notifEmail').checked,
+      whatsapp: document.getElementById('notifWhats').checked,
+      push: document.getElementById('notifPush').checked
+    },
+    tema: document.getElementById('tema').value,
+    permissoes: document.getElementById('permissoes').value.trim()
+  };
+
   try {
-    await setDoc(doc(db, 'perfil', uid), { lojas: stores, plataformas, infoPessoal }, { merge: true });
+    await setDoc(doc(db, 'perfil', uid), profileData, { merge: true });
+    fotoPerfilData = fotoPerfil;
     alert('Perfil salvo com sucesso!');
   } catch (e) {
     console.error('Erro ao salvar perfil:', e);
@@ -66,7 +166,21 @@ async function saveProfile(uid) {
 function initConfiguracaoPerfil() {
   const form = document.getElementById('profileForm');
   const addBtn = document.getElementById('addStoreBtn');
+  const resetBtn = document.getElementById('resetPasswordBtn');
   addBtn.addEventListener('click', () => addStoreRow());
+  resetBtn.addEventListener('click', async () => {
+    if (!auth.currentUser?.email) {
+      alert('E-mail não disponível para redefinição');
+      return;
+    }
+    try {
+      await sendPasswordResetEmail(auth, auth.currentUser.email);
+      alert('E-mail de redefinição enviado');
+    } catch (e) {
+      console.error('Erro ao enviar redefinição de senha:', e);
+      alert('Erro ao enviar redefinição de senha');
+    }
+  });
 
   onAuthStateChanged(auth, user => {
     if (!user) return;


### PR DESCRIPTION
## Summary
- add sections for personal, contact, access credentials, business, and preferences in profile configuration
- support profile photo upload and password reset
- persist new profile fields in Firestore

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac83089004832a9b108987165789c1