### PR TITLE
Use absolute paths for shared partials

### DIFF
--- a/atualizacoes.html
+++ b/atualizacoes.html
@@ -42,7 +42,7 @@
   </main>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="atualizacoes.js"></script>
-  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar.html';</script>
+  <script>window.CUSTOM_SIDEBAR_PATH = '/VendedorPro/partials/sidebar.html';</script>
   <script src="shared.js"></script>
 </body>
 </html>

--- a/desempenho.html
+++ b/desempenho.html
@@ -70,7 +70,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="desempenho.js"></script>
-  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar.html';</script>
+  <script>window.CUSTOM_SIDEBAR_PATH = '/VendedorPro/partials/sidebar.html';</script>
   <script src="shared.js"></script>
 </body>
 </html>

--- a/equipes.html
+++ b/equipes.html
@@ -910,7 +910,7 @@
     </div>
 
     <!-- Script para Firebase e funcionalidades da UI -->
-    <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar.html';</script>
+    <script>window.CUSTOM_SIDEBAR_PATH = '/VendedorPro/partials/sidebar.html';</script>
     <script src="shared.js"></script>
     <script type="module" src="firebase-config.js"></script>
 

--- a/financeiro-inicio.html
+++ b/financeiro-inicio.html
@@ -18,7 +18,7 @@
     <h1 class="text-2xl font-bold">Área Financeira</h1>
     <p>Selecione uma opção no menu ao lado para acessar as ferramentas financeiras.</p>
   </main>
-  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar.html';</script>
+  <script>window.CUSTOM_SIDEBAR_PATH = '/VendedorPro/partials/sidebar.html';</script>
   <script src="shared.js"></script>
 </body>
 </html>

--- a/financeiro.html
+++ b/financeiro.html
@@ -68,7 +68,7 @@
   </div>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="financeiro.js"></script>
-  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar.html';</script>
+  <script>window.CUSTOM_SIDEBAR_PATH = '/VendedorPro/partials/sidebar.html';</script>
   <script src="shared.js"></script>
   </body>
 </html>

--- a/gestao-produtos.html
+++ b/gestao-produtos.html
@@ -59,7 +59,7 @@
   </main>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="gestao-produtos.js"></script>
-  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar.html';</script>
+  <script>window.CUSTOM_SIDEBAR_PATH = '/VendedorPro/partials/sidebar.html';</script>
   <script src="shared.js"></script>
 </body>
 </html>

--- a/gestor.html
+++ b/gestor.html
@@ -58,8 +58,8 @@
     </div>
   </main>
 
-  <script>window.CUSTOM_SIDEBAR_PATH='partials/sidebar.html';
-        window.CUSTOM_NAVBAR_PATH='partials/navbar.html';</script>
+  <script>window.CUSTOM_SIDEBAR_PATH='/VendedorPro/partials/sidebar.html';
+        window.CUSTOM_NAVBAR_PATH='/VendedorPro/partials/navbar.html';</script>
   
   <script src="shared.js"></script>
   <script type="module" src="firebase-config.js"></script>

--- a/mentoria.html
+++ b/mentoria.html
@@ -72,8 +72,8 @@
 
   <!-- Caminhos dos parciais (use os mesmos em todas as páginas) -->
   <script>
-    window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar.html';
-    window.CUSTOM_NAVBAR_PATH  = 'partials/navbar.html';
+    window.CUSTOM_SIDEBAR_PATH = '/VendedorPro/partials/sidebar.html';
+    window.CUSTOM_NAVBAR_PATH  = '/VendedorPro/partials/navbar.html';
   </script>
 
   <!-- Seus scripts globais -->

--- a/perfil-mentorado.html
+++ b/perfil-mentorado.html
@@ -20,8 +20,8 @@
       <div id="perfilMentoradoList" class="card-body space-y-4"></div>
     </div>
   </main>
-  <script>window.CUSTOM_SIDEBAR_PATH='partials/sidebar.html';
-        window.CUSTOM_NAVBAR_PATH='partials/navbar.html';</script>
+  <script>window.CUSTOM_SIDEBAR_PATH='/VendedorPro/partials/sidebar.html';
+        window.CUSTOM_NAVBAR_PATH='/VendedorPro/partials/navbar.html';</script>
 
   <script src="shared.js"></script>
   <script type="module" src="firebase-config.js"></script>

