### PR TITLE
Refactor sidebar loading and navigation handling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2128,3 +2128,8 @@ body.dark .submenu a:hover {
   background-color: rgba(234, 88, 12, 0.2);
   color: #f3f4f6;
 }
+
+@media (min-width:1024px){
+  .main-content { margin-left: 16rem; }
+}
+

--- a/gestor.html
+++ b/gestor.html
@@ -60,73 +60,7 @@
 
   <script>window.CUSTOM_SIDEBAR_PATH='partials/sidebar.html';
         window.CUSTOM_NAVBAR_PATH='partials/navbar.html';</script>
-  <script>
-  // Fallback visual mínimo: garante que o container exista e tenha largura inicial
-  (function ensureSidebarBaseStyles() {
-    const style = document.createElement('style');
-    style.textContent = `
-      #sidebar-container{position:fixed;left:0;top:0;bottom:0;width:260px;max-width:80vw;overflow:auto;background:#6b46c1; /* roxo base */
-        transform:translateX(0); transition:transform .2s ease;}
-      #sidebar-container.hidden{transform:translateX(-105%);}
-      .main-content{margin-left:260px;} /* empurra o conteúdo */
-      @media (max-width:1024px){
-        .main-content{margin-left:0;}
-        #sidebar-container.hidden{transform:translateX(-105%);}
-      }
-      .mobile-menu-btn{position:fixed;left:12px;top:12px;z-index:50;background:#fff;border-radius:8px;padding:6px 10px}
-    `;
-    document.head.appendChild(style);
-    window.toggleSidebar = window.toggleSidebar || function(){
-      document.getElementById('sidebar-container')?.classList.toggle('hidden');
-    };
-  })();
-
-  (function () {
-    const SIDEBAR = window.CUSTOM_SIDEBAR_PATH || 'partials/sidebar.html';
-    const NAVBAR  = window.CUSTOM_NAVBAR_PATH  || 'partials/navbar.html';
-
-    async function loadPartial(selector, path){
-      const host = `${location.origin}${location.pathname.replace(/[^/]+$/, '')}`;
-      const url  = new URL(path, host).toString();
-      const el   = document.querySelector(selector);
-      if(!el) return;
-
-      try{
-        const res = await fetch(url, {cache:'no-cache'});
-        if(!res.ok) throw new Error(`HTTP ${res.status} em ${url}`);
-        const html = await res.text();
-
-        // injeta o HTML
-        el.innerHTML = html;
-
-        // reexecuta <script> contidos no parcial
-        el.querySelectorAll('script').forEach(old=>{
-          const s = document.createElement('script');
-          if (old.src) { s.src = new URL(old.getAttribute('src'), url).toString(); }
-          s.type = old.type || 'text/javascript';
-          s.defer = old.defer || false;
-          s.text = old.src ? '' : (old.textContent || '');
-          old.replaceWith(s);
-        });
-
-        // Se quiser escondido no mobile por padrão:
-        if (selector === '#sidebar-container' && matchMedia('(max-width:1024px)').matches) {
-          el.classList.add('hidden');
-        }
-
-      }catch(err){
-        console.error('[partials] falha', path, err);
-        el.innerHTML = `<div class="p-3 bg-red-50 text-red-700 text-sm rounded">
-          Erro ao carregar <code>${path}</code>. Veja o console para detalhes.</div>`;
-      }
-    }
-
-    document.addEventListener('DOMContentLoaded', ()=>{
-      loadPartial('#sidebar-container', SIDEBAR);
-      loadPartial('#navbar-container', NAVBAR);
-    });
-  })();
-  </script>
+  
   <script src="shared.js"></script>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="gestor.js"></script>

--- a/mentoria.html
+++ b/mentoria.html
@@ -76,51 +76,6 @@
     window.CUSTOM_NAVBAR_PATH  = 'partials/navbar.html';
   </script>
 
