### PR TITLE
fix: expose detalhes de vendas

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -2774,6 +2774,7 @@ window.exportarAcompanhamentoPDF = exportarAcompanhamentoPDF;
 window.printAcompanhamento = printAcompanhamento;
   window.salvarMetasAcompanhamento = salvarMetasAcompanhamento;
 window.exportarVendasMes = exportarVendasMes;
+window.mostrarDetalhesVendas = mostrarDetalhesVendas;
 window.mostrarDetalhesSobra = mostrarDetalhesSobra;
 window.mostrarDetalhesFaturamento = mostrarDetalhesFaturamento;
 window.excluirFaturamento = excluirFaturamento;


### PR DESCRIPTION
## Summary
- expose `mostrarDetalhesVendas` in global scope so its button works

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ada4a1618c832a9507aa783a8fa224