### PR TITLE
Adiciona detalhe de vendas por SKU no acompanhamento mensal

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -2371,15 +2371,63 @@ const dias = dadosAcompanhamento.length;
       const resumoLiquidoMeta = metaLiquidoDiario ? `<small>${diffLiquido >= 0 ? 'Acima' : 'Abaixo'} da meta (${percLiquido.toFixed(2)}%, R$ ${Math.abs(diffLiquido).toLocaleString('pt-BR')})</small>` : '';
       
       resumoEl.classList.add('resumo-grid');
-      resumoEl.innerHTML = `
+resumoEl.innerHTML = `
    <div class="resumo-card"><h4>Total Bruto</h4><p>R$ ${totais.bruto.toLocaleString('pt-BR')}</p>${resumoBrutoMeta}</div>
         <div class="resumo-card"><h4>Total Líquido</h4><p>R$ ${totais.liquido.toLocaleString('pt-BR')}</p>${resumoLiquidoMeta}</div>
-        <div class="resumo-card"><h4>Total Vendido</h4><p>${totais.vendas}</p></div>
+        <div class="resumo-card"><h4>Total Vendido</h4><p>${totais.vendas}</p><button class="btn btn-secondary btn-sm" style="margin-top:0.5rem" onclick="mostrarDetalhesVendas()">Ver mais</button></div>
         <div class="resumo-card"><h4>Total Sobra Esperada</h4><p>R$ ${totais.sobra.toLocaleString('pt-BR')}</p><button class="btn btn-secondary btn-sm" style="margin-top:0.5rem" onclick="mostrarDetalhesSobra()">Ver mais</button></div>
         <div class="resumo-card"><h4>Total Saques</h4><p>R$ ${totalSaques.toLocaleString('pt-BR')}</p></div>
         <div class="resumo-card"><h4>Comissão do Mês</h4><p>R$ ${totalComissao.toLocaleString('pt-BR')}</p></div>
         <div class="resumo-card"><h4>Ticket Médio</h4><p>R$ ${ticket.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</p></div>`;
     }
+
+function mostrarDetalhesVendas(data = resumoSku) {
+  if (!data || !Object.keys(data).length) {
+    Swal.fire('Sem dados', 'Não há informações de vendas por SKU para o período selecionado.', 'info');
+    return;
+  }
+
+  const entries = Object.entries(data)
+    .map(([sku, info]) => [sku, Number(info.vendas) || 0])
+    .sort((a, b) => b[1] - a[1]);
+
+  const total = entries.reduce((acc, [, v]) => acc + v, 0);
+
+  let rows = '';
+  for (const [sku, qtd] of entries) {
+    rows += `
+      <tr>
+        <td style="padding:8px 10px;border-bottom:1px solid #eee;"><strong>${sku}</strong></td>
+        <td style="padding:8px 10px;border-bottom:1px solid #eee;text-align:right;">${qtd}</td>
+      </tr>`;
+  }
+
+  const html = `
+    <div style="text-align:left; max-height:60vh; overflow:auto;">
+      <table style="width:100%; border-collapse:collapse; font-size:14px;">
+        <thead>
+          <tr>
+            <th style="text-align:left; padding:8px 10px; border-bottom:1px solid #ddd;">SKU</th>
+            <th style="text-align:right; padding:8px 10px; border-bottom:1px solid #ddd;">Quantidade Vendida</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+        <tfoot>
+          <tr>
+            <td style="padding:10px; font-weight:600; border-top:2px solid #ddd;">Total</td>
+            <td style="padding:10px; text-align:right; font-weight:600; border-top:2px solid #ddd;">${total}</td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>`;
+
+  Swal.fire({
+    title: 'Vendas por SKU',
+    html,
+    width: '80%',
+    confirmButtonText: 'Fechar'
+  });
+}
 
 function mostrarDetalhesSobra(data = sobraPorSku) {
   if (!data || !Object.keys(data).length) {


### PR DESCRIPTION
## Summary
- exibe botão de detalhes no card **Total Vendido**
- apresenta vendas mensais por SKU em modal dedicado

## Testing
- `npm test` *(falhou: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ada1d9dfc8832a9de94ffcc20264eb