### PR TITLE
Fix login form structure and ping path

### DIFF
--- a/login.html
+++ b/login.html
@@ -5,15 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Login - VendedorPro</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="icon" href="icons/icon-192.png">
 </head>
 <body class="flex items-center justify-center h-screen bg-gray-50">
   <div class="w-full max-w-sm p-6 bg-white rounded shadow">
     <h1 class="mb-4 text-2xl font-bold text-center">Login</h1>
-    <div id="offlineNotice" class="hidden mb-4 text-center text-red-600">Sem conexão com o servidor.</div>
-    <input id="loginEmail" type="email" placeholder="E-mail" class="w-full p-2 mb-3 border rounded">
-    <input id="loginPassword" type="password" placeholder="Senha" class="w-full p-2 mb-3 border rounded">
-    <input id="loginPassphrase" type="text" placeholder="Passphrase (opcional)" class="w-full p-2 mb-3 border rounded">
-    <button id="loginButton" class="w-full py-2 font-semibold text-white bg-orange-600 hover:bg-orange-700 rounded" style="background-color:#FF7043" onclick="login()">Entrar</button>
+    <form id="loginForm" onsubmit="login(); return false;">
+      <div id="offlineNotice" class="hidden mb-4 text-center text-red-600">Sem conexão com o servidor.</div>
+      <input id="loginEmail" type="email" placeholder="E-mail" class="w-full p-2 mb-3 border rounded">
+      <input id="loginPassword" type="password" placeholder="Senha" class="w-full p-2 mb-3 border rounded">
+      <input id="loginPassphrase" type="text" placeholder="Passphrase (opcional)" class="w-full p-2 mb-3 border rounded">
+      <button id="loginButton" type="submit" class="w-full py-2 font-semibold text-white bg-orange-600 hover:bg-orange-700 rounded" style="background-color:#FF7043">Entrar</button>
+    </form>
     <div id="toastContainer" class="mt-4"></div>
   </div>
   <script type="module" src="login.js"></script>

--- a/login.js
+++ b/login.js
@@ -36,7 +36,7 @@ async function pingOnline(timeout = 3000) {
   try {
     const ctrl = new AbortController();
     const t = setTimeout(() => ctrl.abort(), timeout);
-    const res = await fetch('/ping.txt?cb=' + Date.now(), {
+    const res = await fetch('ping.txt?cb=' + Date.now(), {
       cache: 'no-store',
       signal: ctrl.signal
     });


### PR DESCRIPTION
## Summary
- wrap login fields in a form to eliminate password warning
- add favicon link for browser support
- adjust ping file fetch to relative path

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check login.js`


------
https://chatgpt.com/codex/tasks/task_e_68acf27583b0832ab84acf435162cf51