### PR TITLE
Add mobile sidebar toggle and fix mobile layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1930,7 +1930,24 @@ body.dark .sidebar-link.active {
   background-color: #3b0c70;
 }
 
+/* Base layout spacing */
+.main-content {
+  margin-top: var(--navbar-height);
+  margin-left: 0;
+}
+
+/* Desktop sidebar beside content */
 @media (min-width:1024px){
-  .main-content { margin-left: 16rem; }
+  .main-content { margin-left: var(--sidebar-width); }
+}
+
+/* Mobile off-canvas sidebar */
+@media (max-width:768px){
+  .sidebar {
+    transform: translateX(-100%);
+  }
+  .sidebar.active {
+    transform: translateX(0);
+  }
 }
 

--- a/public/shared.js
+++ b/public/shared.js
@@ -387,6 +387,44 @@ window.addEventListener('resize', ()=>{
 window.toggleSidebar = window.toggleSidebar || toggleSidebar;
 window.ensureLayout  = ensureLayout;
 
+function setupMobileSidebar() {
+  const sidebar = document.getElementById('sidebar');
+  const btn = document.querySelector('.mobile-menu-btn');
+  if (!sidebar || !btn || btn.dataset.sidebarReady) return;
+
+  const open = () => {
+    sidebar.classList.add('active');
+    document.body.style.overflow = 'hidden';
+    btn.setAttribute('aria-expanded', 'true');
+  };
+  const close = () => {
+    sidebar.classList.remove('active');
+    document.body.style.overflow = '';
+    btn.setAttribute('aria-expanded', 'false');
+  };
+
+  btn.addEventListener('click', () => {
+    sidebar.classList.contains('active') ? close() : open();
+  });
+
+  document.addEventListener('click', (e) => {
+    if (window.innerWidth > 768) return;
+    if (!sidebar.contains(e.target) && !btn.contains(e.target)) close();
+  });
+
+  sidebar.querySelectorAll('a').forEach(a => a.addEventListener('click', close));
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth > 768) close();
+  });
+
+  btn.dataset.sidebarReady = 'true';
+}
+
+document.addEventListener('navbarLoaded', setupMobileSidebar);
+document.addEventListener('sidebarLoaded', setupMobileSidebar);
+document.addEventListener('DOMContentLoaded', setupMobileSidebar);
+
 // Controle de visibilidade do sidebar baseado no perfil do usuário
 let sidebarPermsApplied = false;
 document.addEventListener('sidebarLoaded', async () => {

--- a/shared.js
+++ b/shared.js
@@ -394,6 +394,44 @@ window.addEventListener('resize', ()=>{
 window.toggleSidebar = window.toggleSidebar || toggleSidebar;
 window.ensureLayout  = ensureLayout;
 
+function setupMobileSidebar() {
+  const sidebar = document.getElementById('sidebar');
+  const btn = document.querySelector('.mobile-menu-btn');
+  if (!sidebar || !btn || btn.dataset.sidebarReady) return;
+
+  const open = () => {
+    sidebar.classList.add('active');
+    document.body.style.overflow = 'hidden';
+    btn.setAttribute('aria-expanded', 'true');
+  };
+  const close = () => {
+    sidebar.classList.remove('active');
+    document.body.style.overflow = '';
+    btn.setAttribute('aria-expanded', 'false');
+  };
+
+  btn.addEventListener('click', () => {
+    sidebar.classList.contains('active') ? close() : open();
+  });
+
+  document.addEventListener('click', (e) => {
+    if (window.innerWidth > 768) return;
+    if (!sidebar.contains(e.target) && !btn.contains(e.target)) close();
+  });
+
+  sidebar.querySelectorAll('a').forEach(a => a.addEventListener('click', close));
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth > 768) close();
+  });
+
+  btn.dataset.sidebarReady = 'true';
+}
+
+document.addEventListener('navbarLoaded', setupMobileSidebar);
+document.addEventListener('sidebarLoaded', setupMobileSidebar);
+document.addEventListener('DOMContentLoaded', setupMobileSidebar);
+
 // Controle de visibilidade do sidebar baseado no perfil do usuário
 let sidebarPermsApplied = false;
 document.addEventListener('sidebarLoaded', async () => {


### PR DESCRIPTION
## Summary
- connect mobile menu button to JavaScript handler that toggles sidebar and locks body scroll
- add off-canvas sidebar behavior and responsive main-content spacing for mobile
- mirror sidebar setup in public assets

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acbd016bd4832a9a70730ee76af074