### PR TITLE
fix: persistent sidebar after login

### DIFF
--- a/login.js
+++ b/login.js
@@ -376,6 +376,7 @@ function checkLogin() {
       showUserArea(user);
       initNotificationListener(user.uid);
       wasLoggedIn = true;
+      if (window.ensureLayout) window.ensureLayout();
     } else {
       if (wasLoggedIn && explicitLogout) {
         clearPassphrase();
@@ -385,6 +386,7 @@ function checkLogin() {
       wasLoggedIn = false;
       hideUserArea();
       if (notifUnsub) { notifUnsub(); notifUnsub = null; }
+      if (window.ensureLayout) window.ensureLayout();
 
       // Sempre exibe o modal se estiver no index.html
       const path = window.location.pathname.toLowerCase();

--- a/service-worker.js
+++ b/service-worker.js
@@ -15,6 +15,11 @@ self.addEventListener('install', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+  if (url.pathname.includes('/partials/') && url.pathname.endsWith('.html')) {
+    event.respondWith(fetch(event.request));
+    return;
+  }
   event.respondWith(
     caches.match(event.request).then((response) => response || fetch(event.request))
   );


### PR DESCRIPTION
## Summary
- ensure sidebar/navbar partials are reloaded and kept after auth or navigation
- reinject layout after login events
- bypass service worker cache for HTML partials

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac90df7074832aac0f83e45cb9bc1b