-  <!-- Loader único dos parciais (execução de <script> internos e offcanvas no mobile) -->
-  <script>
-    function toggleSidebar(){
-      const sb = document.getElementById('sidebar-container');
-      const isOpen = !sb.classList.contains('-translate-x-full');
-      if(isOpen) sb.classList.add('-translate-x-full'); else sb.classList.remove('-translate-x-full');
-    }
-
-    async function loadPartial(selector, path){
-      const base = `${location.origin}${location.pathname.replace(/[^/]+$/, '')}`;
-      const url  = new URL(path, base).toString();
-      const el   = document.querySelector(selector);
-      if(!el) return;
-
-      // evita dupla injeção se outro script já preencheu (ex.: shared.js)
-      if (el.childElementCount > 0 || (el.textContent||'').trim().length > 0) return;
-
-      try{
-        const res = await fetch(url, { cache:'no-cache' });
-        if(!res.ok) throw new Error(`HTTP ${res.status} em ${url}`);
-        const html = await res.text();
-        el.innerHTML = html;
-
-        // reexecuta <script> do parcial
-        el.querySelectorAll('script').forEach(old=>{
-          const s=document.createElement('script');
-          if(old.src){ s.src=new URL(old.getAttribute('src'), url).toString(); }
-          s.type=old.type||'text/javascript';
-          s.defer=old.defer||false;
-          s.text=old.src?'':(old.textContent||'');
-          old.replaceWith(s);
-        });
-      }catch(err){
-        console.error('[partials] falha', path, err);
-        el.innerHTML = `<div class="p-3 bg-red-50 text-red-700 text-sm rounded">Erro ao carregar <code>${path}</code>.</div>`;
-      }
-    }
-
-    document.addEventListener('DOMContentLoaded', ()=>{
-      loadPartial('#sidebar-container', window.CUSTOM_SIDEBAR_PATH);
-      loadPartial('#navbar-container',  window.CUSTOM_NAVBAR_PATH);
-      if (window.initMentoria) window.initMentoria();
-    });
-  </script>
-
   <!-- Seus scripts globais -->
   <script src="shared.js"></script>
   <script type="module" src="firebase-config.js"></script>

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -9,26 +9,6 @@
       </div>
       
       <div class="flex items-center space-x-5">
-        <!-- Atalhos de navegação -->
-        <a href="atualizacoes.html" class="btn btn-primary">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M18.375 12.739 10.682 20.432a5.25 5.25 0 0 1-7.424-7.424L15.257 3.129a3 3 0 0 1 4.243 4.243L8.552 18.32m.009-.009a1.5 1.5 0 0 1-2.121 0 1.5 1.5 0 0 1 0-2.122L14.25 8.379"/>
-          </svg>
-          Atualizações
-        </a>
-        <a href="expedicao.html" class="btn btn-primary">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Zm0 0H14.25m-9 0H3.375A1.125 1.125 0 0 1 2.25 17.625V14.25M19.5 18.75a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Zm0 0l1.125-.001c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 0 0-3.214-9.193 2.056 2.056 0 0 0-1.58-.86H14.25M16.5 18.75H14.25M14.25 7.573v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 0 0-10.026 0 1.106 1.106 0 0 0-.987 1.106v7.635M14.25 7.573v6.677m0 4.5v-4.5m0 0h-12"/>
-          </svg>
-          Expedição
-        </a>
-        <a href="zpl-import.html" class="btn btn-primary">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.875c0-.621.504-1.125 1.125-1.125h4.5A1.125 1.125 0 0 1 10.5 4.875v4.5A1.125 1.125 0 0 1 9.375 10.5h-4.5A1.125 1.125 0 0 1 3.75 9.375v-4.5ZM3.75 14.625c0-.621.504-1.125 1.125-1.125h4.5a1.125 1.125 0 0 1 1.125 1.125v4.5a1.125 1.125 0 0 1-1.125 1.125h-4.5A1.125 1.125 0 0 1 3.75 19.125v-4.5ZM13.5 4.875c0-.621.504-1.125 1.125-1.125h4.5A1.125 1.125 0 0 1 20.25 4.875v4.5a1.125 1.125 0 0 1-1.125 1.125h-4.5A1.125 1.125 0 0 1 13.5 9.375v-4.5ZM6.75 6.75h.75v.75h-.75v-.75ZM6.75 16.5h.75v.75h-.75v-.75ZM16.5 6.75h.75v.75h-.75v-.75ZM13.5 13.5h.75v.75h-.75v-.75ZM13.5 19.5h.75v.75h-.75v-.75ZM19.5 13.5h.75v.75h-.75v-.75ZM19.5 19.5h.75v.75h-.75v-.75ZM16.5 16.5h.75v.75h-.75v-.75Z"/>
-          </svg>
-          Etiquetas ZPL
-        </a>
-
         <!-- Botão de login -->
         <a href="cadastro-interesse.html" class="btn btn-primary">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -75,7 +75,7 @@
       <span class="link-text">Desempenho</span>
     </a>
     <!-- Início -->
