### PR TITLE
feat: redirect gestor to finance

### DIFF
--- a/login.js
+++ b/login.js
@@ -158,6 +158,7 @@ window.login = () => {
       showUserArea(cred.user);
       closeModal('loginModal');
       document.getElementById('loginPassphrase').value = '';
+      sessionStorage.setItem('selectedRole', selectedRole || 'usuario');
       if (selectedRole === 'gestor') {
         window.location.href = 'financeiro.html';
       }

--- a/public/login.js
+++ b/public/login.js
@@ -158,6 +158,7 @@ window.login = () => {
       showUserArea(cred.user);
       closeModal('loginModal');
       document.getElementById('loginPassphrase').value = '';
+      sessionStorage.setItem('selectedRole', selectedRole || 'usuario');
       if (selectedRole === 'gestor') {
         window.location.href = 'financeiro.html';
       }


### PR DESCRIPTION
## Summary
- persist selected login role and redirect gestores to financeiro after login

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac912eb578832ab02e474595e9d666