### PR TITLE
Persist login role to index page

### DIFF
--- a/login.html
+++ b/login.html
@@ -15,6 +15,10 @@
       <input id="loginEmail" type="email" placeholder="E-mail" class="w-full p-2 mb-3 border rounded">
       <input id="loginPassword" type="password" placeholder="Senha" class="w-full p-2 mb-3 border rounded">
       <input id="loginPassphrase" type="password" placeholder="Passphrase (opcional)" class="w-full p-2 mb-3 border rounded">
+      <select id="roleSelect" class="w-full p-2 mb-3 border rounded">
+        <option value="usuario">Usuário</option>
+        <option value="gestor">Gestor</option>
+      </select>
 
       <button id="loginButton" type="submit" class="w-full py-2 font-semibold text-white bg-orange-600 hover:bg-orange-700 rounded" style="background-color:#FF7043">Entrar</button>
     </form>


### PR DESCRIPTION
## Summary
- Add role selector to login page
- Store chosen role and redirect to index after login
- Make login helper functions resilient and apply stored role across pages

## Testing
- `node --check login.js`
- `npx -y htmlhint login.html`


------
https://chatgpt.com/codex/tasks/task_e_68acf52f0bbc832ab8c5c35c049dd51c