### PR TITLE
Improve sidebar accessibility and navigation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -363,51 +363,18 @@ input:checked + .dark-mode-slider:before {
 .badge {
   margin-left: 5px
 }
-.sidebar {
-  background-color: var(--secondary);
-  color: #1f2937;
-  height: 100vh;
-  overflow-y: auto;
-  padding: 20px 0;
-  transition: .3s
-}
 .sidebar-logo {
   text-align: center;
   padding: 0 20px 20px;
   border-bottom: 1px solid rgba(0,0,0,.1);
   margin-bottom: 20px
 }
+
 .sidebar-logo h2 {
   font-family: Inter,sans-serif;
   font-size: 1.4rem;
-  color: #1f2937;
+  color: #fff;
   margin-top: 10px
-}
-.sidebar-menu {
-  list-style: none;
-  padding: 0 15px
-}
-.sidebar-menu li {
-  margin-bottom: 5px
-}
-.sidebar-menu a {
-  display: flex;
-  align-items: center;
-  padding: 12px 15px;
-  color: #1f2937;
-  text-decoration: none;
-  border-radius: 8px;
-  transition: .2s
-}
-.sidebar-menu a.active,
-.sidebar-menu a:hover {
-  background-color: rgba(0,0,0,.1);
-  color: #1f2937
-}
-
-.sidebar-menu a i {
-  font-size: 1.2rem;
-  margin-right: 12px
 }
 
 .user-info {
@@ -640,7 +607,7 @@ tr:hover {
   .sidebar {
     overflow-y: auto;
     overflow-x: hidden;
-    background-color: #1c2b36;
+    background-color: var(--dark);
     width: var(--sidebar-width);
     min-height: 100vh;
     color: #fff;
@@ -649,39 +616,6 @@ tr:hover {
     top: 0;
     padding-top: 1rem;
     z-index: 50
-  }
-  .sidebar-link.active {
-    background-color: var(--hover);
-    font-weight: 700
-  }
-  .sidebar-link {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: .8rem 1.5rem;
-    color: #fff;
-    text-decoration: none;
-    font-size: .95rem;
-    transition: background .3s
-  }
-  .sidebar-link:hover {
-    background-color: rgba(255,255,255,.1)
-  }
-  .submenu {
-    padding-left: 1rem
-  }
-  .submenu a {
-    display: block;
-    color: #ccc;
-    font-size: .9rem;
-    padding: .4rem 1.5rem;
-    border-left: 2px solid transparent;
-    transition: .3s
-  }
-  .submenu a:hover {
-    color: #f45c00;
-    background-color: rgba(255,255,255,.05);
-    border-left-color: #f45c00
   }
   .main-content {
     flex: 1;
@@ -1498,32 +1432,6 @@ body.dark-mode .submenu a:hover {
   background-color: rgba(255,255,255,.1);
   color: #fff;
 }
-.submenu {
-  background-color: rgba(255,255,255,.05);
-  transition: .3s
-}
-
-.submenu .nav-item {
-  padding: .6rem 1.5rem;
-  font-size: .9rem;
-  background-color: transparent
-}
-
-.submenu .nav-item:hover {
- background-color: rgba(255,255,255,.08);
-  border-left: 2px solid var(--primary)
-}
-
-.submenu-link {
-  color: #fff;
-  text-decoration: none;
-  display: block;
-  transition: color .2s
-}
-
-.submenu-link:hover {
-  color: var(--primary)
-}
 
 /* Utilitário para esconder o submenu */
 .hidden {
@@ -1548,19 +1456,24 @@ body.dark-mode .submenu a:hover {
 }
 
 .sidebar-link {
-  color: #cbd5e1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: .8rem 1.5rem;
+  color: #fff;
   text-decoration: none;
+  font-size: .95rem;
+  transition: background .3s;
 }
 
 .sidebar-link.active {
   border-left: 3px solid var(--primary);
-  background-color: rgba(255,255,255,0.1);
-  font-weight: 700;
+  background-color: rgba(255,255,255,0.05);
   color: #fff;
 }
 
 .sidebar-link:hover {
-  background-color: rgba(255,255,255,0.1);
+  background-color: rgba(255,255,255,0.08);
   color: #fff;
 }
 
@@ -1577,8 +1490,22 @@ body.dark-mode .submenu a:hover {
   border-radius: 2px;
 }
 
+
+.menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.menu > li {
+  margin-bottom: 5px;
+}
+
 .submenu {
-  padding-left: 1rem
+  padding-left: 1rem;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height .3s;
 }
 
 .submenu a {
@@ -1587,13 +1514,21 @@ body.dark-mode .submenu a:hover {
   font-size: .9rem;
   padding: .4rem 1.5rem;
   border-left: 2px solid transparent;
-  transition: .3s
+  transition: .3s;
 }
 
 .submenu a:hover {
- color: var(--primary);
-  background-color: rgba(255,255,255,.1);
+  color: var(--primary);
+  background-color: rgba(255,255,255,.05);
   border-left-color: var(--primary)
+}
+
+.submenu-toggle .chevron {
+  transition: transform .3s;
+}
+
+.submenu-toggle .chevron.rotated {
+  transform: rotate(180deg);
 }
 
 
@@ -2032,11 +1967,6 @@ input:checked + .toggle-slider:before {
   }
 }
 
-.sidebar-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
 
 .submenu-toggle {
   background: none;
@@ -2111,22 +2041,6 @@ input:checked + .toggle-slider:before {
     border-radius: 6px;
     padding: 10px;
   }
-}
-
-/* Improved sidebar contrast and hover feedback */
-.sidebar-link:hover {
-  background-color: rgba(234, 88, 12, 0.2);
-}
-
-body.dark .sidebar-link,
-body.dark .submenu a {
-  color: #f3f4f6;
-}
-
-body.dark .sidebar-link:hover,
-body.dark .submenu a:hover {
-  background-color: rgba(234, 88, 12, 0.2);
-  color: #f3f4f6;
 }
 
 @media (min-width:1024px){

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,6 +1,6 @@
  <div class="top-navbar">
       <div class="flex items-center">
-        <button class="mobile-menu-btn mr-4 text-gray-200 md:hidden" aria-label="Abrir menu" aria-expanded="false">
+        <button id="mobileMenuBtn" class="mobile-menu-btn mr-4 text-gray-200 md:hidden" aria-label="Abrir menu" aria-expanded="false">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5" />
           </svg>

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -1,4 +1,4 @@
-<div id="sidebar" class="sidebar w-64 h-screen overflow-y-auto fixed left-0 top-0 z-50">
+<nav id="sidebar" class="sidebar h-screen overflow-y-auto fixed left-0 top-0 z-50">
   <div class="sidebar-logo p-4">
     <div class="flex items-center">
       <div class="bg-white w-10 h-10 rounded-lg flex items-center justify-center mr-3">
@@ -10,260 +10,253 @@
     </div>
   </div>
 
-  <div class="py-4">
-    <!-- Gestão -->
-    <a href="/VendedorPro/gestor.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao" data-perfil="gestor,mentor">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12H12.75M9 15H12.75M9 18H12.75M15.75 18.75H18A2.25 2.25 0 0 0 20.25 16.5V6.108A2.25 2.25 0 0 0 18.273 3.916c-.374-.031-.748-.058-1.123-.08M11.35 3.836A2.251 2.251 0 0 1 13.5 2.25h1.5a2.25 2.25 0 0 1 2.151 1.586M11.35 3.836c-.376.022-.75.049-1.124.08A2.25 2.25 0 0 0 8.25 6.108V8.25M8.25 8.25H4.875a1.125 1.125 0 0 0-1.125 1.125V20.625c0 .621.504 1.125 1.125 1.125H14.625a1.125 1.125 0 0 0 1.125-1.125V9.375A1.125 1.125 0 0 0 14.625 8.25H8.25ZM6.75 12h.007v.008H6.75V12Zm0 3h.007v.008H6.75V15Zm0 3h.007v.008H6.75V18Z"/>
-      </svg>
-      <span class="link-text">Gestão</span>
-    </a>
-    <!-- Financeiro -->
-    <a href="/VendedorPro/financeiro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-financeiro" data-perfil="gestor,mentor">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182A3.221 3.221 0 0 0 12 12c-.725 0-1.45-.219-2.003-.659-1.106-.879-1.106-2.303 0-3.182 1.106-.879 2.899-.879 4.005 0l.415.33M21 12c0 4.971-4.029 9-9 9s-9-4.029-9-9 4.029-9 9-9 9 4.029 9 9Z"/>
-      </svg>
-      <span class="link-text">Financeiro</span>
-    </a>
-    <!-- Atualizações -->
-    <a href="/VendedorPro/atualizacoes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-atualizacoes" data-perfil="gestor,mentor">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M18.375 12.739 10.682 20.432a5.25 5.25 0 0 1-7.424-7.424L15.257 3.129a3 3 0 0 1 4.243 4.243L8.552 18.32m.009-.009a1.5 1.5 0 0 1-2.121 0 1.5 1.5 0 0 1 0-2.122L14.25 8.379"/>
-      </svg>
-      <span class="link-text">Atualizações</span>
-    </a>
-    <!-- Saques -->
-    <a href="/VendedorPro/saques.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-saques" data-perfil="gestor,mentor">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75C7.717 18.75 13.014 19.481 18.047 20.851c.728.198 1.454-.343 1.454-1.096V18.75M3.75 4.5V5.25A.75.75 0 0 1 3 6H2.25M2.25 6V5.625A1.125 1.125 0 0 1 3.375 4.5H20.25M2.25 6v9M20.25 4.5V5.25A.75.75 0 0 0 21 6h.75M20.25 4.5h.375A1.125 1.125 0 0 1 21.75 5.625V15.375A1.125 1.125 0 0 1 20.625 16.5H20.25M21.75 15H21a.75.75 0 0 0-.75.75V16.5M20.25 16.5H3.75m0 0H3.375A1.125 1.125 0 0 1 2.25 15.375V15M3.75 16.5V15.75A.75.75 0 0 0 3 15H2.25M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z"/>
-      </svg>
-      <span class="link-text">Saques</span>
-    </a>
-    <!-- Visão Geral do Mentor -->
-    <a href="/VendedorPro/mentoria.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-mentoria" data-perfil="gestor,mentor">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5M3.75 3h16.5m0 0h1.5m-1.5 0v11.25a2.25 2.25 0 0 1-2.25 2.25H15.75M8.25 16.5h7.5m-7.5 0L7.25 19.5m8.5-3L16.75 19.5m0 0 .5 1.5m-.5-1.5H7.25m0 0-.5 1.5m1.75-9L10.5 9l2.148 2.148A9.013 9.013 0 0 1 16.5 7.605"/>
-      </svg>
-      <span class="link-text">Visão Geral do Mentor</span>
-    </a>
-    <!-- Perfil do Mentorado -->
-    <a href="/VendedorPro/perfil-mentorado.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-perfil-mentorado" data-perfil="gestor,mentor">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M15 9h3.75M15 12h3.75M15 15h3.75M4.5 19.5h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15A2.25 2.25 0 0 0 2.25 6.75v10.5A2.25 2.25 0 0 0 4.5 19.5Zm6-10.125a1.875 1.875 0 1 1-3.75 0 1.875 1.875 0 0 1 3.75 0Zm1.294 6.336A5.985 5.985 0 0 0 8.625 13.5a5.985 5.985 0 0 0-3.169 2.211"/>
-      </svg>
-      <span class="link-text">Perfil do Mentorado</span>
-    </a>
-    <!-- Equipes -->
-    <a href="/VendedorPro/equipes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-equipes" data-perfil="gestor,mentor">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128c.833.242 1.714.372 2.625.372 1.479 0 2.878-.342 4.122-.952v-.173c0-2.278-1.847-4.125-4.125-4.125-1.418 0-2.669.716-3.411 1.806M15 19.128V19.125c0-3.52-2.854-6.375-6.375-6.375S2.25 15.605 2.25 19.125v.009A11.953 11.953 0 0 0 12 21c2.678 0 5.218-.585 7.499-1.632M12.75 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM20.25 8.625a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z"/>
-      </svg>
-      <span class="link-text">Equipes</span>
-    </a>
-    <!-- Gestão de Produtos -->
-    <a href="/VendedorPro/gestao-produtos.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-produtos" data-perfil="gestor,mentor">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M21 7.5 12 2.25 3 7.5m18 0L12 12.75M21 7.5v9L12 21.75M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"/>
-      </svg>
-      <span class="link-text">Gestão de Produtos</span>
-    </a>
-    <!-- Desempenho -->
-    <a href="/VendedorPro/desempenho.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-desempenho" data-perfil="gestor,mentor">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v6.75A1.125 1.125 0 0 1 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 9.75 19.875V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 16.5 19.875V4.125Z"/>
-      </svg>
-      <span class="link-text">Desempenho</span>
-    </a>
-    <!-- Início -->
-    <a href="/VendedorPro/index.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-inicio" data-perfil="usuario,gestor,mentor">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-        <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/>
-      </svg>
-      <span class="link-text">Início</span>
-    </a>
-
-    <!-- Vendas -->
-    <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-vendas" data-perfil="usuario,gestor,mentor">
+  <ul class="menu py-4">
+    <li>
+      <a href="/VendedorPro/gestor.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao" data-perfil="gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"/>
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12H12.75M9 15H12.75M9 18H12.75M15.75 18.75H18A2.25 2.25 0 0 0 20.25 16.5V6.108A2.25 2.25 0 0 0 18.273 3.916c-.374-.031-.748-.058-1.123-.08M11.35 3.836A2.251 2.251 0 0 1 13.5 2.25h1.5a2.25 2.25 0 0 1 2.151 1.586M11.35 3.836c-.376.022-.75.049-1.124.08A2.25 2.25 0 0 0 8.25 6.108V8.25M8.25 8.25H4.875a1.125 1.125 0 0 0-1.125 1.125V20.625c0 .621.504 1.125 1.125 1.125H14.625a1.125 1.125 0 0 0 1.125-1.125V9.375A1.125 1.125 0 0 0 14.625 8.25H8.25ZM6.75 12h.007v.008H6.75V12Zm0 3h.007v.008H6.75V15Zm0 3h.007v.008H6.75V18Z"/>
         </svg>
-        <span class="link-text">Vendas</span>
+        <span class="link-text">Gestão</span>
       </a>
-      <button class="submenu-toggle p-2" onclick="toggleMenu('menuVendas')">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
-        </svg>
-      </button>
-    </div>
-    <div id="menuVendas" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar" class="sidebar-link block py-2 px-4 transition-colors">Conferir Sobras</a>
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento" class="sidebar-link block py-2 px-4 transition-colors">Registrar Faturamento</a>
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=registroFaturamento" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Faturamento</a>
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=controleVendas" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Vendas</a>
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamento" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Mensal</a>
-      <a href="/VendedorPro/saques.html" class="sidebar-link block py-2 px-4 transition-colors">Saques</a>
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a>
-    </div>
-
-    <!-- Precificação -->
-    <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-precificacao" data-perfil="usuario,gestor,mentor">
+    </li>
+    <li>
+      <a href="/VendedorPro/financeiro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-financeiro" data-perfil="gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"/>
-          <path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6Z"/>
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182A3.221 3.221 0 0 0 12 12c-.725 0-1.45-.219-2.003-.659-1.106-.879-1.106-2.303 0-3.182 1.106-.879 2.899-.879 4.005 0l.415.33M21 12c0 4.971-4.029 9-9 9s-9-4.029-9-9 4.029-9 9-9 9 4.029 9 9Z"/>
         </svg>
-        <span class="link-text">Precificação</span>
+        <span class="link-text">Financeiro</span>
       </a>
-      <button class="submenu-toggle p-2" onclick="toggleMenu('menuPrecificacao')">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
-        </svg>
-      </button>
-    </div>
-    <div id="menuPrecificacao" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao" class="sidebar-link block py-2 px-4 transition-colors">Precificação</a>
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=lista-precos" class="sidebar-link block py-2 px-4 transition-colors">Lista Preços</a>
-      <a href="/VendedorPro/SISTEMA%20DE%20CUSTEIO%20DE%20PRODU%C3%87%C3%83O%20E%20PRODUTOS.html#mdf" class="sidebar-link block py-2 px-4 transition-colors">Custeio de Produção</a>
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a>
-    </div>
-
-    <!-- Marketing -->
-    <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/promocoes-shopee.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-marketing" data-perfil="usuario,gestor,mentor">
+    </li>
+    <li>
+      <a href="/VendedorPro/atualizacoes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-atualizacoes" data-perfil="gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"/>
+          <path stroke-linecap="round" stroke-linejoin="round" d="M18.375 12.739 10.682 20.432a5.25 5.25 0 0 1-7.424-7.424L15.257 3.129a3 3 0 0 1 4.243 4.243L8.552 18.32m.009-.009a1.5 1.5 0 0 1-2.121 0 1.5 1.5 0 0 1 0-2.122L14.25 8.379"/>
         </svg>
-        <span class="link-text">Marketing</span>
+        <span class="link-text">Atualizações</span>
       </a>
-      <button class="submenu-toggle p-2" onclick="toggleMenu('menuMarketing')">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
-        </svg>
-      </button>
-    </div>
-    <div id="menuMarketing" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-      <a href="/VendedorPro/promocoes-shopee.html" class="sidebar-link block py-2 px-4 transition-colors">Promoções Shopee</a>
-      <a href="/VendedorPro/ads.html" class="sidebar-link block py-2 px-4 transition-colors">Shopee Ads</a>
-      <a href="/VendedorPro/ads-lista.html" class="sidebar-link block py-2 px-4 transition-colors">Anúncios Salvos</a>
-      <a href="/VendedorPro/acompanhamento-promocoes.html" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Promoções</a>
-    </div>
-
-    <!-- Anúncios -->
-    <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/anuncios-tabs/cadastro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-anuncios" data-perfil="usuario,gestor,mentor">
+    </li>
+    <li>
+      <a href="/VendedorPro/saques.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-saques" data-perfil="gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46"/>
+          <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75C7.717 18.75 13.014 19.481 18.047 20.851c.728.198 1.454-.343 1.454-1.096V18.75M3.75 4.5V5.25A.75.75 0 0 1 3 6H2.25M2.25 6V5.625A1.125 1.125 0 0 1 3.375 4.5H20.25M2.25 6v9M20.25 4.5V5.25A.75.75 0 0 0 21 6h.75M20.25 4.5h.375A1.125 1.125 0 0 1 21.75 5.625V15.375A1.125 1.125 0 0 1 20.625 16.5H20.25M21.75 15H21a.75.75 0 0 0-.75.75V16.5M20.25 16.5H3.75m0 0H3.375A1.125 1.125 0 0 1 2.25 15.375V15M3.75 16.5V15.75A.75.75 0 0 0 3 15H2.25M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z"/>
         </svg>
-        <span class="link-text">Anúncios</span>
+        <span class="link-text">Saques</span>
       </a>
-      <button class="submenu-toggle p-2" onclick="toggleMenu('menuAnuncios')">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
-        </svg>
-      </button>
-    </div>
-    <div id="menuAnuncios" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-      <a href="/VendedorPro/anuncios-tabs/cadastro.html" class="sidebar-link block py-2 px-4 transition-colors">Cadastro / Atualização</a>
-      <a href="/VendedorPro/anuncios-tabs/anuncios.html" class="sidebar-link block py-2 px-4 transition-colors">Anúncios</a>
-      <a href="/VendedorPro/anuncios-tabs/analise.html" class="sidebar-link block py-2 px-4 transition-colors">Análise IA</a>
-      <a href="/VendedorPro/anuncios-tabs/evolucao.html" class="sidebar-link block py-2 px-4 transition-colors">Evolução</a>
-      <a href="/VendedorPro/anuncios-tabs/criar-ia.html" class="sidebar-link block py-2 px-4 transition-colors">Criar Anúncio com IA</a>
-      <a href="/VendedorPro/anuncios-tabs/planilha-shopee.html" class="sidebar-link block py-2 px-4 transition-colors">Planilha Shopee</a>
-      <a href="/VendedorPro/expedicao.html" class="sidebar-link block py-2 px-4 transition-colors">Expedição</a>
-    </div>
-
-    <!-- Expedição -->
-    <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/expedicao.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-expedicao" data-perfil="usuario,gestor,mentor">
+    </li>
+    <li>
+      <a href="/VendedorPro/mentoria.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-mentoria" data-perfil="gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 01-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 00-3.213-9.193 2.056 2.056 0 00-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 00-10.026 0 1.106 1.106 0 00-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12"/>
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5M3.75 3h16.5m0 0h1.5m-1.5 0v11.25a2.25 2.25 0 0 1-2.25 2.25H15.75M8.25 16.5h7.5m-7.5 0L7.25 19.5m8.5-3L16.75 19.5m0 0 .5 1.5m-.5-1.5H7.25m0 0-.5 1.5m1.75-9L10.5 9l2.148 2.148A9.013 9.013 0 0 1 16.5 7.605"/>
         </svg>
-        <span class="link-text">Expedição</span>
+        <span class="link-text">Visão Geral do Mentor</span>
       </a>
-      <button class="submenu-toggle p-2" onclick="toggleMenu('menuExpedicao')">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
-        </svg>
-      </button>
-    </div>
-    <div id="menuExpedicao" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-      <a href="/VendedorPro/relatorios.html" class="sidebar-link block py-2 px-4 transition-colors">Relatórios</a>
-      <a href="/VendedorPro/etiquetas-ocr.html" class="sidebar-link block py-2 px-4 transition-colors">Etiquetas OCR</a>
-      <a href="/VendedorPro/expedicao-historico.html" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a>
-    </div>
-
-    <!-- Gestão Contas -->
-    <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/gestao-contas.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao-contas" data-perfil="usuario,gestor,mentor">
+    </li>
+    <li>
+      <a href="/VendedorPro/perfil-mentorado.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-perfil-mentorado" data-perfil="gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z"/>
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 9h3.75M15 12h3.75M15 15h3.75M4.5 19.5h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15A2.25 2.25 0 0 0 2.25 6.75v10.5A2.25 2.25 0 0 0 4.5 19.5Zm6-10.125a1.875 1.875 0 1 1-3.75 0 1.875 1.875 0 0 1 3.75 0Zm1.294 6.336A5.985 5.985 0 0 0 8.625 13.5a5.985 5.985 0 0 0-3.169 2.211"/>
         </svg>
-        <span class="link-text">Gestão Contas</span>
+        <span class="link-text">Perfil do Mentorado</span>
       </a>
-      <button class="submenu-toggle p-2" onclick="toggleMenu('menuGestaoContas')">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
-        </svg>
-      </button>
-    </div>
-    <div id="menuGestaoContas" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-      <a href="/VendedorPro/pdf-x-excel.html" class="sidebar-link block py-2 px-4 transition-colors">PDF X Excel</a>
-    </div>
-
-    <!-- Configurações -->
-    <div class="sidebar-item flex items-center justify-between">
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-configuracoes" data-perfil="usuario,gestor,mentor">
+    </li>
+    <li>
+      <a href="/VendedorPro/equipes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-equipes" data-perfil="gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"/>
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128c.833.242 1.714.372 2.625.372 1.479 0 2.878-.342 4.122-.952v-.173c0-2.278-1.847-4.125-4.125-4.125-1.418 0-2.669.716-3.411 1.806M15 19.128V19.125c0-3.52-2.854-6.375-6.375-6.375S2.25 15.605 2.25 19.125v.009A11.953 11.953 0 0 0 12 21c2.678 0 5.218-.585 7.499-1.632M12.75 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM20.25 8.625a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z"/>
         </svg>
-        <span class="link-text">Configurações</span>
+        <span class="link-text">Equipes</span>
       </a>
-      <button class="submenu-toggle p-2" onclick="toggleMenu('menuConfiguracoes')">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
+    </li>
+    <li>
+      <a href="/VendedorPro/gestao-produtos.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-produtos" data-perfil="gestor,mentor">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M21 7.5 12 2.25 3 7.5m18 0L12 12.75M21 7.5v9L12 21.75M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"/>
         </svg>
+        <span class="link-text">Gestão de Produtos</span>
+      </a>
+    </li>
+    <li>
+      <a href="/VendedorPro/desempenho.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-desempenho" data-perfil="gestor,mentor">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v6.75A1.125 1.125 0 0 1 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 9.75 19.875V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 16.5 19.875V4.125Z"/>
+        </svg>
+        <span class="link-text">Desempenho</span>
+      </a>
+    </li>
+    <li>
+      <a href="/VendedorPro/index.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-inicio" data-perfil="usuario,gestor,mentor">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+          <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/>
+        </svg>
+        <span class="link-text">Início</span>
+      </a>
+    </li>
+
+    <li class="has-sub">
+      <button class="sidebar-link submenu-toggle w-full flex items-center justify-between" onclick="toggleMenu('menuVendas')">
+        <span class="flex items-center">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"/>
+          </svg>
+          <span class="link-text">Vendas</span>
+        </span>
+        <svg class="w-5 h-5 chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
       </button>
-    </div>
-    <div id="menuConfiguracoes" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=produtos" class="sidebar-link block py-2 px-4 transition-colors">Produtos</a>
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link block py-2 px-4 transition-colors">Dashboard</a>
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=graficos" class="sidebar-link block py-2 px-4 transition-colors">Gráficos</a>
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=metas" class="sidebar-link block py-2 px-4 transition-colors">Cadastro de Sobra</a>
-      <a href="/VendedorPro/pedidos-bling.html" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Bling</a>
-      <a href="/VendedorPro/pedidos-shopee.html" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Shopee</a>
-      <a href="https://matheus-35023.web.app" class="sidebar-link block py-2 px-4 transition-colors" target="_blank">Tiny</a>
-      <a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=configuracoes" class="sidebar-link block py-2 px-4 transition-colors">Configurações</a>
-      <a href="painel-usuarios.html" class="sidebar-link block py-2 px-4 transition-colors">Painel Usuários</a>
-      <a href="/VendedorPro/configuracao-perfil.html" class="sidebar-link block py-2 px-4 transition-colors">Configuração Perfil</a>
-      <a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a>
-      <a href="/VendedorPro/email-expedicao.html" class="sidebar-link block py-2 px-4 transition-colors">E-mail Expedição</a>
-    </div>
+      <ul id="menuVendas" class="submenu space-y-1">
+        <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar" class="sidebar-link block py-2 px-4 transition-colors">Conferir Sobras</a></li>
+        <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento" class="sidebar-link block py-2 px-4 transition-colors">Registrar Faturamento</a></li>
+        <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=registroFaturamento" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Faturamento</a></li>
+        <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=controleVendas" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Vendas</a></li>
+        <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamento" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Mensal</a></li>
+        <li><a href="/VendedorPro/saques.html" class="sidebar-link block py-2 px-4 transition-colors">Saques</a></li>
+        <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a></li>
+      </ul>
+    </li>
 
-    <a href="/VendedorPro/manual.html" target="_blank" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-manual" data-perfil="usuario,gestor,mentor">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/>
-      </svg>
-      <span class="link-text">Manual</span>
-    </a>
+    <li class="has-sub">
+      <button class="sidebar-link submenu-toggle w-full flex items-center justify-between" onclick="toggleMenu('menuPrecificacao')">
+        <span class="flex items-center">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"/>
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6Z"/>
+          </svg>
+          <span class="link-text">Precificação</span>
+        </span>
+        <svg class="w-5 h-5 chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
+      </button>
+      <ul id="menuPrecificacao" class="submenu space-y-1">
+        <li><a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao" class="sidebar-link block py-2 px-4 transition-colors">Precificação</a></li>
+        <li><a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=lista-precos" class="sidebar-link block py-2 px-4 transition-colors">Lista Preços</a></li>
+        <li><a href="/VendedorPro/SISTEMA%20DE%20CUSTEIO%20DE%20PRODU%C3%87%C3%83O%20E%20PRODUTOS.html#mdf" class="sidebar-link block py-2 px-4 transition-colors">Custeio de Produção</a></li>
+        <li><a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a></li>
+      </ul>
+    </li>
 
-    <button id="startSidebarTourBtn" class="sidebar-link w-full text-left flex items-center py-2 px-4 transition-colors">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z"/>
-      </svg>
-      <span class="link-text">Modo Introdução</span>
-    </button>
+    <li class="has-sub">
+      <button class="sidebar-link submenu-toggle w-full flex items-center justify-between" onclick="toggleMenu('menuMarketing')">
+        <span class="flex items-center">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 18h.008v.008H12V18Zm0-6h.008v.008H12V12Zm0-6h.008V6H12v.008Zm9-3v15a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3V3"/>
+          </svg>
+          <span class="link-text">Marketing</span>
+        </span>
+        <svg class="w-5 h-5 chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
+      </button>
+      <ul id="menuMarketing" class="submenu space-y-1">
+        <li><a href="/VendedorPro/promocoes-shopee.html" class="sidebar-link block py-2 px-4 transition-colors">Promoções Shopee</a></li>
+        <li><a href="/VendedorPro/ads.html" class="sidebar-link block py-2 px-4 transition-colors">Shopee Ads</a></li>
+        <li><a href="/VendedorPro/ads-lista.html" class="sidebar-link block py-2 px-4 transition-colors">Anúncios Salvos</a></li>
+        <li><a href="/VendedorPro/acompanhamento-promocoes.html" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Promoções</a></li>
+      </ul>
+    </li>
 
-    <!-- Modo Escuro -->
-    <div class="flex items-center justify-between px-4 mt-6">
-      <span class="text-sm text-gray-300">Modo Escuro</span>
-      <label class="relative inline-flex items-center cursor-pointer">
-        <input type="checkbox" id="darkModeToggle" class="sr-only peer">
-        <div class="w-11 h-6 bg-gray-300 peer-focus:outline-none rounded-full peer peer-checked:bg-orange-500 transition"></div>
-        <div class="absolute left-1 top-1 bg-white w-4 h-4 rounded-full transition peer-checked:translate-x-full"></div>
-      </label>
-    </div>
-  </div>
-</div>
+    <li class="has-sub">
+      <button class="sidebar-link submenu-toggle w-full flex items-center justify-between" onclick="toggleMenu('menuAnuncios')">
+        <span class="flex items-center">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6.115 5.19 5.041 3.636A1.125 1.125 0 0 0 4.112 3H3.75A2.25 2.25 0 0 0 1.5 5.25v13.5A2.25 2.25 0 0 0 3.75 21h16.5a2.25 2.25 0 0 0 2.25-2.25V5.25A2.25 2.25 0 0 0 20.25 3h-.362c-.376 0-.725.176-.929.48L18.032 5.19a1.125 1.125 0 0 1-.929.48H7.044a1.125 1.125 0 0 1-.929-.48Z"/>
+          </svg>
+          <span class="link-text">Anúncios</span>
+        </span>
+        <svg class="w-5 h-5 chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
+      </button>
+      <ul id="menuAnuncios" class="submenu space-y-1">
+        <li><a href="/VendedorPro/anuncios-tabs/cadastro.html" class="sidebar-link block py-2 px-4 transition-colors">Cadastro / Atualização</a></li>
+        <li><a href="/VendedorPro/anuncios-tabs/anuncios.html" class="sidebar-link block py-2 px-4 transition-colors">Anúncios</a></li>
+        <li><a href="/VendedorPro/anuncios-tabs/analise.html" class="sidebar-link block py-2 px-4 transition-colors">Análise IA</a></li>
+        <li><a href="/VendedorPro/anuncios-tabs/evolucao.html" class="sidebar-link block py-2 px-4 transition-colors">Evolução</a></li>
+        <li><a href="/VendedorPro/anuncios-tabs/criar-ia.html" class="sidebar-link block py-2 px-4 transition-colors">Criar Anúncio com IA</a></li>
+        <li><a href="/VendedorPro/anuncios-tabs/planilha-shopee.html" class="sidebar-link block py-2 px-4 transition-colors">Planilha Shopee</a></li>
+        <li><a href="/VendedorPro/expedicao.html" class="sidebar-link block py-2 px-4 transition-colors">Expedição</a></li>
+      </ul>
+    </li>
+
+    <li class="has-sub">
+      <button class="sidebar-link submenu-toggle w-full flex items-center justify-between" onclick="toggleMenu('menuExpedicao')">
+        <span class="flex items-center">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 3h1.5l.75 12h13.5l.75-12H21M5.25 21h13.5M8.25 21v-3.75A2.25 2.25 0 0 1 10.5 15h3a2.25 2.25 0 0 1 2.25 2.25V21"/>
+          </svg>
+          <span class="link-text">Expedição</span>
+        </span>
+        <svg class="w-5 h-5 chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
+      </button>
+      <ul id="menuExpedicao" class="submenu space-y-1">
+        <li><a href="/VendedorPro/relatorios.html" class="sidebar-link block py-2 px-4 transition-colors">Relatórios</a></li>
+        <li><a href="/VendedorPro/etiquetas-ocr.html" class="sidebar-link block py-2 px-4 transition-colors">Etiquetas OCR</a></li>
+        <li><a href="/VendedorPro/expedicao-historico.html" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a></li>
+      </ul>
+    </li>
+
+    <li class="has-sub">
+      <button class="sidebar-link submenu-toggle w-full flex items-center justify-between" onclick="toggleMenu('menuGestaoContas')">
+        <span class="flex items-center">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75h.008v.008h-.008V6.75Zm0 4.5h.008v.008h-.008V11.25Zm0 4.5h.008v.008h-.008V15.75ZM3 9.75h12m-12 4.5h12M4.5 6h1.5A1.5 1.5 0 0 1 7.5 7.5v9A1.5 1.5 0 0 1 6 18H4.5a1.5 1.5 0 0 1-1.5-1.5v-9A1.5 1.5 0 0 1 4.5 6Zm12 0H19.5a1.5 1.5 0 0 1 1.5 1.5v9a1.5 1.5 0 0 1-1.5 1.5H16.5a1.5 1.5 0 0 1-1.5-1.5v-9A1.5 1.5 0 0 1 16.5 6Z"/>
+          </svg>
+          <span class="link-text">Gestão Contas</span>
+        </span>
+        <svg class="w-5 h-5 chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
+      </button>
+      <ul id="menuGestaoContas" class="submenu space-y-1">
+        <li><a href="/VendedorPro/pdf-x-excel.html" class="sidebar-link block py-2 px-4 transition-colors">PDF X Excel</a></li>
+      </ul>
+    </li>
+
+    <li class="has-sub">
+      <button class="sidebar-link submenu-toggle w-full flex items-center justify-between" onclick="toggleMenu('menuConfiguracoes')">
+        <span class="flex items-center">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.28c.063.374.313.686.666.846l1.197.535c.511.229.748.825.55 1.348l-.48 1.259a1.125 1.125 0 0 0 .213 1.164l.852.985c.39.452.39 1.107 0 1.559l-.852.985a1.125 1.125 0 0 0-.213 1.164l.48 1.259c.198.523-.039 1.12-.55 1.349l-1.197.535a1.125 1.125 0 0 0-.666.846l-.213 1.28c-.09.542-.56.94-1.11.94h-2.593c-.55 0-1.02-.398-1.11-.94l-.213-1.28a1.125 1.125 0 0 0-.666-.846l-1.197-.535c-.511-.229-.748-.825-.55-1.349l.48-1.259a1.125 1.125 0 0 0-.213-1.164l-.852-.985a1.125 1.125 0 0 1 0-1.559l.852-.985a1.125 1.125 0 0 0 .213-1.164l-.48-1.259a1.125 1.125 0 0 1 .55-1.348l1.197-.535c.353-.16.603-.472.666-.846l.213-1.28Z"/>
+          </svg>
+          <span class="link-text">Configurações</span>
+        </span>
+        <svg class="w-5 h-5 chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
+      </button>
+      <ul id="menuConfiguracoes" class="submenu space-y-1">
+        <li><a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=produtos" class="sidebar-link block py-2 px-4 transition-colors">Produtos</a></li>
+        <li><a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link block py-2 px-4 transition-colors">Dashboard</a></li>
+        <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=graficos" class="sidebar-link block py-2 px-4 transition-colors">Gráficos</a></li>
+        <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=metas" class="sidebar-link block py-2 px-4 transition-colors">Cadastro de Sobra</a></li>
+        <li><a href="/VendedorPro/pedidos-bling.html" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Bling</a></li>
+        <li><a href="/VendedorPro/pedidos-shopee.html" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Shopee</a></li>
+        <li><a href="https://matheus-35023.web.app" class="sidebar-link block py-2 px-4 transition-colors" target="_blank">Tiny</a></li>
+        <li><a href="/VendedorPro/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=configuracoes" class="sidebar-link block py-2 px-4 transition-colors">Configurações</a></li>
+        <li><a href="painel-usuarios.html" class="sidebar-link block py-2 px-4 transition-colors">Painel Usuários</a></li>
+        <li><a href="/VendedorPro/configuracao-perfil.html" class="sidebar-link block py-2 px-4 transition-colors">Configuração Perfil</a></li>
+        <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a></li>
+        <li><a href="/VendedorPro/email-expedicao.html" class="sidebar-link block py-2 px-4 transition-colors">E-mail Expedição</a></li>
+      </ul>
+    </li>
+
+    <li>
+      <a href="/VendedorPro/manual.html" target="_blank" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-manual" data-perfil="usuario,gestor,mentor">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/>
+        </svg>
+        <span class="link-text">Manual</span>
+      </a>
+    </li>
+
+    <li>
+      <button id="startSidebarTourBtn" class="sidebar-link w-full text-left flex items-center py-2 px-4 transition-colors">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z"/>
+        </svg>
+        <span class="link-text">Modo Introdução</span>
+      </button>
+    </li>
+
+    <li>
+      <div class="flex items-center justify-between px-4 mt-6">
+        <span class="text-sm text-gray-300">Modo Escuro</span>
+        <label class="relative inline-flex items-center cursor-pointer">
+          <input type="checkbox" id="darkModeToggle" class="sr-only peer">
+          <div class="w-11 h-6 bg-gray-300 peer-focus:outline-none rounded-full peer peer-checked:bg-orange-500 transition"></div>
+          <div class="absolute left-1 top-1 bg-white w-4 h-4 rounded-full transition peer-checked:translate-x-full"></div>
+        </label>
+      </div>
+    </li>
+  </ul>
+</nav>
 

--- a/public/shared.js
+++ b/public/shared.js
@@ -38,10 +38,12 @@
   
   // Toggle submenu visibility using max-height for smooth transitions
   window.toggleMenu = function(menuId) {
-    var el = document.getElementById(menuId);
-    if (!el) return;
-    var isOpen = el.style.maxHeight && el.style.maxHeight !== '0px';
-    el.style.maxHeight = isOpen ? '0px' : el.scrollHeight + 'px';
+    var submenu = document.getElementById(menuId);
+    if (!submenu) return;
+    var isOpen = submenu.style.maxHeight && submenu.style.maxHeight !== '0px';
+    submenu.style.maxHeight = isOpen ? '0px' : submenu.scrollHeight + 'px';
+    var toggleIcon = submenu.previousElementSibling.querySelector('.chevron');
+    if (toggleIcon) toggleIcon.classList.toggle('rotated', !isOpen);
   };
   
   // Toggle visibility of the Importar Produtos card on the precificação page

--- a/shared.js
+++ b/shared.js
@@ -38,10 +38,12 @@
   
   // Toggle submenu visibility using max-height for smooth transitions
   window.toggleMenu = function(menuId) {
-    var el = document.getElementById(menuId);
-    if (!el) return;
-    var isOpen = el.style.maxHeight && el.style.maxHeight !== '0px';
-    el.style.maxHeight = isOpen ? '0px' : el.scrollHeight + 'px';
+    var submenu = document.getElementById(menuId);
+    if (!submenu) return;
+    var isOpen = submenu.style.maxHeight && submenu.style.maxHeight !== '0px';
+    submenu.style.maxHeight = isOpen ? '0px' : submenu.scrollHeight + 'px';
+    var toggleIcon = submenu.previousElementSibling.querySelector('.chevron');
+    if (toggleIcon) toggleIcon.classList.toggle('rotated', !isOpen);
   };
 
   // Toggle visibility of the Importar Produtos card on the precificação page


### PR DESCRIPTION
## Summary
- increase sidebar contrast and unify link styles
- restructure sidebar into semantic nav with keyboard-friendly submenus
- add mobile menu button and rotate submenu chevron on toggle

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aca0f06584832ab7738473e83f01b7