### PR TITLE
Exibe top 5 SKUs previstos com suas projeções

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -2079,6 +2079,7 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
         selectSku.innerHTML = '<option value="todos">Todos</option>' + skus.map(s => `<option value="${s}">${s}</option>`).join('');
         cards.innerHTML = '';
         renderizarPrevisao();
+        renderizarTopSkus();
       } else {
         previsaoDados = { skus: {} };
         selectSku.innerHTML = '<option value="todos">Todos</option>';
@@ -2139,6 +2140,24 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
             ${labels.map(d => `<tr><td class="px-2 py-1 border">${d}</td><td class="px-2 py-1 border">${diario[d].toFixed(0)}</td></tr>`).join('')}
           </tbody>
         </table>`;
+    }
+
+    function renderizarTopSkus() {
+      const container = document.getElementById('topSkusPrevisao');
+      if (!container) return;
+      const lista = Object.entries(previsaoDados.skus || {})
+        .sort((a, b) => (b[1].total || 0) - (a[1].total || 0))
+        .slice(0, 5);
+      if (!lista.length) {
+        container.innerHTML = '<p class="text-gray-500">Nenhuma previsão disponível.</p>';
+        return;
+      }
+      container.innerHTML = `
+        <h4 class="font-bold mb-2">Top 5 SKUs projetados</h4>
+        <ul class="list-disc pl-5">
+          ${lista.map(([sku, info]) => `<li>${sku}: ${info.total.toFixed(0)}</li>`).join('')}
+        </ul>
+      `;
     }
 
     function gerarDatas(qtd, endDate = new Date()) {

--- a/sobras-tabs/previsao.html
+++ b/sobras-tabs/previsao.html
@@ -15,6 +15,7 @@
     </button>
   </div>
   <div id="cardsPrevisao" class="grid grid-cols-1 md:grid-cols-3 gap-4 p-4"></div>
+  <div id="topSkusPrevisao" class="p-4"></div>
   <div class="p-4">
     <canvas id="graficoPrevisao"></canvas>
   </div>


### PR DESCRIPTION
## Resumo
- Adicionada seção na tela de previsão para listar os cinco SKUs mais vendidos e suas respectivas projeções.
- Criada função `renderizarTopSkus` que ordena os SKUs previstos e popula a nova seção.

## Testes
- `npm test` *(falhou: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68adaa4ef708832a83090c9c7caf5dd7