### PR TITLE
feat: add hotline autofill extension

### DIFF
--- a/shopee-hotline-autofill-extension/content.js
+++ b/shopee-hotline-autofill-extension/content.js
@@ -1,0 +1,152 @@
+const norm = s => (s || "")
+  .toString()
+  .toLowerCase()
+  .normalize("NFD")
+  .replace(/\p{Diacritic}/gu, "")
+  .trim();
+
+const LABELS = {
+  linkLoja: ["link da sua loja", "link da loja"],
+  outrasLojas: ["voce tem outras lojas no mesmo endereco de coleta", "outras lojas"],
+  contatoTel: ["gostaria de receber nosso contato por telefone", "contato por telefone"],
+  telefone: ["melhor numero de telefone para retornarmos o contato", "telefone"],
+  responsavel: ["nome do responsavel para contato", "responsavel"],
+  modeloLogistico: ["em qual modelo logistico voce esta enfrentando dificuldades", "modelo logistico"],
+  descricao: ["descricao do problema", "descricao"]
+};
+
+function byText(el) {
+  return norm(
+    el?.textContent ||
+    el?.innerText ||
+    el?.getAttribute?.("aria-label") ||
+    el?.placeholder ||
+    ""
+  );
+}
+
+function $all(sel) { return Array.from(document.querySelectorAll(sel)); }
+
+function collectFields() {
+  const inputs = $all("input, textarea, select");
+  const labels = $all("label");
+  const labelFor = new Map();
+
+  for (const lb of labels) {
+    const t = byText(lb);
+    const id = lb.getAttribute("for");
+    if (id) labelFor.set(id, t);
+  }
+
+  const items = inputs.map(el => {
+    let guess = "";
+    const id = el.getAttribute("id");
+    if (id && labelFor.has(id)) guess = labelFor.get(id);
+    else {
+      const near = el.closest("label") || el.parentElement?.querySelector?.("label");
+      if (near) guess = byText(near);
+    }
+    if (!guess) guess = byText(el);
+    return { el, label: guess, labelNorm: norm(guess), tag: el.tagName.toLowerCase(), type: (el.type || "").toLowerCase() };
+  });
+
+  return items;
+}
+
+function pickField(fields, aliases) {
+  const set = new Set(aliases.map(norm));
+  return fields.find(f => set.has(f.labelNorm)) ||
+         fields.find(f => [...set].some(a => f.labelNorm.includes(a)));
+}
+
+function selectByVisibleText(selectEl, text) {
+  const wanted = norm(text);
+  const opt = Array.from(selectEl.options).find(o => norm(o.textContent).includes(wanted));
+  if (opt) { selectEl.value = opt.value; selectEl.dispatchEvent(new Event("change", { bubbles: true })); return true; }
+  return false;
+}
+
+function fill(el, value) {
+  if (!el) return false;
+  const tag = el.tagName.toLowerCase();
+  if (tag === "select") return selectByVisibleText(el, value);
+  el.focus();
+  el.value = value;
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+  el.dispatchEvent(new Event("change", { bubbles: true }));
+  el.blur();
+  return true;
+}
+
+function clickSubmit() {
+  const buttons = $all('button, [role="button"], input[type="submit"]');
+  const btn = buttons.find(b => /(enviar|submit)/.test(byText(b)));
+  if (btn) { btn.scrollIntoView({behavior:"smooth", block:"center"}); btn.click(); return true; }
+  return false;
+}
+
+async function autofillHotline(data) {
+  const fields = collectFields();
+
+  const map = {
+    linkLoja: pickField(fields, LABELS.linkLoja),
+    outrasLojas: pickField(fields, LABELS.outrasLojas),
+    contatoTel: pickField(fields, LABELS.contatoTel),
+    telefone: pickField(fields, LABELS.telefone),
+    responsavel: pickField(fields, LABELS.responsavel),
+    modeloLogistico: pickField(fields, LABELS.modeloLogistico),
+    descricao: pickField(fields, LABELS.descricao)
+  };
+
+  // 1) Link da loja
+  if (data.linkLoja) fill(map.linkLoja?.el, data.linkLoja);
+
+  // 2) Outras lojas? (select)
+  if (map.outrasLojas?.el) selectByVisibleText(map.outrasLojas.el, data.temOutrasLojasMesmoEndereco ? "Sim" : "Não");
+
+  // 3) Contato por telefone? (select)
+  if (map.contatoTel?.el) selectByVisibleText(map.contatoTel.el, data.aceitaContatoPorTelefone ? "Sim" : "Não");
+
+  // 4) Telefone (DDI + número)
+  //   - Muitas páginas usam 2 campos. Tente achar um select/combobox próximo ao campo de telefone.
+  if (map.telefone?.el) {
+    // tenta achar sibling select para DDI
+    const container = map.telefone.el.closest("div") || document;
+    const ddiSelect = container.querySelector("select");
+    if (ddiSelect && data.ddi) selectByVisibleText(ddiSelect, data.ddi);
+    fill(map.telefone.el, data.telefone);
+  }
+
+  // 5) Responsável
+  if (data.nomeResponsavel) fill(map.responsavel?.el, data.nomeResponsavel);
+
+  // 6) Modelo logístico (select por texto)
+  if (map.modeloLogistico?.el && data.modeloLogistico) {
+    if (!selectByVisibleText(map.modeloLogistico.el, data.modeloLogistico)) {
+      // fallback: tenta digitar (caso seja combobox custom)
+      fill(map.modeloLogistico.el, data.modeloLogistico);
+    }
+  }
+
+  // 7) Descrição
+  if (data.descricao) fill(map.descricao?.el, data.descricao);
+
+  // 8) enviar?
+  if (data.submit) clickSubmit();
+}
+
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (msg?.type === "SHOPEE_HOTLINE_AUTOFILL") {
+    autofillHotline(msg.payload)
+      .then(() => sendResponse({ ok: true }))
+      .catch(e => sendResponse({ ok: false, error: String(e) }));
+    return true; // async
+  }
+});
+
+// debug no console:
+window._hotlineDebug = () => {
+  const f = collectFields();
+  console.table(f.map(x => ({label:x.label, tag:x.tag, type:x.type})));
+  return f;
+};