-    <a href="/VendedorPro/index.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-inicio">
+    <a href="/VendedorPro/index.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-inicio" data-perfil="usuario,gestor,mentor">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
         <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/>
       </svg>
@@ -84,7 +84,7 @@
 
     <!-- Vendas -->
     <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-vendas">
+      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-vendas" data-perfil="usuario,gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"/>
         </svg>
@@ -96,7 +96,7 @@
         </svg>
       </button>
     </div>
-    <div id="menuVendas" class="pl-8 space-y-1 max-h-0 overflow-hidden transition-all duration-300">
+    <div id="menuVendas" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
       <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar" class="sidebar-link block py-2 px-4 transition-colors">Conferir Sobras</a>
       <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento" class="sidebar-link block py-2 px-4 transition-colors">Registrar Faturamento</a>
       <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=registroFaturamento" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Faturamento</a>
@@ -108,7 +108,7 @@
 
     <!-- Precificação -->
     <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-precificacao">
+      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-precificacao" data-perfil="usuario,gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"/>
           <path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6Z"/>
@@ -121,7 +121,7 @@
         </svg>
       </button>
     </div>
-    <div id="menuPrecificacao" class="pl-8 space-y-1 max-h-0 overflow-hidden transition-all duration-300">
+    <div id="menuPrecificacao" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
       <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao" class="sidebar-link block py-2 px-4 transition-colors">Precificação</a>
       <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=lista-precos" class="sidebar-link block py-2 px-4 transition-colors">Lista Preços</a>
       <a href="/VendedorPro/SISTEMA%20DE%20CUSTEIO%20DE%20PRODU%C3%87%C3%83O%20E%20PRODUTOS.html#mdf" class="sidebar-link block py-2 px-4 transition-colors">Custeio de Produção</a>
@@ -130,7 +130,7 @@
 
     <!-- Marketing -->
     <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/promocoes-shopee.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-marketing">
+      <a href="/VendedorPro/promocoes-shopee.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-marketing" data-perfil="usuario,gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"/>
         </svg>
@@ -142,7 +142,7 @@
         </svg>
       </button>
     </div>
-    <div id="menuMarketing" class="pl-8 space-y-1 max-h-0 overflow-hidden transition-all duration-300">
+    <div id="menuMarketing" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
       <a href="/VendedorPro/promocoes-shopee.html" class="sidebar-link block py-2 px-4 transition-colors">Promoções Shopee</a>
       <a href="/VendedorPro/ads.html" class="sidebar-link block py-2 px-4 transition-colors">Shopee Ads</a>
       <a href="/VendedorPro/ads-lista.html" class="sidebar-link block py-2 px-4 transition-colors">Anúncios Salvos</a>
@@ -151,7 +151,7 @@
 
     <!-- Anúncios -->
     <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/anuncios-tabs/cadastro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-anuncios">
+      <a href="/VendedorPro/anuncios-tabs/cadastro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-anuncios" data-perfil="usuario,gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46"/>
         </svg>
@@ -163,7 +163,7 @@
         </svg>
       </button>
     </div>
-    <div id="menuAnuncios" class="pl-8 space-y-1 max-h-0 overflow-hidden transition-all duration-300">
+    <div id="menuAnuncios" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
       <a href="/VendedorPro/anuncios-tabs/cadastro.html" class="sidebar-link block py-2 px-4 transition-colors">Cadastro / Atualização</a>
       <a href="/VendedorPro/anuncios-tabs/anuncios.html" class="sidebar-link block py-2 px-4 transition-colors">Anúncios</a>
       <a href="/VendedorPro/anuncios-tabs/analise.html" class="sidebar-link block py-2 px-4 transition-colors">Análise IA</a>
@@ -175,7 +175,7 @@
 
     <!-- Expedição -->
     <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/expedicao.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-expedicao">
+      <a href="/VendedorPro/expedicao.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-expedicao" data-perfil="usuario,gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 01-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 00-3.213-9.193 2.056 2.056 0 00-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 00-10.026 0 1.106 1.106 0 00-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12"/>
         </svg>
