### PR TITLE
Fix financeiro filter interactions and load aggregated sales chart

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -20,14 +20,18 @@
   <main class="main-content p-4 space-y-4">
     <div class="card p-4 flex flex-wrap items-center gap-4">
       <div class="flex items-center gap-2">
-        <i class="fa fa-user text-blue-500"></i>
+        <button type="button" id="usuarioIcon" class="text-blue-500 focus:outline-none">
+          <i class="fa fa-user"></i>
+        </button>
         <div class="flex flex-col">
           <label for="usuarioFiltro" class="text-xs font-medium">Usuário</label>
           <select id="usuarioFiltro" class="border rounded p-2 text-sm"></select>
         </div>
       </div>
       <div class="flex items-center gap-2">
-        <i class="fa fa-calendar text-blue-500"></i>
+        <button type="button" id="mesIcon" class="text-blue-500 focus:outline-none">
+          <i class="fa fa-calendar"></i>
+        </button>
         <div class="flex flex-col">
           <label for="mesFiltro" class="text-xs font-medium">Mês</label>
           <input type="month" id="mesFiltro" class="border rounded p-2 text-sm" />


### PR DESCRIPTION
## Summary
- Make user and month icons interactive buttons without unwanted redirects
- Prevent finance filter clicks from triggering hidden links and show proper pickers
- Aggregate faturamento across users when "todos" is selected and populate sales chart

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acee138a90832a96d5d708e5a29d73