### PR TITLE
Improve mobile layout with collapsible sidebar

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -13,6 +13,13 @@
   box-shadow: 0 15px 25px -3px rgba(0,0,0,0.1), 0 10px 10px -3px rgba(0,0,0,0.04);
   transform: translateY(-2px);
 }
+
+@media (max-width:768px) {
+  .card {
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+  }
+}
 .card-header {
   display: flex;
   align-items: center;

--- a/css/styles.css
+++ b/css/styles.css
@@ -1472,6 +1472,12 @@ body.dark-mode th {
   background: var(--primary);
   border-radius: 3px 3px 0 0
 }
+@media (max-width:768px) {
+  .tabs {
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+  }
+}
 .tab-content {
   display: none;
   max-width: 1200px;

--- a/public/shared.js
+++ b/public/shared.js
@@ -403,8 +403,19 @@ function setupMobileSidebar() {
   sidebar.querySelectorAll('a').forEach(a => a.addEventListener('click', close));
 
   window.addEventListener('resize', () => {
-    if (window.innerWidth > 768) close();
+    if (window.innerWidth > 768) {
+      container.classList.remove('-translate-x-full');
+      sidebar.classList.remove('active');
+      document.body.style.overflow = '';
+      btn.setAttribute('aria-expanded', 'false');
+    } else {
+      close();
+    }
   });
+
+  if (window.innerWidth <= 768) {
+    close();
+  }
 
   btn.dataset.sidebarReady = 'true';
 }

--- a/shared.js
+++ b/shared.js
@@ -410,8 +410,19 @@ function setupMobileSidebar() {
   sidebar.querySelectorAll('a').forEach(a => a.addEventListener('click', close));
 
   window.addEventListener('resize', () => {
-    if (window.innerWidth > 768) close();
+    if (window.innerWidth > 768) {
+      container.classList.remove('-translate-x-full');
+      sidebar.classList.remove('active');
+      document.body.style.overflow = '';
+      btn.setAttribute('aria-expanded', 'false');
+    } else {
+      close();
+    }
   });
+
+  if (window.innerWidth <= 768) {
+    close();
+  }
 
   btn.dataset.sidebarReady = 'true';
 }


### PR DESCRIPTION
## Summary
- Hide sidebar by default on small screens and expose toggle logic for mobile
- Reduce horizontal margins for cards and tabs on mobile for better spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad05234338832a94a5e4dc1d723f38