### PR TITLE
Adicionar link de acompanhamento de sobras para gestores

### DIFF
--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -111,6 +111,7 @@
         <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=registroFaturamento" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Faturamento</a></li>
         <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=controleVendas" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Vendas</a></li>
         <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamento" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Mensal</a></li>
+        <li data-perfil="gestor,mentor"><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamentoGestor" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Gestor</a></li>
         <li><a href="/VendedorPro/saques.html" class="sidebar-link block py-2 px-4 transition-colors">Saques</a></li>
         <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a></li>
       </ul>


### PR DESCRIPTION
## Sumário
- torna acessível no menu lateral o acompanhamento de sobras específico para gestores

## Testes
- `npm test` *(falhou: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ace6a9b85c832a8a42166cf6625c41