### PR TITLE
Fix sidebar loading on Ads and Monitoramento pages

### DIFF
--- a/ads.html
+++ b/ads.html
@@ -50,15 +50,9 @@
   </main>
 
   <!-- Scripts comuns -->
-  <script src="shared.js"></script>
   <script>
-    document.addEventListener("DOMContentLoaded", () => {
-      fetch("sidebar.html").then(r => r.text()).then(html => {
-        document.getElementById("sidebar-container").innerHTML = html;
-      });
-      fetch("navbar.html").then(r => r.text()).then(html => {
-        document.getElementById("navbar-container").innerHTML = html;
-      });
-    });
+    window.CUSTOM_SIDEBAR_PATH = '/VendedorPro/partials/sidebar.html';
+    window.CUSTOM_NAVBAR_PATH  = '/VendedorPro/partials/navbar.html';
   </script>
+  <script src="shared.js"></script>
 </body>

--- a/monitoramento.html
+++ b/monitoramento.html
@@ -34,17 +34,10 @@
 </div>
 <script type="module" src="firebase-config.js"></script>
 <script type="module" src="monitoramento.js"></script>
-  <script>
-  document.addEventListener("DOMContentLoaded", () => {
-    fetch("all_navbars.html").then(r => r.text()).then(html => {
-      document.getElementById("navbar-container").innerHTML = html;
-    });
-    fetch("layout.html").then(r => r.text()).then(html => {
-      document.getElementById("sidebar-container").innerHTML = html;
-    });
-  });
+<script>
+  window.CUSTOM_SIDEBAR_PATH = '/VendedorPro/partials/sidebar.html';
+  window.CUSTOM_NAVBAR_PATH  = '/VendedorPro/partials/navbar.html';
 </script>
-
 <script src="shared.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove outdated manual sidebar/navbar fetching in Ads and Monitoramento pages
- Explicitly set sidebar and navbar partial paths before loading shared script

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aceb6bc564832ab2f2aa659f2a04b7