### PR TITLE
Refine sidebar handling and profile menus

### DIFF
--- a/email-expedicao.html
+++ b/email-expedicao.html
@@ -152,8 +152,6 @@
       }
     });
 
-    loadSidebar();
-    loadNavbar();
   </script>
   <script src="shared.js"></script>
 </body>

--- a/expedicao-historico.html
+++ b/expedicao-historico.html
@@ -77,8 +77,6 @@
       }
     }
 
-    loadSidebar();
-    loadNavbar();
   </script>
   <script type="module" src="login.js"></script>
   <script src="shared.js"></script>

--- a/expedicao.html
+++ b/expedicao.html
@@ -771,8 +771,6 @@
       setTimeout(() => toast.remove(), 2500);
     }
 
-    loadSidebar();
-    loadNavbar();
   </script>
   <script type="module" src="login.js"></script>
   <script src="shared.js"></script>

--- a/login.js
+++ b/login.js
@@ -239,7 +239,7 @@ async function showUserArea(user) {
     }
 
     // 1) aplica restrições de UI
-    applyPerfilRestrictions(perfil);
+    aplicarPerfil(perfil);
 
     // 2) se for expedição, executa fluxo especial
     if (perfil === 'expedicao') {
@@ -286,15 +286,12 @@ function restoreSidebar() {
     link.classList.remove('hidden');
   });
 }
