### PR TITLE
Handle backend connectivity check without CORS error

### DIFF
--- a/login.js
+++ b/login.js
@@ -35,8 +35,8 @@ let selectedRole = null;
 export async function checkBackend() {
   if (!navigator.onLine) return false;
   try {
-    const res = await fetch('https://www.gstatic.com/generate_204', { cache: 'no-store' });
-    return res.ok;
+    await fetch('https://www.gstatic.com/generate_204', { cache: 'no-store', mode: 'no-cors' });
+    return true;
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
## Summary
- Avoid cross-origin failures in backend connectivity check by using `no-cors` mode and ignoring response

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acf007c908832aba706d81ef3d2bf0