### PR TITLE
Ensure mentor overview loads mentorados

### DIFF
--- a/mentoria.html
+++ b/mentoria.html
@@ -81,6 +81,13 @@
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="mentoria.js"></script>
   <script type="module" src="login.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      if (window.initMentoria) {
+        window.initMentoria();
+      }
+    });
+  </script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Automatically invoke `initMentoria` after the page loads so mentorados tied to a gestor's email are displayed

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/VendedorPro/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68acab15edb4832a99637ecbbeb20de9