### PR TITLE
Include gestor tracking tab in admin menus

### DIFF
--- a/public/shared.js
+++ b/public/shared.js
@@ -441,6 +441,7 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-financeiro',
     'menu-atualizacoes',
     'menu-saques',
+    'menu-acompanhamento-gestor',
     'menu-mentoria',
     'menu-perfil-mentorado',
     'menu-equipes',

--- a/shared.js
+++ b/shared.js
@@ -458,6 +458,7 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-financeiro',
     'menu-atualizacoes',
     'menu-saques',
+    'menu-acompanhamento-gestor',
     'menu-mentoria',
     'menu-perfil-mentorado',
     'menu-equipes',


### PR DESCRIPTION
## Summary
- include 'Acompanhamento Gestor' tab in gestor sidebar menu array

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acf4339528832aaf75205b2210d1a6