### PR TITLE
feat: add role selection step to login modal

### DIFF
--- a/login.js
+++ b/login.js
@@ -131,6 +131,11 @@ window.closeModal = (id) => {
   const el = document.getElementById(id);
   if (el) {
     el.style.display = 'none';
+    if (id === 'loginModal') {
+      document.getElementById('roleSelection')?.classList.remove('hidden');
+      document.getElementById('loginForm')?.classList.add('hidden');
+      selectedRole = null;
+    }
   }
 };
 

--- a/public/login.js
+++ b/public/login.js
@@ -131,6 +131,11 @@ window.closeModal = (id) => {
   const el = document.getElementById(id);
   if (el) {
     el.style.display = 'none';
+    if (id === 'loginModal') {
+      document.getElementById('roleSelection')?.classList.remove('hidden');
+      document.getElementById('loginForm')?.classList.add('hidden');
+      selectedRole = null;
+    }
   }
 };
 

--- a/public/partials/auth-modals.html
+++ b/public/partials/auth-modals.html
@@ -1,0 +1,137 @@
+<div id="loginModal" class="modal">
+  <div class="modal-content">
+    <span class="btn-close float-right text-gray-500 hover:text-gray-700 cursor-pointer text-2xl" onclick="closeModal('loginModal')">&times;</span>
+
+    <div class="text-center mb-6">
+      <div class="w-20 h-20 rounded-full bg-gradient-to-r from-orange-500 to-orange-600 flex items-center justify-center mx-auto mb-4">
+        <i class="fas fa-lock text-white text-3xl"></i>
+      </div>
+      <h3 class="text-2xl font-bold text-gray-800">Acesso ao Sistema</h3>
+      <p class="text-gray-600 mt-2">Insira suas credenciais para acessar as ferramentas</p>
+    </div>
+
+    <div id="roleSelection" class="space-y-6 text-center">
+      <p class="text-gray-600">Escolha o tipo de acesso</p>
+      <div class="flex justify-center space-x-4">
+        <button onclick="selectRole('usuario')" class="btn-primary px-4 py-2">Usuário</button>
+        <button onclick="selectRole('gestor')" class="btn-primary px-4 py-2">Gestor</button>
+      </div>
+    </div>
+
+    <div id="loginForm" class="space-y-6 hidden">
+      <div>
+        <label class="block text-sm font-medium mb-2 text-gray-700">E-mail</label>
+        <div class="relative">
+          <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <i class="fas fa-envelope text-gray-400"></i>
+          </div>
+          <input type="email" id="loginEmail" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="seu@email.com">
+        </div>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium mb-2 text-gray-700">Senha</label>
+        <div class="relative">
+          <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <i class="fas fa-lock text-gray-400"></i>
+          </div>
+          <input type="password" id="loginPassword" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
+        </div>
+      </div>
+      <div>
+        <label class="block text-sm font-medium mb-2 text-gray-700">Senha de visualização</label>
+        <div class="relative">
+          <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <i class="fas fa-eye text-gray-400"></i>
+          </div>
+          <input type="password" id="loginPassphrase" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
+        </div>
+      </div>
+      <button onclick="login()" class="btn-primary w-full py-3.5">
+        <i class="fas fa-sign-in-alt mr-2"></i> Entrar
+      </button>
+
+      <div class="text-center pt-4">
+        <a href="#recover" onclick="openRecoverModal()" class="text-sm text-orange-600 hover:text-orange-800 font-medium">
+          Esqueci minha senha
+        </a>
+        <div class="mt-2">
+          <a href="/VendedorPro/cadastro-interesse.html" class="text-sm text-blue-600 hover:text-blue-800 font-medium">Não é cliente? Cadastre-se</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="recoverModal" class="modal">
+  <div class="modal-content">
+    <span class="btn-close float-right text-gray-500 hover:text-gray-700 cursor-pointer text-2xl" onclick="closeModal('recoverModal')">&times;</span>
+
+    <div class="text-center mb-6">
+      <div class="w-20 h-20 rounded-full bg-gradient-to-r from-orange-500 to-orange-600 flex items-center justify-center mx-auto mb-4">
+        <i class="fas fa-key text-white text-3xl"></i>
+      </div>
+      <h3 class="text-2xl font-bold text-gray-800">Recuperar Senha</h3>
+      <p class="text-gray-600 mt-2">Insira seu e-mail para receber as instruções de recuperação</p>
+    </div>
+
+    <div class="space-y-6">
+      <div>
+        <label class="block text-sm font-medium mb-2 text-gray-700">E-mail cadastrado</label>
+        <div class="relative">
+          <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <i class="fas fa-envelope text-gray-400"></i>
+          </div>
+          <input type="email" id="recoverEmail" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="seu@email.com">
+        </div>
+      </div>
+
+      <button onclick="sendRecovery()" class="btn-primary w-full py-3.5">
+        <i class="fas fa-paper-plane mr-2"></i> Enviar Link de Recuperação
+      </button>
+    </div>
+  </div>
+</div>
+<div id="passphraseModal" class="modal">
+  <div class="modal-content">
+    <span class="btn-close float-right text-gray-500 hover:text-gray-700 cursor-pointer text-2xl" onclick="closeModal('passphraseModal')">&times;</span>
+
+    <div class="text-center mb-6">
+      <div class="w-20 h-20 rounded-full bg-gradient-to-r from-orange-500 to-orange-600 flex items-center justify-center mx-auto mb-4">
+        <i class="fas fa-key text-white text-3xl"></i>
+      </div>
+      <h3 class="text-2xl font-bold text-gray-800">Senha de Visualização</h3>
+      <p class="text-gray-600 mt-2">Digite a senha para acessar dados criptografados</p>
+    </div>
+
+    <div class="space-y-6">
+      <input type="password" id="passphraseInput" class="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
+      <button onclick="savePassphrase()" class="btn-primary w-full py-3.5">
+        <i class="fas fa-check mr-2"></i> Confirmar
+      </button>
+    </div>
+  </div>
+</div>
+
+<div id="displayNameModal" class="modal">
+  <div class="modal-content">
+    <span class="btn-close float-right text-gray-500 hover:text-gray-700 cursor-pointer text-2xl" onclick="closeModal('displayNameModal')">&times;</span>
+
+    <div class="text-center mb-6">
+      <div class="w-20 h-20 rounded-full bg-gradient-to-r from-orange-500 to-orange-600 flex items-center justify-center mx-auto mb-4">
+        <i class="fas fa-user text-white text-3xl"></i>
+      </div>
+      <h3 class="text-2xl font-bold text-gray-800">Nome de Identificação</h3>
+      <p class="text-gray-600 mt-2">Escolha como seu nome será exibido</p>
+    </div>
+
+    <div class="space-y-6">
+      <input type="text" id="displayNameInput" class="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="Seu nome">
+      <button onclick="saveDisplayName()" class="btn-primary w-full py-3.5">
+        <i class="fas fa-check mr-2"></i> Salvar
+      </button>
+    </div>
+  </div>
+</div>
+
+<div id="toastContainer" class="fixed bottom-5 right-5 z-50 space-y-2"></div>


### PR DESCRIPTION
## Summary
- add profile selection step to login modal with "Usuário" and "Gestor" options
- reset login modal to profile selection when closed
- include auth modals partial under `public` for deployments

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68ac84770334832a82bafc89538368cc