### PR TITLE
Fix mobile sidebar toggle in financial pages

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -352,9 +352,6 @@ input:checked + .dark-mode-slider:before {
   body.has-sidebar .content-wrapper {
     margin-left: 0;
   }
-  .mobile-menu-btn {
-    display: flex;
-  }
 }
 .badge {
   margin-left: 5px
@@ -619,6 +616,11 @@ tr:hover {
   align-items: center;
   justify-content: center;
   box-shadow: 0 2px 5px rgba(0,0,0,.2)
+}
+@media (max-width:768px) {
+  .mobile-menu-btn {
+    display: flex;
+  }
 }
 .app-container {
   display: flex;

--- a/financeiro-inicio.html
+++ b/financeiro-inicio.html
@@ -11,8 +11,8 @@
   <link rel="stylesheet" href="css/components.css" />
 </head>
 <body class="bg-gray-100 text-gray-800">
-  <button class="mobile-menu-btn" onclick="toggleSidebar()" aria-label="Abrir menu" aria-expanded="false">☰</button>
-  <div id="sidebar-container"></div>
+  <button class="mobile-menu-btn" aria-label="Abrir menu" aria-expanded="false">☰</button>
+  <div id="sidebar-container" class="-translate-x-full"></div>
   <div id="navbar-container"></div>
   <main class="main-content p-4 space-y-4">
     <h1 class="text-2xl font-bold">Área Financeira</h1>

--- a/financeiro.html
+++ b/financeiro.html
@@ -14,8 +14,8 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="bg-gray-100 text-gray-800">
-  <button class="mobile-menu-btn" onclick="toggleSidebar()" aria-label="Abrir menu" aria-expanded="false">☰</button>
-  <div id="sidebar-container"></div>
+  <button class="mobile-menu-btn" aria-label="Abrir menu" aria-expanded="false">☰</button>
+  <div id="sidebar-container" class="-translate-x-full"></div>
   <div id="navbar-container"></div>
   <main class="main-content p-4 space-y-4">
     <div class="card p-4 flex flex-wrap items-center gap-4">


### PR DESCRIPTION
## Summary
- Ensure mobile menu button appears on small screens
- Load financial pages with the sidebar hidden by default

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ace64945fc832aa2cccd8ced0ed3db