### PR TITLE
Mostrar apenas pedidos críticos no acompanhamento de sobras do gestor

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -2605,10 +2605,10 @@ async function verificarGestorFinanceiro() {
 async function carregarAcompanhamentoGestor() {
   const totalEl = document.getElementById('totalSobraGestor');
   const tbody = document.querySelector('#tabelaSobraSkuGestor tbody');
-  const lista = document.getElementById('listaPedidosErradosGestor');
+  const pedidosBody = document.querySelector('#tabelaPedidosCriticosGestor tbody');
   if (totalEl) totalEl.textContent = 'Carregando...';
   if (tbody) tbody.innerHTML = '';
-  if (lista) lista.innerHTML = '';
+  if (pedidosBody) pedidosBody.innerHTML = '';
 
   try {
     const usuariosSnap = await db.collection('usuarios')
@@ -2666,23 +2666,32 @@ async function carregarAcompanhamentoGestor() {
         tbody.appendChild(tr);
       });
     }
-
-    if (lista) {
-      if (!pedidosErrados.length) {
-        lista.innerHTML = '<li class="text-gray-500">Sem divergências</li>';
+    if (pedidosBody) {
+      const pedidosCriticos = pedidosErrados.filter(p => {
+        const esp = Number(p.sobraEsperada || p.metaEsperada || 0);
+        const real = Number(p.sobraReal || p.totalLiquido || 0);
+        if (!esp) return false;
+        const perc = ((real - esp) / esp) * 100;
+        return perc <= -10;
+      });
+      if (!pedidosCriticos.length) {
+        pedidosBody.innerHTML = '<tr><td colspan="5" class="text-center text-gray-500">Sem pedidos críticos</td></tr>';
       } else {
-        pedidosErrados.forEach(p => {
-          const li = document.createElement('li');
-          const esp = p.sobraEsperada || p.metaEsperada || 0;
-          const real = p.sobraReal || p.totalLiquido || 0;
-          li.textContent = `${p.usuario} - ${p.dia || ''} - ${p.sku}: Esperado R$ ${esp.toFixed(2)} | Real R$ ${real.toFixed(2)}`;
-          lista.appendChild(li);
+        pedidosCriticos.forEach(p => {
+          const pedido = p.pedido || p.numeroPedido || p.id || '';
+          const sku = p.sku || '';
+          const qtd = p.quantidade || p.qtd || 0;
+          const esp = Number(p.sobraEsperada || p.metaEsperada || 0);
+          const real = Number(p.sobraReal || p.totalLiquido || 0);
+          const tr = document.createElement('tr');
+          tr.innerHTML = `<td>${pedido}</td><td>${sku}</td><td>${qtd}</td><td>R$ ${esp.toFixed(2)}</td><td>R$ ${real.toFixed(2)}</td>`;
+          pedidosBody.appendChild(tr);
         });
       }
     }
   } catch (e) {
     console.error('Erro ao carregar acompanhamento do gestor', e);
-    if (lista) lista.innerHTML = '<li class="text-red-500">Erro ao carregar dados</li>';
+    if (pedidosBody) pedidosBody.innerHTML = '<tr><td colspan="5" class="text-red-500">Erro ao carregar dados</td></tr>';
   }
 }
 window.carregarRegistrosFaturamento = carregarRegistrosFaturamento;

--- a/sobras-tabs/acompanhamentoGestor.html
+++ b/sobras-tabs/acompanhamentoGestor.html
@@ -18,8 +18,21 @@
       </table>
     </div>
     <div>
-      <h4 class="text-lg font-semibold mb-2">Pedidos com sobra divergente</h4>
-      <ul id="listaPedidosErradosGestor" class="list-disc pl-6 text-sm space-y-1"></ul>
+      <h4 class="text-lg font-semibold mb-2">Pedidos críticos (sobra muito abaixo)</h4>
+      <div class="table-container overflow-x-auto rounded-lg shadow">
+        <table id="tabelaPedidosCriticosGestor" class="data-table min-w-full text-sm text-left">
+          <thead>
+            <tr class="bg-indigo-50 text-indigo-700">
+              <th class="py-3 px-4 font-bold">Pedido</th>
+              <th class="py-3 px-4 font-bold">SKU</th>
+              <th class="py-3 px-4 font-bold">Quantidade</th>
+              <th class="py-3 px-4 font-bold">Sobra Esperada</th>
+              <th class="py-3 px-4 font-bold">Sobra Real</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white divide-y divide-gray-100"></tbody>
+        </table>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Mostrar tabela de pedidos críticos com número, SKU, quantidade e sobras
- Filtrar e exibir apenas pedidos com sobras muito abaixo do esperado

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9d65b618832a93fe561f570c8104