### PR TITLE
Corrige alinhamento das abas do menu de vendas

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -753,7 +753,8 @@ tr:hover {
   background: #fff;
   border-radius: 12px;
   padding: .5rem;
-  box-shadow: var(--card-shadow)
+  box-shadow: var(--card-shadow);
+  justify-content: center;
 }
 .tab-btn {
   padding: .8rem 1.5rem;
@@ -767,7 +768,8 @@ tr:hover {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-family: Inter,sans-serif
+  font-family: Inter,sans-serif;
+  justify-content: center;
 }
 .tab-btn.active,
 .tab-btn:hover {
@@ -1347,7 +1349,7 @@ body.dark-mode th {
 }
 
 .submenu {
-  padding-left: 1rem
+  padding-left: 0
 }
 
 .submenu a {

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -124,7 +124,7 @@
           </svg>
         </button>
       </div>
-      <ul id="menuVendas" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
+      <ul id="menuVendas" class="submenu space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
         <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar" class="sidebar-link block py-2 px-4 transition-colors">Conferir Sobras</a></li>
         <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento" class="sidebar-link block py-2 px-4 transition-colors">Registrar Faturamento</a></li>
         <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=registroFaturamento" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Faturamento</a></li>


### PR DESCRIPTION
## Summary
- Alinha centralmente as abas do menu de vendas para evitar deslocamento do conteúdo
- Remove recuo extra no submenu de vendas

## Testing
- `npm test` *(erro: package.json ausente)*

------
https://chatgpt.com/codex/tasks/task_e_68acf1b6ab10832ab19e735234c1ecca