### PR TITLE
Implementa serviço de comissões mensais

### DIFF
--- a/comissoes-service.js
+++ b/comissoes-service.js
@@ -1,0 +1,73 @@
+import {
+  collection,
+  addDoc,
+  doc,
+  getDocs,
+  setDoc,
+  deleteDoc,
+  getDoc,
+  onSnapshot
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { anoMesBR, calcularResumo } from './comissoes-utils.js';
+
+export async function registrarSaque({ db, uid, dataISO, valor, percentualPago, origem }) {
+  if (!uid) throw new Error('uid obrigatório');
+  if (!dataISO) throw new Error('dataISO obrigatório');
+  if (typeof valor !== 'number') throw new Error('valor inválido');
+  if (![0.03, 0.04, 0.05].includes(percentualPago)) throw new Error('percentualPago inválido');
+
+  const anoMes = anoMesBR(new Date(dataISO));
+  const col = collection(db, 'usuarios', uid, 'comissoes', anoMes, 'saques');
+  const comissaoPaga = valor * percentualPago;
+  await addDoc(col, {
+    data: dataISO,
+    valor,
+    percentualPago,
+    comissaoPaga,
+    ...(origem ? { origem } : {})
+  });
+  await recalcularResumoMes({ db, uid, anoMes });
+}
+
+export async function recalcularResumoMes({ db, uid, anoMes }) {
+  const col = collection(db, 'usuarios', uid, 'comissoes', anoMes, 'saques');
+  const snap = await getDocs(col);
+  const saques = snap.docs.map(d => d.data());
+  const resumo = calcularResumo(saques);
+  const ref = doc(db, 'usuarios', uid, 'comissoes', anoMes);
+  await setDoc(ref, {
+    ...resumo,
+    atualizadoEm: new Date().toISOString()
+  });
+}
+
+export async function deletarSaque({ db, uid, anoMes, saqueId }) {
+  const ref = doc(db, 'usuarios', uid, 'comissoes', anoMes, 'saques', saqueId);
+  await deleteDoc(ref);
+  await recalcularResumoMes({ db, uid, anoMes });
+}
+
+export async function fecharMes({ db, uid, anoMes }) {
+  const resumoRef = doc(db, 'usuarios', uid, 'comissoes', anoMes);
+  const snap = await getDoc(resumoRef);
+  if (!snap.exists()) return null;
+  const dados = snap.data();
+  if ((dados.ajusteFinal || 0) > 0) {
+    const ajustesCol = collection(db, 'usuarios', uid, 'comissoes', anoMes, 'ajustes');
+    const ajuste = {
+      data: new Date().toISOString(),
+      valorAjuste: dados.ajusteFinal,
+      taxaFinalAplicada: dados.taxaFinal
+    };
+    const docRef = await addDoc(ajustesCol, ajuste);
+    return docRef.id;
+  }
+  return null;
+}
+
+export function watchResumoMes({ db, uid, anoMes, onChange }) {
+  const ref = doc(db, 'usuarios', uid, 'comissoes', anoMes);
+  return onSnapshot(ref, snap => {
+    onChange(snap.exists() ? snap.data() : null);
+  });
+}

--- a/comissoes-utils.js
+++ b/comissoes-utils.js
@@ -1,0 +1,44 @@
+export const TIERS = [
+  { limite: 150_000, taxa: 0.03 },
+  { limite: 250_000, taxa: 0.04 },
+  { limite: Infinity, taxa: 0.05 }
+];
+
+export function taxaFinalPorTotal(total) {
+  if (total <= TIERS[0].limite) return TIERS[0].taxa;
+  if (total <= TIERS[1].limite) return TIERS[1].taxa;
+  return TIERS[2].taxa;
+}
+
+export function faltasParaTiers(total) {
+  return {
+    para4: Math.max(0, 150_000 - total),
+    para5: Math.max(0, 250_000 - total)
+  };
+}
+
+// Chave mensal no fuso Brasil
+export function anoMesBR(d = new Date()) {
+  const dt = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
+  const mm = String(dt.getMonth() + 1).padStart(2, '0');
+  return `${dt.getFullYear()}-${mm}`;
+}
+
+// Utilitário para calcular resumo mensal a partir de uma lista de saques
+export function calcularResumo(saques = []) {
+  const totalSacado = saques.reduce((s, x) => s + (x.valor || 0), 0);
+  const taxaFinal = taxaFinalPorTotal(totalSacado);
+  const comissaoPrevista = totalSacado * taxaFinal;
+  const comissaoJaPaga = saques.reduce((s, x) => s + (x.valor || 0) * (x.percentualPago || 0), 0);
+  const ajusteFinal = comissaoPrevista - comissaoJaPaga;
+  const { para4, para5 } = faltasParaTiers(totalSacado);
+  return {
+    totalSacado,
+    taxaFinal,
+    comissaoPrevista,
+    comissaoJaPaga,
+    ajusteFinal,
+    faltamPara4: para4,
+    faltamPara5: para5
+  };
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -5,6 +5,17 @@ service cloud.firestore {
       return exists(/databases/$(database)/documents/usuarios/$(uid)) &&
         get(/databases/$(database)/documents/usuarios/$(uid)).data.perfil in ['Gestor', 'ADM'];
     }
+
+    match /usuarios/{uid}/comissoes/{anoMes} {
+      allow read, write: if request.auth != null && (request.auth.uid == uid || isGestorOrADM(request.auth.uid));
+      match /saques/{saqueId} {
+        allow read, write: if request.auth != null && (request.auth.uid == uid || isGestorOrADM(request.auth.uid));
+      }
+      match /ajustes/{ajusteId} {
+        allow read, write: if request.auth != null && (request.auth.uid == uid || isGestorOrADM(request.auth.uid));
+      }
+    }
+
     match /pdfDocs/{fileId} {
       allow read: if request.auth != null && (
         resource.data.ownerUid == request.auth.uid ||

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "vendedorpro",
+  "type": "module",
+  "scripts": {
+    "test": "node tests/comissoes.test.js"
+  }
+}

--- a/tests/comissoes.test.js
+++ b/tests/comissoes.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { calcularResumo } from '../comissoes-utils.js';
+
+function testeAbaixo150k() {
+  const saques = [
+    { valor: 50_000, percentualPago: 0.03 },
+    { valor: 40_000, percentualPago: 0.04 }
+  ];
+  const r = calcularResumo(saques);
+  assert.equal(r.totalSacado, 90_000);
+  assert.equal(r.taxaFinal, 0.03);
+  assert.equal(r.comissaoPrevista, 2_700);
+  assert.equal(r.comissaoJaPaga, 3_100);
+  assert.equal(r.ajusteFinal, -400);
+  assert.equal(r.faltamPara4, 60_000);
+  assert.equal(r.faltamPara5, 160_000);
+}
+
+function testeCruza150k() {
+  const saques = [
+    { valor: 100_000, percentualPago: 0.03 },
+    { valor: 60_000, percentualPago: 0.03 }
+  ];
+  const r = calcularResumo(saques);
+  assert.equal(r.totalSacado, 160_000);
+  assert.equal(r.taxaFinal, 0.04);
+  assert.equal(r.comissaoPrevista, 6_400);
+  assert.equal(r.comissaoJaPaga, 4_800);
+  assert.equal(r.ajusteFinal, 1_600);
+  assert.equal(r.faltamPara4, 0);
+  assert.equal(r.faltamPara5, 90_000);
+}
+
+function testeCruza250k() {
+  const saques = [
+    { valor: 200_000, percentualPago: 0.04 },
+    { valor: 60_000, percentualPago: 0.04 }
+  ];
+  const r = calcularResumo(saques);
+  assert.equal(r.totalSacado, 260_000);
+  assert.equal(r.taxaFinal, 0.05);
+  assert.equal(r.comissaoPrevista, 13_000);
+  assert.equal(r.comissaoJaPaga, 10_400);
+  assert.equal(r.ajusteFinal, 2_600);
+  assert.equal(r.faltamPara4, 0);
+  assert.equal(r.faltamPara5, 0);
+}
+
+testeAbaixo150k();
+testeCruza150k();
+testeCruza250k();
+console.log('Tests passed');


### PR DESCRIPTION
## Resumo
- Adiciona utilidades de cálculo de comissões com faixas e projeções
- Implementa serviço Firestore para registrar saques, recalcular resumos e fechar mês
- Atualiza regras de segurança e cria testes de validação das faixas de comissão

## Testes
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adac10058c832ab55106c94207329a