@@ -187,7 +187,7 @@
         </svg>
       </button>
     </div>
-    <div id="menuExpedicao" class="pl-8 space-y-1 max-h-0 overflow-hidden transition-all duration-300">
+    <div id="menuExpedicao" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
       <a href="/VendedorPro/relatorios.html" class="sidebar-link block py-2 px-4 transition-colors">Relatórios</a>
       <a href="/VendedorPro/etiquetas-ocr.html" class="sidebar-link block py-2 px-4 transition-colors">Etiquetas OCR</a>
       <a href="/VendedorPro/expedicao-historico.html" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a>
@@ -195,7 +195,7 @@
 
     <!-- Gestão Contas -->
     <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/gestao-contas.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao-contas">
+      <a href="/VendedorPro/gestao-contas.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao-contas" data-perfil="usuario,gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z"/>
         </svg>
@@ -207,13 +207,13 @@
         </svg>
       </button>
     </div>
-    <div id="menuGestaoContas" class="pl-8 space-y-1 max-h-0 overflow-hidden transition-all duration-300">
+    <div id="menuGestaoContas" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
       <a href="/VendedorPro/pdf-x-excel.html" class="sidebar-link block py-2 px-4 transition-colors">PDF X Excel</a>
     </div>
 
     <!-- Configurações -->
     <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-configuracoes">
+      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-configuracoes" data-perfil="usuario,gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"/>
           <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
@@ -226,7 +226,7 @@
         </svg>
       </button>
     </div>
-    <div id="menuConfiguracoes" class="pl-8 space-y-1 max-h-0 overflow-hidden transition-all duration-300">
+    <div id="menuConfiguracoes" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
       <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=produtos" class="sidebar-link block py-2 px-4 transition-colors">Produtos</a>
       <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link block py-2 px-4 transition-colors">Dashboard</a>
       <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=graficos" class="sidebar-link block py-2 px-4 transition-colors">Gráficos</a>
@@ -241,7 +241,7 @@
       <a href="/VendedorPro/email-expedicao.html" class="sidebar-link block py-2 px-4 transition-colors">E-mail Expedição</a>
     </div>
 
-    <a href="/VendedorPro/manual.html" target="_blank" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-manual">
+    <a href="/VendedorPro/manual.html" target="_blank" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-manual" data-perfil="usuario,gestor,mentor">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/>
       </svg>

--- a/perfil-mentorado.html
+++ b/perfil-mentorado.html
@@ -22,73 +22,7 @@
   </main>
   <script>window.CUSTOM_SIDEBAR_PATH='partials/sidebar.html';
         window.CUSTOM_NAVBAR_PATH='partials/navbar.html';</script>
-  <script>
-  // Fallback visual mínimo: garante que o container exista e tenha largura inicial
-  (function ensureSidebarBaseStyles() {
-    const style = document.createElement('style');
-    style.textContent = `
-      #sidebar-container{position:fixed;left:0;top:0;bottom:0;width:260px;max-width:80vw;overflow:auto;background:#6b46c1; /* roxo base */
-        transform:translateX(0); transition:transform .2s ease;}
-      #sidebar-container.hidden{transform:translateX(-105%);}
-      .main-content{margin-left:260px;} /* empurra o conteúdo */
-      @media (max-width:1024px){
-        .main-content{margin-left:0;}
-        #sidebar-container.hidden{transform:translateX(-105%);}
-      }
-      .mobile-menu-btn{position:fixed;left:12px;top:12px;z-index:50;background:#fff;border-radius:8px;padding:6px 10px}
-    `;
-    document.head.appendChild(style);
-    window.toggleSidebar = window.toggleSidebar || function(){
-      document.getElementById('sidebar-container')?.classList.toggle('hidden');
-    };
-  })();
 
