### PR TITLE
feat: add sales forecast

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -72,6 +72,9 @@
         <button class="tab-btn" onclick="trocarAba('controleVendas'); carregarControleVendas()">
           <i class="fas fa-boxes"></i> Controle de Vendas
          </button>
+        <button class="tab-btn" onclick="trocarAba('previsao'); carregarPrevisao()">
+          <i class="fas fa-chart-area"></i> 📈 Previsão
+        </button>
         <button class="tab-btn" onclick="trocarAba('acompanhamento'); carregarAcompanhamento()">
           <i class="fas fa-chart-line"></i> Acompanhamento
         </button>
@@ -113,7 +116,12 @@
 
       <!-- Aba de Controle de Vendas -->
       <div id="controleVendas" class="tab-content">
-       
+
+      </div>
+
+      <!-- Aba de Previsão -->
+      <div id="previsao" class="tab-content">
+
       </div>
 
       <!-- Aba de Acompanhamento -->
@@ -152,10 +160,11 @@
       let totalSaquesAcompanhamento = 0;
       let totalComissaoAcompanhamento = 0;
       let usuarioLogado = { uid: null, perfil: '' };
-      let pedidosProcessados = [];
-      let graficoBarras, graficoPizza;
-      const API_URL = 'https://us-central1-matheus-35023.cloudfunctions.net/proxyDeepSeek';
-   const tabIds = ['importar','metas','graficos','historico','faturamento','registroFaturamento','controleVendas','acompanhamento','acompanhamentoGestor'];
+let pedidosProcessados = [];
+let graficoBarras, graficoPizza, graficoPrevisao;
+let previsaoDados = {};
+const API_URL = 'https://us-central1-matheus-35023.cloudfunctions.net/proxyDeepSeek';
+   const tabIds = ['importar','metas','graficos','historico','faturamento','registroFaturamento','controleVendas','previsao','acompanhamento','acompanhamentoGestor'];
       const tabsLoaded = Promise.all(
         tabIds.map(t =>
           fetch(`sobras-tabs/${t}.html`)
@@ -1936,9 +1945,11 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
     async function carregarControleVendas() {
       const container = document.getElementById("listaControleVendas");
       const resumoContainer = document.getElementById("resumoMensalVendas");
+      const projecaoContainer = document.getElementById("cardsProjecao");
       const filtroMes = document.getElementById("filtroMesVendas")?.value;
       container.innerHTML = "🔄 Carregando...";
       if (resumoContainer) resumoContainer.innerHTML = "";
+      if (projecaoContainer) projecaoContainer.innerHTML = "🔄 Carregando...";
 
       let ref;
       if (["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())) {
@@ -1947,6 +1958,48 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
         ref = db.collection('uid').doc(usuarioLogado.uid).collection('skusVendidos');
       }
       const snap = await ref.get();
+
+      if (projecaoContainer) {
+        const hoje = new Date();
+        const proxMes = new Date(hoje.getFullYear(), hoje.getMonth() + 1, 1);
+        const anoMesPrev = proxMes.toISOString().slice(0, 7);
+        try {
+          if (["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())) {
+            const prevSnap = await db.collectionGroup('previsoes')
+              .where(firebase.firestore.FieldPath.documentId(), '==', anoMesPrev)
+              .get();
+            const totalPrev = {};
+            prevSnap.forEach(doc => {
+              const dados = doc.data();
+              if (dados.skus) {
+                Object.entries(dados.skus).forEach(([sku, info]) => {
+                  totalPrev[sku] = (totalPrev[sku] || 0) + (info.total || 0);
+                });
+              }
+            });
+            if (Object.keys(totalPrev).length) {
+              projecaoContainer.innerHTML = Object.entries(totalPrev)
+                .map(([sku, total]) => `<div class="bg-yellow-100 text-yellow-800 p-4 rounded shadow flex justify-between"><span>${sku}</span><span class="font-bold">${total.toFixed(0)}</span></div>`)
+                .join('');
+            } else {
+              projecaoContainer.innerHTML = '<p class="text-gray-500">Nenhuma previsão disponível.</p>';
+            }
+          } else {
+            const prevDoc = await db.collection('uid').doc(usuarioLogado.uid).collection('previsoes').doc(anoMesPrev).get();
+            if (prevDoc.exists) {
+              const dados = prevDoc.data();
+              projecaoContainer.innerHTML = Object.entries(dados.skus || {})
+                .map(([sku, info]) => `<div class="bg-yellow-100 text-yellow-800 p-4 rounded shadow flex justify-between"><span>${sku}</span><span class="font-bold">${(info.total || 0).toFixed(0)}</span></div>`)
+                .join('');
+            } else {
+              projecaoContainer.innerHTML = '<p class="text-gray-500">Nenhuma previsão disponível.</p>';
+            }
+          }
+        } catch (err) {
+          console.error('Erro ao carregar previsão', err);
+          projecaoContainer.innerHTML = '<p class="text-red-500">Erro ao carregar previsão.</p>';
+        }
+      }
 
       container.innerHTML = "";
       const totaisSku = {};
@@ -2008,6 +2061,173 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
           resumoContainer.innerHTML = `<p class="text-gray-500">Nenhum dado encontrado para o período selecionado.</p>`;
         }
       }
+    }
+
+    async function carregarPrevisao() {
+      await tabsLoaded;
+      const selectSku = document.getElementById('filtroSkuPrevisao');
+      const cards = document.getElementById('cardsPrevisao');
+      if (!selectSku || !cards) return;
+      cards.innerHTML = '🔄 Carregando...';
+      const hoje = new Date();
+      const proxMes = new Date(hoje.getFullYear(), hoje.getMonth() + 1, 1);
+      const anoMes = proxMes.toISOString().slice(0,7);
+      const doc = await db.collection('uid').doc(usuarioLogado.uid).collection('previsoes').doc(anoMes).get();
+      if (doc.exists) {
+        previsaoDados = doc.data() || {};
+        const skus = Object.keys(previsaoDados.skus || {});
+        selectSku.innerHTML = '<option value="todos">Todos</option>' + skus.map(s => `<option value="${s}">${s}</option>`).join('');
+        cards.innerHTML = '';
+        renderizarPrevisao();
+      } else {
+        previsaoDados = { skus: {} };
+        selectSku.innerHTML = '<option value="todos">Todos</option>';
+        cards.innerHTML = '<p class="text-gray-500">Nenhuma previsão gerada. Clique em "Gerar previsão".</p>';
+      }
+    }
+
+    function renderizarPrevisao() {
+      const selectSku = document.getElementById('filtroSkuPrevisao');
+      const sku = selectSku?.value || 'todos';
+      const cards = document.getElementById('cardsPrevisao');
+      const tabela = document.getElementById('tabelaPrevisao');
+      const ctx = document.getElementById('graficoPrevisao')?.getContext('2d');
+      if (!cards || !tabela || !ctx) return;
+
+      let diario = {};
+      let totalBase = 0;
+      if (sku === 'todos') {
+        for (const info of Object.values(previsaoDados.skus || {})) {
+          totalBase += info.total || 0;
+          for (const [data, val] of Object.entries(info.diario || {})) {
+            diario[data] = (diario[data] || 0) + val;
+          }
+        }
+      } else if (previsaoDados.skus && previsaoDados.skus[sku]) {
+        const info = previsaoDados.skus[sku];
+        totalBase = info.total || 0;
+        diario = info.diario || {};
+      }
+
+      const pess = totalBase * 0.85;
+      const otm = totalBase * 1.15;
+      cards.innerHTML = `
+        <div class="bg-red-100 text-red-800 p-4 rounded shadow text-center">
+          <div class="font-bold">Pessimista</div><div>${pess.toFixed(0)}</div>
+        </div>
+        <div class="bg-blue-100 text-blue-800 p-4 rounded shadow text-center">
+          <div class="font-bold">Base</div><div>${totalBase.toFixed(0)}</div>
+        </div>
+        <div class="bg-green-100 text-green-800 p-4 rounded shadow text-center">
+          <div class="font-bold">Otimista</div><div>${otm.toFixed(0)}</div>
+        </div>`;
+
+      const labels = Object.keys(diario).sort();
+      const dados = labels.map(d => diario[d]);
+      if (graficoPrevisao) graficoPrevisao.destroy();
+      graficoPrevisao = new Chart(ctx, {
+        type: 'line',
+        data: { labels, datasets: [{ label: 'Previsão diária', data: dados, borderColor: '#2563eb', backgroundColor: 'rgba(37,99,235,0.3)', tension: 0.2 }] },
+        options: { responsive: true, maintainAspectRatio: false }
+      });
+
+      tabela.innerHTML = `
+        <table class="min-w-full text-sm text-left">
+          <thead><tr><th class="px-2 py-1 border">Data</th><th class="px-2 py-1 border">Qtde</th></tr></thead>
+          <tbody>
+            ${labels.map(d => `<tr><td class="px-2 py-1 border">${d}</td><td class="px-2 py-1 border">${diario[d].toFixed(0)}</td></tr>`).join('')}
+          </tbody>
+        </table>`;
+    }
+
+    function gerarDatas(qtd, endDate = new Date()) {
+      const datas = [];
+      for (let i = qtd; i > 0; i--) {
+        const d = new Date(endDate);
+        d.setDate(d.getDate() - i);
+        datas.push(d.toISOString().slice(0,10));
+      }
+      return datas;
+    }
+
+    function calcularBeta(arr) {
+      const n = arr.length;
+      const xMean = (n + 1) / 2;
+      const yMean = arr.reduce((a, b) => a + b, 0) / n;
+      let num = 0, den = 0;
+      for (let i = 0; i < n; i++) {
+        num += (i + 1 - xMean) * (arr[i] - yMean);
+        den += Math.pow(i + 1 - xMean, 2);
+      }
+      return den ? num / den : 0;
+    }
+
+    function clamp(v, min, max) {
+      return Math.min(max, Math.max(min, v));
+    }
+
+    async function gerarPrevisao() {
+      const btn = document.getElementById('btnGerarPrevisao');
+      if (btn) { btn.disabled = true; btn.innerText = 'Gerando...'; }
+      const hoje = new Date();
+      const proxMes = new Date(hoje.getFullYear(), hoje.getMonth() + 1, 1);
+      const anoMes = proxMes.toISOString().slice(0,7);
+      const diasProxMes = new Date(proxMes.getFullYear(), proxMes.getMonth()+1, 0).getDate();
+      const datas30 = gerarDatas(30, hoje);
+      const datas56 = gerarDatas(56, hoje);
+      const ref = db.collection(`uid/${usuarioLogado.uid}/skusVendidos`);
+      const snap = await ref.get();
+      const serieSkus = {};
+
+      for (const doc of snap.docs) {
+        const dataDoc = doc.id;
+        if (!datas56.includes(dataDoc)) continue;
+        const listaSnap = await doc.ref.collection('lista').get();
+        for (const skuDoc of listaSnap.docs) {
+          const { sku, total } = skuDoc.data();
+          const skuKey = sku || skuDoc.id;
+          if (!serieSkus[skuKey]) {
+            serieSkus[skuKey] = {};
+            datas56.forEach(d => serieSkus[skuKey][d] = 0);
+          }
+          serieSkus[skuKey][dataDoc] += total || 0;
+        }
+      }
+
+      const previsao = { skus: {}, totalGeral: 0 };
+      for (const [sku, serie] of Object.entries(serieSkus)) {
+        const arr30 = datas30.map(d => serie[d] || 0);
+        const arr7 = datas30.slice(-7).map(d => serie[d] || 0);
+        const avg7 = arr7.reduce((a,b)=>a+b,0) / 7;
+        const beta = calcularBeta(arr30);
+        const globalMean = datas56.reduce((s,d)=>s+(serie[d]||0),0) / datas56.length;
+        const fatores = {};
+        for (let w=0; w<7; w++) {
+          const vals = datas56.filter(d => new Date(d).getDay()===w).map(d => serie[d]||0);
+          const m = vals.length ? vals.reduce((a,b)=>a+b,0)/vals.length : 0;
+          fatores[w] = clamp(globalMean ? m/globalMean : 1, 0.7, 1.3);
+        }
+        const diario = {};
+        let total = 0;
+        for (let i=0;i<diasProxMes;i++) {
+          const d = new Date(proxMes.getFullYear(), proxMes.getMonth(), i+1);
+          const wd = d.getDay();
+          let val = avg7 + beta*(i+1);
+          val *= fatores[wd] || 1;
+          if (val < 0) val = 0;
+          const ds = d.toISOString().slice(0,10);
+          diario[ds] = val;
+          total += val;
+        }
+        previsao.skus[sku] = { diario, total };
+        previsao.totalGeral += total;
+      }
+
+      await db.collection('uid').doc(usuarioLogado.uid).collection('previsoes').doc(anoMes).set(previsao);
+      if (btn) { btn.disabled = false; btn.innerHTML = '<i class="fas fa-sync-alt"></i> Gerar previsão'; }
+      Swal.fire('Sucesso','Previsão gerada!','success');
+      carregarPrevisao();
+      carregarControleVendas();
     }
     window.verDetalhesDia = async function (dataDoc) {
 let uids = [];
@@ -2766,6 +2986,9 @@ async function carregarAcompanhamentoGestor() {
 }
 window.carregarRegistrosFaturamento = carregarRegistrosFaturamento;
 window.carregarControleVendas = carregarControleVendas;
+window.carregarPrevisao = carregarPrevisao;
+window.gerarPrevisao = gerarPrevisao;
+window.renderizarPrevisao = renderizarPrevisao;
 window.carregarAcompanhamento = carregarAcompanhamento;
 window.carregarAcompanhamentoGestor = carregarAcompanhamentoGestor;
 window.verificarGestorFinanceiro = verificarGestorFinanceiro;

--- a/sobras-tabs/controleVendas.html
+++ b/sobras-tabs/controleVendas.html
@@ -17,6 +17,7 @@
             <i class="fas fa-file-excel"></i> Exportar Mês
           </button>
         </div>
+        <div id="cardsProjecao" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 p-4"></div>
         <div id="resumoMensalVendas" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 p-4"></div>
         <div id="listaControleVendas" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 p-4"></div>
       </div>

--- a/sobras-tabs/previsao.html
+++ b/sobras-tabs/previsao.html
@@ -1,0 +1,22 @@
+<div class="card">
+  <div class="card-header">
+    <i class="fas fa-chart-line"></i>
+    <h3>Previsão de Vendas</h3>
+  </div>
+  <div class="flex flex-col md:flex-row items-center gap-4 p-4">
+    <div class="flex items-center gap-2">
+      <label for="filtroSkuPrevisao" class="font-medium">SKU:</label>
+      <select id="filtroSkuPrevisao" class="border border-gray-300 rounded px-2 py-2" onchange="renderizarPrevisao()">
+        <option value="todos">Todos</option>
+      </select>
+    </div>
+    <button id="btnGerarPrevisao" onclick="gerarPrevisao()" class="ml-auto px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded">
+      <i class="fas fa-sync-alt"></i> Gerar previsão
+    </button>
+  </div>
+  <div id="cardsPrevisao" class="grid grid-cols-1 md:grid-cols-3 gap-4 p-4"></div>
+  <div class="p-4">
+    <canvas id="graficoPrevisao"></canvas>
+  </div>
+  <div id="tabelaPrevisao" class="p-4 overflow-x-auto"></div>
+</div>


### PR DESCRIPTION
## Summary
- add Previsão tab for next-month sales projections
- compute forecasts using moving averages, trend and weekday factors
- show forecast cards in Controle de Vendas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ada60ec6e0832a8bc1e6f064c27774