-function applyPerfilRestrictions(perfil) {
-  const currentPerfil = (perfil || '').toLowerCase().trim();
-  if (!currentPerfil) return;
-  document.querySelectorAll('[data-perfil]').forEach(el => {
-    const allowed = (el.getAttribute('data-perfil') || '')
-      .toLowerCase()
+function aplicarPerfil(perfil) {
+  document.querySelectorAll('#sidebar [data-perfil]').forEach(el => {
+    const perfis = (el.getAttribute('data-perfil') || '')
       .split(',')
-      .map(p => p.trim());
-    if (!allowed.includes(currentPerfil)) {
+      .map(s => s.trim());
+    if (!perfis.includes(perfil)) {
       el.classList.add('hidden');
     } else {
       el.classList.remove('hidden');
@@ -456,5 +453,5 @@ function checkLogin() {
   });
 
 document.addEventListener('sidebarLoaded', () => {
-  if (window.userPerfil) applyPerfilRestrictions(window.userPerfil);
+  if (window.userPerfil) aplicarPerfil(window.userPerfil);
 });

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -9,25 +9,6 @@
       </div>
       
       <div class="flex items-center space-x-5">
-        <!-- Atalhos de navegação -->
-        <a href="atualizacoes.html" class="btn btn-primary">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M18.375 12.739 10.682 20.432a5.25 5.25 0 0 1-7.424-7.424L15.257 3.129a3 3 0 0 1 4.243 4.243L8.552 18.32m.009-.009a1.5 1.5 0 0 1-2.121 0 1.5 1.5 0 0 1 0-2.122L14.25 8.379"/>
-          </svg>
-          Atualizações
-        </a>
-        <a href="expedicao.html" class="btn btn-primary">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Zm0 0H14.25m-9 0H3.375A1.125 1.125 0 0 1 2.25 17.625V14.25M19.5 18.75a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Zm0 0l1.125-.001c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 0 0-3.214-9.193 2.056 2.056 0 0 0-1.58-.86H14.25M16.5 18.75H14.25M14.25 7.573v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 0 0-10.026 0 1.106 1.106 0 0 0-.987 1.106v7.635M14.25 7.573v6.677m0 4.5v-4.5m0 0h-12"/>
-          </svg>
-          Expedição
-        </a>
-        <a href="zpl-import.html" class="btn btn-primary">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.875c0-.621.504-1.125 1.125-1.125h4.5A1.125 1.125 0 0 1 10.5 4.875v4.5A1.125 1.125 0 0 1 9.375 10.5h-4.5A1.125 1.125 0 0 1 3.75 9.375v-4.5ZM3.75 14.625c0-.621.504-1.125 1.125-1.125h4.5a1.125 1.125 0 0 1 1.125 1.125v4.5a1.125 1.125 0 0 1-1.125 1.125h-4.5A1.125 1.125 0 0 1 3.75 19.125v-4.5ZM13.5 4.875c0-.621.504-1.125 1.125-1.125h4.5A1.125 1.125 0 0 1 20.25 4.875v4.5a1.125 1.125 0 0 1-1.125 1.125h-4.5A1.125 1.125 0 0 1 13.5 9.375v-4.5ZM6.75 6.75h.75v.75h-.75v-.75ZM6.75 16.5h.75v.75h-.75v-.75ZM16.5 6.75h.75v.75h-.75v-.75ZM13.5 13.5h.75v.75h-.75v-.75ZM13.5 19.5h.75v.75h-.75v-.75ZM19.5 13.5h.75v.75h-.75v-.75ZM19.5 19.5h.75v.75h-.75v-.75ZM16.5 16.5h.75v.75h-.75v-.75Z"/>
-          </svg>
-          Etiquetas ZPL
-        </a>
 
         <!-- Botão de login -->
         <a href="cadastro-interesse.html" class="btn btn-primary">

--- a/public/login.js
+++ b/public/login.js
@@ -239,7 +239,7 @@ async function showUserArea(user) {
     }
 
     // 1) aplica restrições de UI
-    applyPerfilRestrictions(perfil);
+    aplicarPerfil(perfil);
 
     // 2) se for expedição, executa fluxo especial
     if (perfil === 'expedicao') {
@@ -286,14 +286,12 @@ function restoreSidebar() {
     link.parentElement.classList.remove('hidden');
   });
 }
-function applyPerfilRestrictions(perfil) {
-  const currentPerfil = (perfil || '').toLowerCase();
-  document.querySelectorAll('[data-perfil]').forEach(el => {
-    const allowed = (el.getAttribute('data-perfil') || '')
-      .toLowerCase()
+function aplicarPerfil(perfil) {
+  document.querySelectorAll('#sidebar [data-perfil]').forEach(el => {
+    const perfis = (el.getAttribute('data-perfil') || '')
       .split(',')
-      .map(p => p.trim());
-    if (!allowed.includes(currentPerfil)) {
+      .map(s => s.trim());
+    if (!perfis.includes(perfil)) {
       el.classList.add('hidden');
     } else {
       el.classList.remove('hidden');
@@ -453,5 +451,5 @@ function checkLogin() {
   });
 
 document.addEventListener('sidebarLoaded', () => {
-  if (window.userPerfil) applyPerfilRestrictions(window.userPerfil);
+  if (window.userPerfil) aplicarPerfil(window.userPerfil);
 });

--- a/public/shared.js
+++ b/public/shared.js
@@ -36,17 +36,12 @@
     });
   }
   
-  // Toggle submenu visibility with smooth slide animation
-  window.toggleMenu = function(menuId) {
-    var el = document.getElementById(menuId);
+  // Toggle submenu visibility using max-height for smooth animation
+  window.toggleMenu = function(id) {
+    var el = document.getElementById(id);
     if (!el) return;
-    if (el.classList.contains('max-h-0')) {
-      el.classList.remove('max-h-0');
-      el.classList.add('max-h-screen');
-    } else {
-      el.classList.add('max-h-0');
-      el.classList.remove('max-h-screen');
-    }
+    var isOpen = el.style.maxHeight && el.style.maxHeight !== '0px';
+    el.style.maxHeight = isOpen ? '0px' : el.scrollHeight + 'px';
   };
   
   // Toggle visibility of the Importar Produtos card on the precificação page
@@ -239,6 +234,9 @@ document.addEventListener('navbarLoaded', function () {
 });
 
 document.addEventListener('sidebarLoaded', function () {
+  document.querySelectorAll('#sidebar div[id^="menu"]').forEach(function(el){
+    el.style.maxHeight = '0px';
+  });
   loadIntroJs().then(function () {
     var btn = document.getElementById('startSidebarTourBtn');
     if (btn) {

--- a/shared.js
+++ b/shared.js
@@ -36,17 +36,12 @@
     });
   }
   
-  // Toggle submenu visibility with smooth slide animation
-  window.toggleMenu = function(menuId) {
-    var el = document.getElementById(menuId);
+  // Toggle submenu visibility using max-height for smooth animation
+  window.toggleMenu = function(id) {
+    var el = document.getElementById(id);
     if (!el) return;
-    if (el.classList.contains('max-h-0')) {
-      el.classList.remove('max-h-0');
-      el.classList.add('max-h-screen');
-    } else {
-      el.classList.add('max-h-0');
-      el.classList.remove('max-h-screen');
-    }
+    var isOpen = el.style.maxHeight && el.style.maxHeight !== '0px';
+    el.style.maxHeight = isOpen ? '0px' : el.scrollHeight + 'px';
   };
 
   // Toggle visibility of the Importar Produtos card on the precificação page
@@ -253,6 +248,9 @@ document.addEventListener('navbarLoaded', function () {
 
 document.addEventListener('sidebarLoaded', function () {
   document.body.classList.add('has-sidebar');
+  document.querySelectorAll('#sidebar div[id^="menu"]').forEach(function(el){
+    el.style.maxHeight = '0px';
+  });
   loadIntroJs().then(function () {
     var btn = document.getElementById('startSidebarTourBtn');
     if (btn) {


### PR DESCRIPTION
## Summary
- use scrollHeight-based submenu toggles and reset collapsed state on sidebar load
- hide sidebar links by user profile via `aplicarPerfil`
- remove redundant navbar links and extra sidebar/nav loaders

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac994a5b38832a8ad714473c152d17