### PR TITLE
Mostrar apenas pedidos críticos no acompanhamento do gestor

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -2671,28 +2671,32 @@ async function carregarAcompanhamentoGestor() {
       const pedidosCriticos = pedidosErrados.filter(p => {
         const esp = Number(p.sobraEsperada || p.metaEsperada || 0);
         const real = Number(p.sobraReal || p.totalLiquido || 0);
+        const status = String(p.status || p.nivel || '').toLowerCase();
+        const criticoFlag = p.critico || status.includes('critico');
+        if (criticoFlag) return true;
         if (!esp) return false;
         const perc = ((real - esp) / esp) * 100;
         return perc <= -10;
       });
       if (!pedidosCriticos.length) {
-        pedidosBody.innerHTML = '<tr><td colspan="5" class="text-center text-gray-500">Sem pedidos críticos</td></tr>';
+        pedidosBody.innerHTML = '<tr><td colspan="6" class="text-center text-gray-500">Sem pedidos críticos</td></tr>';
       } else {
         pedidosCriticos.forEach(p => {
+          const dataPedido = p.dia || p.dataPedido || p.data || '';
           const pedido = p.pedido || p.numeroPedido || p.id || '';
           const sku = p.sku || '';
           const qtd = p.quantidade || p.qtd || 0;
           const esp = Number(p.sobraEsperada || p.metaEsperada || 0);
           const real = Number(p.sobraReal || p.totalLiquido || 0);
           const tr = document.createElement('tr');
-          tr.innerHTML = `<td>${pedido}</td><td>${sku}</td><td>${qtd}</td><td>R$ ${esp.toFixed(2)}</td><td>R$ ${real.toFixed(2)}</td>`;
+          tr.innerHTML = `<td>${dataPedido}</td><td>${pedido}</td><td>${sku}</td><td>${qtd}</td><td>R$ ${esp.toFixed(2)}</td><td>R$ ${real.toFixed(2)}</td>`;
           pedidosBody.appendChild(tr);
         });
       }
     }
   } catch (e) {
     console.error('Erro ao carregar acompanhamento do gestor', e);
-    if (pedidosBody) pedidosBody.innerHTML = '<tr><td colspan="5" class="text-red-500">Erro ao carregar dados</td></tr>';
+    if (pedidosBody) pedidosBody.innerHTML = '<tr><td colspan="6" class="text-red-500">Erro ao carregar dados</td></tr>';
   }
 }
 window.carregarRegistrosFaturamento = carregarRegistrosFaturamento;

--- a/sobras-tabs/acompanhamentoGestor.html
+++ b/sobras-tabs/acompanhamentoGestor.html
@@ -23,6 +23,7 @@
         <table id="tabelaPedidosCriticosGestor" class="data-table min-w-full text-sm text-left">
           <thead>
             <tr class="bg-indigo-50 text-indigo-700">
+              <th class="py-3 px-4 font-bold">Data</th>
               <th class="py-3 px-4 font-bold">Pedido</th>
               <th class="py-3 px-4 font-bold">SKU</th>
               <th class="py-3 px-4 font-bold">Quantidade</th>


### PR DESCRIPTION
## Summary
- Exibe apenas pedidos críticos no acompanhamento de sobras do gestor
- Adiciona coluna de data e detalhes de sobra por pedido

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/VendedorPro/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68ada192b654832ab316d780c576ed89