### PR TITLE
feat: add role selection to login modal

### DIFF
--- a/login.js
+++ b/login.js
@@ -112,7 +112,24 @@ window.openModal = (id) => {
   const el = document.getElementById(id);
   if (el) {
     el.style.display = 'block';
+    if (id === 'loginModal') {
+      document.getElementById('loginRoleSelection')?.classList.remove('hidden');
+      document.getElementById('loginForm')?.classList.add('hidden');
+      const subtitle = document.getElementById('loginModalSubtitle');
+      if (subtitle) subtitle.textContent = 'Selecione o tipo de acesso';
+    }
   }
+};
+
+window.selectUsuarioLogin = () => {
+  document.getElementById('loginRoleSelection')?.classList.add('hidden');
+  document.getElementById('loginForm')?.classList.remove('hidden');
+  const subtitle = document.getElementById('loginModalSubtitle');
+  if (subtitle) subtitle.textContent = 'Insira suas credenciais para acessar as ferramentas';
+};
+
+window.selectGestorLogin = () => {
+  window.location.href = 'login-gestor.html';
 };
 
 window.closeModal = (id) => {

--- a/partials/auth-modals.html
+++ b/partials/auth-modals.html
@@ -7,10 +7,18 @@
         <i class="fas fa-lock text-white text-3xl"></i>
       </div>
       <h3 class="text-2xl font-bold text-gray-800">Acesso ao Sistema</h3>
-      <p class="text-gray-600 mt-2">Insira suas credenciais para acessar as ferramentas</p>
+      <p id="loginModalSubtitle" class="text-gray-600 mt-2">Selecione o tipo de acesso</p>
+    </div>
+    <div id="loginRoleSelection" class="space-y-4">
+      <button onclick="selectUsuarioLogin()" class="btn-primary w-full py-3.5">
+        <i class="fas fa-user mr-2"></i> Usuário
+      </button>
+      <button onclick="selectGestorLogin()" class="w-full py-3.5 bg-gray-200 hover:bg-gray-300 text-gray-800 rounded-lg">
+        <i class="fas fa-user-tie mr-2"></i> Gestor
+      </button>
     </div>
 
-    <div class="space-y-6">
+    <div id="loginForm" class="space-y-6 hidden">
       <div>
         <label class="block text-sm font-medium mb-2 text-gray-700">E-mail</label>
         <div class="relative">
@@ -30,7 +38,7 @@
           <input type="password" id="loginPassword" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
         </div>
       </div>
-<div>
+      <div>
         <label class="block text-sm font-medium mb-2 text-gray-700">Senha de visualização</label>
         <div class="relative">
           <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">

--- a/public/login.js
+++ b/public/login.js
@@ -112,7 +112,24 @@ window.openModal = (id) => {
   const el = document.getElementById(id);
   if (el) {
     el.style.display = 'block';
+    if (id === 'loginModal') {
+      document.getElementById('loginRoleSelection')?.classList.remove('hidden');
+      document.getElementById('loginForm')?.classList.add('hidden');
+      const subtitle = document.getElementById('loginModalSubtitle');
+      if (subtitle) subtitle.textContent = 'Selecione o tipo de acesso';
+    }
   }
+};
+
+window.selectUsuarioLogin = () => {
+  document.getElementById('loginRoleSelection')?.classList.add('hidden');
+  document.getElementById('loginForm')?.classList.remove('hidden');
+  const subtitle = document.getElementById('loginModalSubtitle');
+  if (subtitle) subtitle.textContent = 'Insira suas credenciais para acessar as ferramentas';
+};
+
+window.selectGestorLogin = () => {
+  window.location.href = 'login-gestor.html';
 };
 
 window.closeModal = (id) => {


### PR DESCRIPTION
## Summary
- add initial role selection between usuário and gestor to login modal
- handle role selection in login scripts to toggle forms and redirect gestor login

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac805729b0832ab6bf864d5c386667