### PR TITLE
Wrap password inputs in forms and update intro.js usage

### DIFF
--- a/login.html
+++ b/login.html
@@ -10,10 +10,12 @@
   <div class="w-full max-w-sm p-6 bg-white rounded shadow">
     <h1 class="mb-4 text-2xl font-bold text-center">Login</h1>
     <div id="offlineNotice" class="hidden mb-4 text-center text-red-600">Sem conexão com o servidor.</div>
-    <input id="loginEmail" type="email" placeholder="E-mail" class="w-full p-2 mb-3 border rounded">
-    <input id="loginPassword" type="password" placeholder="Senha" class="w-full p-2 mb-3 border rounded">
-    <input id="loginPassphrase" type="text" placeholder="Passphrase (opcional)" class="w-full p-2 mb-3 border rounded">
-    <button id="loginButton" class="w-full py-2 font-semibold text-white bg-orange-600 hover:bg-orange-700 rounded" style="background-color:#FF7043" onclick="login()">Entrar</button>
+    <form onsubmit="login(); return false;">
+      <input id="loginEmail" type="email" placeholder="E-mail" class="w-full p-2 mb-3 border rounded">
+      <input id="loginPassword" type="password" placeholder="Senha" class="w-full p-2 mb-3 border rounded">
+      <input id="loginPassphrase" type="password" placeholder="Passphrase (opcional)" class="w-full p-2 mb-3 border rounded">
+      <button id="loginButton" type="submit" class="w-full py-2 font-semibold text-white bg-orange-600 hover:bg-orange-700 rounded" style="background-color:#FF7043">Entrar</button>
+    </form>
     <div id="toastContainer" class="mt-4"></div>
   </div>
   <script type="module" src="login.js"></script>

--- a/partials/auth-modals.html
+++ b/partials/auth-modals.html
@@ -20,7 +20,7 @@
       </div>
     </div>
 
-    <div id="loginForm" class="space-y-6 hidden">
+    <form id="loginForm" class="space-y-6 hidden" onsubmit="login(); return false;">
       <div>
         <label class="block text-sm font-medium mb-2 text-gray-700">E-mail</label>
         <div class="relative">
@@ -56,7 +56,7 @@
           <input type="password" id="loginPassphrase" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
         </div>
       </div>
-      <button onclick="login()" class="btn-primary w-full py-3.5">
+      <button type="submit" class="btn-primary w-full py-3.5">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6A2.25 2.25 0 0 0 5.25 5.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9"/>
         </svg> Entrar
@@ -70,7 +70,7 @@
           <a href="/VendedorPro/cadastro-interesse.html" class="text-sm text-blue-600 hover:text-blue-800 font-medium">Não é cliente? Cadastre-se</a>
         </div>
       </div>
-    </div>
+    </form>
   </div>
 </div>
 
@@ -123,14 +123,14 @@
       <p class="text-gray-600 mt-2">Digite a senha para acessar dados criptografados</p>
     </div>
 
-    <div class="space-y-6">
+    <form class="space-y-6" onsubmit="savePassphrase(); return false;">
       <input type="password" id="passphraseInput" class="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
-      <button onclick="savePassphrase()" class="btn-primary w-full py-3.5">
+      <button type="submit" class="btn-primary w-full py-3.5">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75 10.5 18.75 19.5 5.25"/>
       </svg> Confirmar
       </button>
-    </div>
+    </form>
   </div>
 </div>
 

--- a/public/partials/auth-modals.html
+++ b/public/partials/auth-modals.html
@@ -18,7 +18,7 @@
       </div>
     </div>
 
-    <div id="loginForm" class="space-y-6 hidden">
+    <form id="loginForm" class="space-y-6 hidden" onsubmit="login(); return false;">
       <div>
         <label class="block text-sm font-medium mb-2 text-gray-700">E-mail</label>
         <div class="relative">
@@ -47,7 +47,7 @@
           <input type="password" id="loginPassphrase" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
         </div>
       </div>
-      <button onclick="login()" class="btn-primary w-full py-3.5">
+      <button type="submit" class="btn-primary w-full py-3.5">
         <i class="fas fa-sign-in-alt mr-2"></i> Entrar
       </button>
 
@@ -59,7 +59,7 @@
           <a href="/VendedorPro/cadastro-interesse.html" class="text-sm text-blue-600 hover:text-blue-800 font-medium">Não é cliente? Cadastre-se</a>
         </div>
       </div>
-    </div>
+    </form>
   </div>
 </div>
 
@@ -104,12 +104,12 @@
       <p class="text-gray-600 mt-2">Digite a senha para acessar dados criptografados</p>
     </div>
 
-    <div class="space-y-6">
+    <form class="space-y-6" onsubmit="savePassphrase(); return false;">
       <input type="password" id="passphraseInput" class="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
-      <button onclick="savePassphrase()" class="btn-primary w-full py-3.5">
+      <button type="submit" class="btn-primary w-full py-3.5">
         <i class="fas fa-check mr-2"></i> Confirmar
       </button>
-    </div>
+    </form>
   </div>
 </div>
 

--- a/public/shared.js
+++ b/public/shared.js
@@ -199,7 +199,7 @@
   window.startSidebarTour = function(force) {
     if (typeof introJs === 'undefined') return;
     if (!force && localStorage.getItem('sidebarTourSeen') === 'true') return;
-    var intro = introJs();
+    var intro = introJs.tour();
     intro.setOptions({
       steps: [
         { element: '#menu-inicio', intro: 'Voltar para a página inicial.' },

--- a/shared.js
+++ b/shared.js
@@ -199,7 +199,7 @@
   window.startSidebarTour = function(force) {
     if (typeof introJs === 'undefined') return;
     if (!force && localStorage.getItem('sidebarTourSeen') === 'true') return;
-    var intro = introJs();
+    var intro = introJs.tour();
     intro.setOptions({
       steps: [
         { element: '#menu-inicio', intro: 'Voltar para a página inicial.' },


### PR DESCRIPTION
## Summary
- replace deprecated `introJs()` call with `introJs.tour()`
- wrap password inputs in forms and submit buttons for login and passphrase modals
- convert login passphrase field to password type

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acf2911390832a993e8e70a1e36b79