### PR TITLE
Redirect gestor login to finance

### DIFF
--- a/login.js
+++ b/login.js
@@ -229,6 +229,14 @@ async function showUserArea(user) {
     const perfil = snap.exists() ? String(snap.data().perfil || '').toLowerCase() : '';
     window.userPerfil = perfil;
 
+    if (perfil === 'gestor') {
+      const path = window.location.pathname.toLowerCase();
+      if (!path.endsWith('/financeiro.html')) {
+        window.location.href = 'financeiro.html';
+        return;
+      }
+    }
+
     // 1) aplica restrições de UI
     applyPerfilRestrictions(perfil);
 

--- a/public/login.js
+++ b/public/login.js
@@ -229,6 +229,14 @@ async function showUserArea(user) {
     const perfil = snap.exists() ? String(snap.data().perfil || '').toLowerCase() : '';
     window.userPerfil = perfil;
 
+    if (perfil === 'gestor') {
+      const path = window.location.pathname.toLowerCase();
+      if (!path.endsWith('/financeiro.html')) {
+        window.location.href = 'financeiro.html';
+        return;
+      }
+    }
+
     // 1) aplica restrições de UI
     applyPerfilRestrictions(perfil);
 


### PR DESCRIPTION
## Summary
- redirect users with gestor profile to financeiro page after login

## Testing
- `node --check login.js`
- `node --check public/login.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac881aa464832a837f7e2b9c963d47