--- a/public/shared.js
+++ b/public/shared.js
@@ -80,16 +80,21 @@
 // Load sidebar HTML into placeholder
   window.loadSidebar = function(containerId, sidebarPath) {
     containerId = containerId || 'sidebar-container';
-    sidebarPath = sidebarPath || 'partials/sidebar.html';
+    sidebarPath = sidebarPath || '/VendedorPro/partials/sidebar.html';
 
-    var paths = [
-      ROOT_PATH + sidebarPath,
-      BASE_PATH + sidebarPath,
-      '/' + sidebarPath,
-      ROOT_PATH + 'partials/sidebar.html',
-      BASE_PATH + 'partials/sidebar.html',
-      '/partials/sidebar.html'
-    ];
+    var paths = [];
+    if (/^https?:\/\//.test(sidebarPath) || sidebarPath.startsWith('/')) {
+      paths = [sidebarPath];
+    } else {
+      paths = [
+        ROOT_PATH + sidebarPath,
+        BASE_PATH + sidebarPath,
+        '/VendedorPro/' + sidebarPath,
+        ROOT_PATH + 'partials/sidebar.html',
+        BASE_PATH + 'partials/sidebar.html',
+        '/VendedorPro/partials/sidebar.html'
+      ];
+    }
 
     return fetchWithFallback(paths)
       .then(function(html) {
@@ -105,13 +110,24 @@
       });
   };
 // Load navbar HTML into placeholder