--- a/shopee-hotline-autofill-extension/manifest.json
+++ b/shopee-hotline-autofill-extension/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 3,
+  "name": "Shopee Hotline Autofill",
+  "version": "1.0.0",
+  "description": "Preenche o webform de Hotline Logística da Shopee com dados do Firebase.",
+  "permissions": ["activeTab", "scripting", "storage"],
+  "host_permissions": ["https://help.shopee.com.br/portal/webform/*"],
+  "action": { "default_popup": "popup.html" },
+  "content_scripts": [
+    {
+      "matches": ["https://help.shopee.com.br/portal/webform/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/shopee-hotline-autofill-extension/popup.html
+++ b/shopee-hotline-autofill-extension/popup.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Hotline Autofill</title>
+  <style>
+    body { font: 14px system-ui, -apple-system, Segoe UI, Roboto, Arial; padding: 12px; width: 360px }
+    label { display:block; margin-top:8px; font-weight:600 }
+    input, textarea, select { width:100%; padding:8px; box-sizing:border-box }
+    textarea { min-height: 90px }
+    .row { display:grid; grid-template-columns: 1fr 1fr; gap:8px }
+    button { margin-top:10px; width:100%; padding:10px; font-weight:700; cursor:pointer }
+    small { color:#666 }
+    .muted { color:#666; font-weight:400 }
+  </style>
+</head>
+<body>
+  <h3>Hotline Autofill</h3>
+
+  <!-- Login simples -->
+  <div id="loginBox">
+    <label>Email (Firebase) <input id="authEmail" type="email" /></label>
+    <label>Senha <input id="authPass" type="password" /></label>
+    <button id="doLogin">Entrar</button>
+  </div>
+
+  <div id="app" style="display:none">
+    <label>Loja
+      <select id="loja"></select>
+    </label>
+
+    <label>Link da loja <input id="linkLoja" /></label>
+    <div class="row">
+      <label>Outras lojas no mesmo endereço?
+        <select id="outrasLojas"><option>Sim</option><option selected>Não</option></select>
+      </label>
+      <label>Contato por telefone?
+        <select id="contatoTel"><option selected>Sim</option><option>Não</option></select>
+      </label>
+    </div>
+
+    <div class="row">
+      <label>DDI <input id="ddi" placeholder="+55" /></label>
+      <label>Telefone <input id="telefone" placeholder="11999998888" /></label>
+    </div>
+
+    <label>Responsável <input id="responsavel" /></label>
+    <label>Modelo logístico
+      <input id="modeloLogistico" placeholder="Shopee Xpress / Correios / ..." />
+    </label>
+    <label>Descrição <textarea id="descricao"></textarea></label>
+
+    <label class="muted"><input type="checkbox" id="autoSend" /> Enviar automaticamente após preencher</label>
+
+    <div class="row">
+      <button id="preencher">Preencher</button>
+      <button id="preencherEnviar">Preencher + Enviar</button>
+    </div>
+    <small>Abra o formulário antes de clicar.</small>
+  </div>
+
+  <!-- Firebase (CDN compat) -->
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/shopee-hotline-autofill-extension/popup.js
+++ b/shopee-hotline-autofill-extension/popup.js
@@ -1,0 +1,102 @@
+// --- Firebase init ---
+const firebaseConfig = {
+  apiKey: "AIzaSyC78l9b2DTNj64y_0fbRKofNupO6NHDmeo",
+  authDomain: "matheus-35023.firebaseapp.com",
+  projectId: "matheus-35023",
+};
+firebase.initializeApp(firebaseConfig);
+
+const auth = firebase.auth();
+const db = firebase.firestore();
+
+const els = {
+  loginBox: document.getElementById("loginBox"),
+  app: document.getElementById("app"),
+  authEmail: document.getElementById("authEmail"),
+  authPass: document.getElementById("authPass"),
+  doLogin: document.getElementById("doLogin"),
+
+  loja: document.getElementById("loja"),
+  linkLoja: document.getElementById("linkLoja"),
+  outrasLojas: document.getElementById("outrasLojas"),
+  contatoTel: document.getElementById("contatoTel"),
+  ddi: document.getElementById("ddi"),
+  telefone: document.getElementById("telefone"),
+  responsavel: document.getElementById("responsavel"),
+  modeloLogistico: document.getElementById("modeloLogistico"),
+  descricao: document.getElementById("descricao"),
+  autoSend: document.getElementById("autoSend"),
+
+  preencher: document.getElementById("preencher"),
+  preencherEnviar: document.getElementById("preencherEnviar"),
+};
+
+function ui(authenticated) {
+  els.loginBox.style.display = authenticated ? "none" : "";
+  els.app.style.display = authenticated ? "" : "none";
+}
+
+els.doLogin.onclick = async () => {
+  await auth.signInWithEmailAndPassword(els.authEmail.value, els.authPass.value);
+};
+
+auth.onAuthStateChanged(async (user) => {
+  ui(!!user);
+  if (!user) return;
+
+  // carrega lojas
+  const snap = await db.collection("usuarios").doc(user.uid).collection("lojas").get();
+  els.loja.innerHTML = "";
+  snap.forEach(doc => {
+    const opt = document.createElement("option");
+    opt.value = doc.id;
+    opt.textContent = doc.data().linkLoja || doc.id;
+    els.loja.appendChild(opt);
+  });
+
+  if (els.loja.options.length) {
+    await loadLoja(els.loja.value);
+  }
+
+  els.loja.onchange = () => loadLoja(els.loja.value);
+});
+
+async function loadLoja(id) {
+  const user = auth.currentUser;
+  const doc = await db.collection("usuarios").doc(user.uid).collection("lojas").doc(id).get();
+  const d = doc.data() || {};
+
+  els.linkLoja.value = d.linkLoja || "";
+  els.outrasLojas.value = d.temOutrasLojasMesmoEndereco ? "Sim" : "Não";
+  els.contatoTel.value = d.aceitaContatoPorTelefone ? "Sim" : "Não";
+  els.ddi.value = d.ddi || "+55";
+  els.telefone.value = d.telefone || "";
+  els.responsavel.value = d.nomeResponsavel || "";
+  els.modeloLogistico.value = d.modeloLogistico || "";
+  els.descricao.value = d.descricaoProblemaPadrao || "";
+}
+
+function currentPayload() {
+  return {
+    linkLoja: els.linkLoja.value.trim(),
+    temOutrasLojasMesmoEndereco: els.outrasLojas.value === "Sim",
+    aceitaContatoPorTelefone: els.contatoTel.value === "Sim",
+    ddi: els.ddi.value.trim() || "+55",
+    telefone: els.telefone.value.replace(/\D+/g, ""),
+    nomeResponsavel: els.responsavel.value.trim(),
+    modeloLogistico: els.modeloLogistico.value.trim(),
+    descricao: els.descricao.value.trim(),
+    autoSend: els.autoSend.checked
+  };
+}
+
+async function sendToContent(payload, alsoSend) {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  await chrome.tabs.sendMessage(tab.id, {
+    type: "SHOPEE_HOTLINE_AUTOFILL",
+    payload: { ...payload, submit: !!alsoSend }
+  });
+}
+
+els.preencher.onclick = () => sendToContent(currentPayload(), false);
+els.preencherEnviar.onclick = () => sendToContent(currentPayload(), true);


### PR DESCRIPTION
## Summary
- add Chrome extension that auto-fills Shopee Hotline Logistics form using Firebase data
- include popup UI with Firebase login, store selection, and send options
- implement content script to map labels, fill fields, and optionally submit the form

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac91af01f0832aaa73d0dd1fa27187