-  (function () {
-    const SIDEBAR = window.CUSTOM_SIDEBAR_PATH || 'partials/sidebar.html';
-    const NAVBAR  = window.CUSTOM_NAVBAR_PATH  || 'partials/navbar.html';
-
-    async function loadPartial(selector, path){
-      const host = `${location.origin}${location.pathname.replace(/[^/]+$/, '')}`;
-      const url  = new URL(path, host).toString();
-      const el   = document.querySelector(selector);
-      if(!el) return;
-
-      try{
-        const res = await fetch(url, {cache:'no-cache'});
-        if(!res.ok) throw new Error(`HTTP ${res.status} em ${url}`);
-        const html = await res.text();
-
-        // injeta o HTML
-        el.innerHTML = html;
-
-        // reexecuta <script> contidos no parcial
-        el.querySelectorAll('script').forEach(old=>{
-          const s = document.createElement('script');
-          if (old.src) { s.src = new URL(old.getAttribute('src'), url).toString(); }
-          s.type = old.type || 'text/javascript';
-          s.defer = old.defer || false;
-          s.text = old.src ? '' : (old.textContent || '');
-          old.replaceWith(s);
-        });
-
-        // Se quiser escondido no mobile por padrão:
-        if (selector === '#sidebar-container' && matchMedia('(max-width:1024px)').matches) {
-          el.classList.add('hidden');
-        }
-
-      }catch(err){
-        console.error('[partials] falha', path, err);
-        el.innerHTML = `<div class="p-3 bg-red-50 text-red-700 text-sm rounded">
-          Erro ao carregar <code>${path}</code>. Veja o console para detalhes.</div>`;
-      }
-    }
-
-    document.addEventListener('DOMContentLoaded', ()=>{
-      loadPartial('#sidebar-container', SIDEBAR);
-      loadPartial('#navbar-container', NAVBAR);
-    });
-  })();
-  </script>
   <script src="shared.js"></script>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="perfil-mentorado.js"></script>

--- a/public/shared.js
+++ b/public/shared.js
@@ -36,17 +36,12 @@
     });
   }
   
-  // Toggle submenu visibility with smooth slide animation
+  // Toggle submenu visibility using max-height for smooth transitions
   window.toggleMenu = function(menuId) {
     var el = document.getElementById(menuId);
     if (!el) return;
-    if (el.classList.contains('max-h-0')) {
-      el.classList.remove('max-h-0');
-      el.classList.add('max-h-screen');
-    } else {
-      el.classList.add('max-h-0');
-      el.classList.remove('max-h-screen');
-    }
+    var isOpen = el.style.maxHeight && el.style.maxHeight !== '0px';
+    el.style.maxHeight = isOpen ? '0px' : el.scrollHeight + 'px';
   };
   
   // Toggle visibility of the Importar Produtos card on the precificação page
@@ -239,6 +234,9 @@ document.addEventListener('navbarLoaded', function () {
 });
 
 document.addEventListener('sidebarLoaded', function () {
+  document.querySelectorAll('#sidebar .submenu').forEach(function(el){
+    el.style.maxHeight = '0px';
+  });
   loadIntroJs().then(function () {
     var btn = document.getElementById('startSidebarTourBtn');
     if (btn) {

--- a/shared.js
+++ b/shared.js
@@ -36,17 +36,12 @@
     });
   }
   
-  // Toggle submenu visibility with smooth slide animation
+  // Toggle submenu visibility using max-height for smooth transitions
   window.toggleMenu = function(menuId) {
     var el = document.getElementById(menuId);
     if (!el) return;
-    if (el.classList.contains('max-h-0')) {
-      el.classList.remove('max-h-0');
-      el.classList.add('max-h-screen');
-    } else {
-      el.classList.add('max-h-0');
-      el.classList.remove('max-h-screen');
-    }
+    var isOpen = el.style.maxHeight && el.style.maxHeight !== '0px';
+    el.style.maxHeight = isOpen ? '0px' : el.scrollHeight + 'px';
   };
 
   // Toggle visibility of the Importar Produtos card on the precificação page
@@ -253,6 +248,9 @@ document.addEventListener('navbarLoaded', function () {
 
 document.addEventListener('sidebarLoaded', function () {
   document.body.classList.add('has-sidebar');
+  document.querySelectorAll('#sidebar .submenu').forEach(function(el){
+    el.style.maxHeight = '0px';
+  });
   loadIntroJs().then(function () {
     var btn = document.getElementById('startSidebarTourBtn');
     if (btn) {


### PR DESCRIPTION
## Summary
- unify sidebar layout with profile-aware links and smooth submenu toggles
- remove redundant sidebar loaders and duplicate navbar shortcuts
- tweak layout spacing for consistent sidebar offset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac994a5b38832a8ad714473c152d17