### PR TITLE
refactor: clean up CSS and unify navbar

### DIFF
--- a/all_navbars.html
+++ b/all_navbars.html
@@ -13,7 +13,7 @@
   <div id="navbar-container"></div>
   <div class="main-content">
   <!-- Top Navbar from index.html -->
-  <div class="top-navbar">
+    <div class="navbar">
     <div class="flex items-center">
       <button class="mobile-menu-btn mr-4 text-gray-600 md:hidden" aria-label="Abrir menu" aria-expanded="false">
         <i class="fas fa-bars text-xl"></i>

--- a/css/styles.css
+++ b/css/styles.css
@@ -49,23 +49,6 @@ body {
   color: var(--text-dark);
 }
 
-.top-navbar {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 60px;
-  background-color: var(--nav-bg);
-  box-shadow: 0 2px 10px rgba(0,0,0,.05);
-  z-index: 30;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 20px;
-  transition: .3s;
-  color: #fff;
-}
-
 .content-wrapper {
   flex: 1;
   margin-left: 0;
@@ -73,7 +56,7 @@ body {
   padding: 30px;
 }
 
-body.has-sidebar .top-navbar {
+body.has-sidebar .navbar {
   left: var(--sidebar-width);
 }
 
@@ -161,9 +144,6 @@ input:checked + .dark-mode-slider {
 }
 input:checked + .dark-mode-slider:before {
   transform: translateX(26px)
-}
-.tooltip .tooltip-text {
-  background-color: var(--dark)
 }
 /* Caixa principal */
 .introjs-tooltip {
@@ -346,7 +326,7 @@ input:checked + .dark-mode-slider:before {
 @media (max-width:768px) {
   /* Sidebar visibility is handled via #sidebar-container classes.
      Removing legacy transforms prevents double translations on mobile. */
-  body.has-sidebar .top-navbar {
+  body.has-sidebar .navbar {
     left: 0;
   }
   body.has-sidebar .content-wrapper {
@@ -394,35 +374,7 @@ h4 {
   color: var(--secondary);
   margin-top: 0;
   margin-bottom: 10px;
-}
-  font-size: 1.1rem
-}
-input,
-select {
-  border: 1px solid var(--border);
-  transition: .3s;
-  font-family: Inter,sans-serif
-}
-label {
-  display: block;
-  margin-bottom: 8px;
-  font-weight: 500;
-  color: var(--text-dark)
-}
-button {
-  background: var(--primary);
-  color: #fff;
-  border: none;
-  padding: 12px 25px;
-  border-radius: 30px;
-  cursor: pointer;
-  transition: .3s;
-  font-size: 16px
-}
-button:hover {
-  background: var(--hover);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0,0,0,.15)
+  font-size: 1.1rem;
 }
 
 .result {
@@ -528,28 +480,6 @@ tr:hover {
   font-size: .9rem;
   border-top: 1px solid var(--border)
 }
-  h2 {
-    font-family: Inter,sans-serif;
-    color: var(--secondary);
-    margin-top: 30px;
-    padding-bottom: 10px;
-    border-bottom: 2px solid var(--border);
-    font-size: 1.6rem
-  }
-  h3 {
-    font-family: Inter,sans-serif;
-    color: var(--secondary);
-    margin-top: 25px;
-    margin-bottom: 15px;
-    font-size: 1.3rem
-  }
-  h4 {
-    font-family: Inter,sans-serif;
-    color: var(--secondary);
-    margin-top: 0;
-    margin-bottom: 10px;
-    font-size: 1.1rem
-  }
   input,
   select {
     padding: 12px;
@@ -598,7 +528,6 @@ tr:hover {
   .flex-container {
     flex-direction: column
   }
-}
 .mobile-menu-btn {
   display: none;
   position: fixed;
@@ -1244,10 +1173,6 @@ tr:hover td {
   padding-top: .5rem;
   padding-bottom: .5rem
 }
-.tooltip .tooltip-text {
-  background-color: var(--secondary);
-  transform: translateX(-50%)
-}
 .menu-toggle {
   display: none;
   background: 0 0;
@@ -1419,7 +1344,7 @@ body.dark-mode th {
 }
 .main-content {
   margin-top: 70px;
-  margin-left: 260px;
+  margin-left: var(--sidebar-width);
   padding: 25px;
   min-height: calc(100vh - 70px)
 }

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,4 +1,4 @@
- <div class="top-navbar">
+  <div class="navbar">
       <div class="flex items-center">
         <button class="mobile-menu-btn mr-4 text-gray-200 md:hidden" aria-label="Abrir menu" aria-expanded="false">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">


### PR DESCRIPTION
## Summary
- remove top-navbar usage and standardize on navbar
- fix h4 block and drop duplicate rules for headings, inputs, buttons, and tooltips
- replace hardcoded 260px margin with --sidebar-width and tidy stray brace

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9c7ed85c832a9730d89c4b286857