-  window.loadNavbar = function(containerId) {
+  window.loadNavbar = function(containerId, navbarPath) {
     containerId = containerId || 'navbar-container';
-    var paths = [
-      ROOT_PATH + 'partials/navbar.html',
-      BASE_PATH + 'partials/navbar.html',
-      '/partials/navbar.html'
-    ];
+    navbarPath = navbarPath || '/VendedorPro/partials/navbar.html';
+
+    var paths = [];
+    if (/^https?:\/\//.test(navbarPath) || navbarPath.startsWith('/')) {
+      paths = [navbarPath];
+    } else {
+      paths = [
+        ROOT_PATH + navbarPath,
+        BASE_PATH + navbarPath,
+        '/VendedorPro/' + navbarPath,
+        ROOT_PATH + 'partials/navbar.html',
+        BASE_PATH + 'partials/navbar.html',
+        '/VendedorPro/partials/navbar.html'
+      ];
+    }
+
     return fetchWithFallback(paths)
       .then(function(html) {
         var container = document.getElementById(containerId);
@@ -129,7 +145,7 @@
     var paths = [
       ROOT_PATH + 'partials/auth-modals.html',
       BASE_PATH + 'partials/auth-modals.html',
-      '/partials/auth-modals.html'
+      '/VendedorPro/partials/auth-modals.html'
     ];
     return fetchWithFallback(paths)
       .then(function(html) {
@@ -266,8 +282,8 @@ document.addEventListener('sidebarLoaded', function () {
 })();
 
 /** === LAYOUT PERSISTENTE DO SIDEBAR/NAV === **/
-window.CUSTOM_SIDEBAR_PATH = window.CUSTOM_SIDEBAR_PATH || 'partials/sidebar.html';
-window.CUSTOM_NAVBAR_PATH  = window.CUSTOM_NAVBAR_PATH  || 'partials/navbar.html';
+window.CUSTOM_SIDEBAR_PATH = window.CUSTOM_SIDEBAR_PATH || '/VendedorPro/partials/sidebar.html';
+window.CUSTOM_NAVBAR_PATH  = window.CUSTOM_NAVBAR_PATH  || '/VendedorPro/partials/navbar.html';
 const PARTIALS_VERSION = '2025-08-25-02'; // mude quando atualizar parciais
 
 function toggleSidebar(){

--- a/saques.html
+++ b/saques.html
@@ -66,7 +66,7 @@
   </main>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="saques.js"></script>
-  <script>window.CUSTOM_SIDEBAR_PATH = 'partials/sidebar.html';</script>
+  <script>window.CUSTOM_SIDEBAR_PATH = '/VendedorPro/partials/sidebar.html';</script>
   <script src="shared.js"></script>
 </body>
 </html>

--- a/shared.js
+++ b/shared.js
@@ -81,16 +81,21 @@
 // Load sidebar HTML into placeholder
   window.loadSidebar = function(containerId, sidebarPath) {
     containerId = containerId || 'sidebar-container';
-    sidebarPath = sidebarPath || 'partials/sidebar.html';
+    sidebarPath = sidebarPath || '/VendedorPro/partials/sidebar.html';
 
-    var paths = [
-      ROOT_PATH + sidebarPath,
-      BASE_PATH + sidebarPath,
-      '/' + sidebarPath,
-      ROOT_PATH + 'partials/sidebar.html',
-      BASE_PATH + 'partials/sidebar.html',
-      '/partials/sidebar.html'
-    ];
+    var paths = [];
+    if (/^https?:\/\//.test(sidebarPath) || sidebarPath.startsWith('/')) {
+      paths = [sidebarPath];
+    } else {
+      paths = [
+        ROOT_PATH + sidebarPath,
+        BASE_PATH + sidebarPath,
+        '/VendedorPro/' + sidebarPath,
+        ROOT_PATH + 'partials/sidebar.html',
+        BASE_PATH + 'partials/sidebar.html',
+        '/VendedorPro/partials/sidebar.html'
+      ];
+    }
 
     return fetchWithFallback(paths)
       .then(function(html) {
@@ -106,13 +111,24 @@
       });
   };
 // Load navbar HTML into placeholder
-  window.loadNavbar = function(containerId) {
+  window.loadNavbar = function(containerId, navbarPath) {
     containerId = containerId || 'navbar-container';
-    var paths = [
-      ROOT_PATH + 'partials/navbar.html',
-      BASE_PATH + 'partials/navbar.html',
-      '/partials/navbar.html'
-    ];
+    navbarPath = navbarPath || '/VendedorPro/partials/navbar.html';
+
+    var paths = [];
+    if (/^https?:\/\//.test(navbarPath) || navbarPath.startsWith('/')) {
+      paths = [navbarPath];
+    } else {
+      paths = [
+        ROOT_PATH + navbarPath,
+        BASE_PATH + navbarPath,
+        '/VendedorPro/' + navbarPath,
+        ROOT_PATH + 'partials/navbar.html',
+        BASE_PATH + 'partials/navbar.html',
+        '/VendedorPro/partials/navbar.html'
+      ];
+    }
+
     return fetchWithFallback(paths)
       .then(function(html) {
         var container = document.getElementById(containerId);
@@ -130,7 +146,7 @@
     var paths = [
       ROOT_PATH + 'partials/auth-modals.html',
       BASE_PATH + 'partials/auth-modals.html',
-      '/partials/auth-modals.html'
+      '/VendedorPro/partials/auth-modals.html'
     ];
     return fetchWithFallback(paths)
       .then(function(html) {
@@ -267,8 +283,8 @@ document.addEventListener('sidebarLoaded', function () {
 })();
 
 /** === LAYOUT PERSISTENTE DO SIDEBAR/NAV === **/
-window.CUSTOM_SIDEBAR_PATH = window.CUSTOM_SIDEBAR_PATH || 'partials/sidebar.html';
-window.CUSTOM_NAVBAR_PATH  = window.CUSTOM_NAVBAR_PATH  || 'partials/navbar.html';
+window.CUSTOM_SIDEBAR_PATH = window.CUSTOM_SIDEBAR_PATH || '/VendedorPro/partials/sidebar.html';
+window.CUSTOM_NAVBAR_PATH  = window.CUSTOM_NAVBAR_PATH  || '/VendedorPro/partials/navbar.html';
 const PARTIALS_VERSION = '2025-08-25-02'; // mude quando atualizar parciais
 
 function toggleSidebar(){


### PR DESCRIPTION
## Summary
- Load sidebar, navbar, and auth modals using absolute paths under `/VendedorPro/partials` to prevent 404s in nested pages
- Update all HTML pages to reference the new absolute partial paths

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acadc4b618832a84b3df2508022ce9