### PR TITLE
Refactor sidebar offcanvas and fix mobile layout

### DIFF
--- a/SISTEMA DE CUSTEIO DE PRODUÇÃO E PRODUTOS.html
+++ b/SISTEMA DE CUSTEIO DE PRODUÇÃO E PRODUTOS.html
@@ -54,7 +54,13 @@
             userSpan.textContent = user.email || 'Usuário';
           }
           document.getElementById('sidebarToggle').addEventListener('click', () => {
-        document.querySelector('.sidebar').classList.toggle('active');
+        const container = document.getElementById('sidebar-container');
+        if (container) {
+          const isOpen = container.classList.toggle('open');
+          const overlay = document.getElementById('sidebar-overlay');
+          if (overlay) overlay.classList.toggle('hidden', !isOpen);
+          document.body.style.overflow = isOpen ? 'hidden' : '';
+        }
       });
         });
       }

--- a/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
+++ b/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
@@ -171,8 +171,13 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
     const sidebarToggle = document.getElementById('sidebarToggle');
     if (sidebarToggle) {
       sidebarToggle.addEventListener('click', () => {
-        const sidebar = document.querySelector('.sidebar');
-        if (sidebar) sidebar.classList.toggle('active');
+        const container = document.getElementById('sidebar-container');
+        if (container) {
+          const isOpen = container.classList.toggle('open');
+          const overlay = document.getElementById('sidebar-overlay');
+          if (overlay) overlay.classList.toggle('hidden', !isOpen);
+          document.body.style.overflow = isOpen ? 'hidden' : '';
+        }
       });
     }
     const filtroPlataforma = document.getElementById('filtroPlataforma');

--- a/css/styles.css
+++ b/css/styles.css
@@ -56,12 +56,14 @@ body {
   padding: 30px;
 }
 
-body.has-sidebar .navbar {
-  left: var(--sidebar-width);
-}
+@media (min-width:1024px) {
+  body.has-sidebar .navbar {
+    left: var(--sidebar-width);
+  }
 
-body.has-sidebar .content-wrapper {
-  margin-left: var(--sidebar-width);
+  body.has-sidebar .content-wrapper {
+    margin-left: var(--sidebar-width);
+  }
 }
 
 
@@ -1883,13 +1885,29 @@ body.dark .sidebar-link.active {
   .main-content { margin-left: var(--sidebar-width); }
 }
 
+/* Sidebar overlay */
+#sidebar-container {
+  z-index: 40;
+}
+#sidebar-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  z-index: 30;
+  display: none;
+}
+
 /* Mobile off-canvas sidebar */
 @media (max-width:768px){
-  .sidebar {
+  #sidebar-container {
     transform: translateX(-100%);
+    transition: transform .2s ease-out;
   }
-  .sidebar.active {
+  #sidebar-container.open {
     transform: translateX(0);
+  }
+  #sidebar-overlay:not(.hidden) {
+    display: block;
   }
 }
 

--- a/custeio.js
+++ b/custeio.js
@@ -1,14 +1,16 @@
 import { encryptString, decryptString } from './crypto.js';
 
 function toggleSidebar() {
-     const sidebar = document.getElementById('sidebar') ||
-                  document.querySelector('.sidebar');
-  if (sidebar) {
-    const isActive = sidebar.classList.toggle('active');
+  const container = document.getElementById('sidebar-container');
+  if (container) {
+    const isOpen = container.classList.toggle('open');
+    const overlay = document.getElementById('sidebar-overlay');
+    if (overlay) overlay.classList.toggle('hidden', !isOpen);
     const btn = document.querySelector('.mobile-menu-btn');
     if (btn) {
-      btn.setAttribute('aria-expanded', isActive ? 'true' : 'false');
+      btn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
     }
+    document.body.style.overflow = isOpen ? 'hidden' : '';
   }
 }
     

--- a/financeiro-inicio.html
+++ b/financeiro-inicio.html
@@ -12,7 +12,7 @@
 </head>
 <body class="bg-gray-100 text-gray-800">
   <button class="mobile-menu-btn" aria-label="Abrir menu" aria-expanded="false">☰</button>
-  <div id="sidebar-container" class="-translate-x-full"></div>
+  <div id="sidebar-container"></div>
   <div id="navbar-container"></div>
   <main class="main-content p-4 space-y-4">
     <h1 class="text-2xl font-bold">Área Financeira</h1>

--- a/financeiro.html
+++ b/financeiro.html
@@ -15,7 +15,7 @@
 </head>
 <body class="bg-gray-100 text-gray-800">
   <button class="mobile-menu-btn" aria-label="Abrir menu" aria-expanded="false">☰</button>
-  <div id="sidebar-container" class="-translate-x-full"></div>
+  <div id="sidebar-container"></div>
   <div id="navbar-container"></div>
   <main class="main-content p-4 space-y-4">
     <div class="card p-4 flex flex-wrap items-center gap-4">

--- a/mentoria.html
+++ b/mentoria.html
@@ -33,7 +33,7 @@
   <aside id="sidebar-container"
          class="fixed inset-y-0 left-0 w-64 max-w-[80vw] bg-purple-700 text-white overflow-auto z-40
                 transition-transform duration-200 ease-out
-                -translate-x-full lg:translate-x-0 shadow-lg">
+                lg:translate-x-0 shadow-lg">
     <!-- parcial é injetado aqui -->
   </aside>
 

--- a/public/shared.js
+++ b/public/shared.js
@@ -275,8 +275,13 @@ const PARTIALS_VERSION = '2025-08-25-02'; // mude quando atualizar parciais
 
 function toggleSidebar(){
   const sb = document.getElementById('sidebar-container');
+  const overlay = document.getElementById('sidebar-overlay');
   if (!sb) return;
-  sb.classList.toggle('-translate-x-full');
+  sb.classList.toggle('open');
+  if (overlay) overlay.classList.toggle('hidden', !sb.classList.contains('open'));
+  document.body.style.overflow = sb.classList.contains('open') ? 'hidden' : '';
+  try { localStorage.removeItem('sidebarClosed'); } catch(e){}
+  document.cookie = 'sidebarClosed=; Max-Age=0; path=/';
 }
 
 async function loadPartial(selector, path){
@@ -287,10 +292,22 @@ async function loadPartial(selector, path){
     const id = selector.replace('#', '');
     el.id = id;
     if (id === 'sidebar-container') {
-      el.className = 'fixed inset-y-0 left-0 w-64 max-w-[80vw] bg-purple-700 text-white overflow-auto z-40 transition-transform duration-200 ease-out -translate-x-full lg:translate-x-0 shadow-lg';
+      el.className = 'fixed inset-y-0 left-0 w-64 max-w-[80vw] bg-purple-700 text-white overflow-auto z-40 transition-transform duration-200 ease-out lg:translate-x-0 shadow-lg';
       document.body.prepend(el);
       // garante margem do conteúdo no desktop
       document.querySelector('.main-content')?.classList.add('lg:ml-64');
+      let overlay = document.getElementById('sidebar-overlay');
+      if (!overlay) {
+        overlay = document.createElement('div');
+        overlay.id = 'sidebar-overlay';
+        overlay.className = 'fixed inset-0 bg-black bg-opacity-50 z-30 hidden';
+        overlay.addEventListener('click', () => {
+          el.classList.remove('open');
+          overlay.classList.add('hidden');
+          document.body.style.overflow = '';
+        });
+        document.body.insertBefore(overlay, el.nextSibling);
+      }
     } else {
       // navbar acima do main
       document.body.insertBefore(el, document.querySelector('main') || null);
@@ -330,7 +347,9 @@ async function loadPartial(selector, path){
 
     // no desktop, sempre aberto
     if (selector === '#sidebar-container' && matchMedia('(min-width:1024px)').matches) {
-      el.classList.remove('-translate-x-full','hidden');
+      el.classList.add('open');
+      const overlay = document.getElementById('sidebar-overlay');
+      if (overlay) overlay.classList.add('hidden');
       // limpa qualquer estado salvo que esconda
       try { localStorage.removeItem('sidebarClosed'); } catch(e){}
       document.cookie = 'sidebarClosed=; Max-Age=0; path=/';
@@ -363,8 +382,11 @@ mo.observe(document.documentElement, { childList: true, subtree: true });
 // ao redimensionar para desktop, garante aberto
 window.addEventListener('resize', ()=>{
   const sb = document.getElementById('sidebar-container');
+  const overlay = document.getElementById('sidebar-overlay');
   if (sb && matchMedia('(min-width:1024px)').matches) {
-    sb.classList.remove('-translate-x-full','hidden');
+    sb.classList.add('open');
+    overlay?.classList.add('hidden');
+    document.body.style.overflow = '';
   }
 });
 
@@ -374,38 +396,36 @@ window.ensureLayout  = ensureLayout;
 
 function setupMobileSidebar() {
   const container = document.getElementById('sidebar-container');
-  const sidebar = document.getElementById('sidebar');
+  const overlay = document.getElementById('sidebar-overlay');
   const btn = document.querySelector('.mobile-menu-btn');
-  if (!container || !sidebar || !btn || btn.dataset.sidebarReady) return;
+  if (!container || !btn || btn.dataset.sidebarReady) return;
 
   const open = () => {
-    container.classList.remove('-translate-x-full');
-    sidebar.classList.add('active');
+    container.classList.add('open');
+    overlay?.classList.remove('hidden');
     document.body.style.overflow = 'hidden';
     btn.setAttribute('aria-expanded', 'true');
+    try { localStorage.removeItem('sidebarClosed'); } catch(e){}
+    document.cookie = 'sidebarClosed=; Max-Age=0; path=/';
   };
   const close = () => {
-    container.classList.add('-translate-x-full');
-    sidebar.classList.remove('active');
+    container.classList.remove('open');
+    overlay?.classList.add('hidden');
     document.body.style.overflow = '';
     btn.setAttribute('aria-expanded', 'false');
   };
 
   btn.addEventListener('click', () => {
-    container.classList.contains('-translate-x-full') ? open() : close();
+    container.classList.contains('open') ? close() : open();
   });
 
-  document.addEventListener('click', (e) => {
-    if (window.innerWidth > 768) return;
-    if (!container.contains(e.target) && !btn.contains(e.target)) close();
-  });
-
-  sidebar.querySelectorAll('a').forEach(a => a.addEventListener('click', close));
+  overlay?.addEventListener('click', close);
+  container.querySelectorAll('a').forEach(a => a.addEventListener('click', close));
 
   window.addEventListener('resize', () => {
     if (window.innerWidth > 768) {
-      container.classList.remove('-translate-x-full');
-      sidebar.classList.remove('active');
+      container.classList.add('open');
+      overlay?.classList.add('hidden');
       document.body.style.overflow = '';
       btn.setAttribute('aria-expanded', 'false');
     } else {
@@ -413,7 +433,9 @@ function setupMobileSidebar() {
     }
   });
 
-  if (window.innerWidth <= 768) {
+  if (window.innerWidth > 768) {
+    container.classList.add('open');
+  } else {
     close();
   }
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'financeiro-cache-v1';
+const CACHE_NAME = 'financeiro-cache-v2';
 const URLS_TO_CACHE = [
   'financeiro.html',
   'financeiro.js',


### PR DESCRIPTION
## Summary
- Restrict desktop sidebar layout rules and add mobile off-canvas behavior with overlay
- Refactor shared scripts to toggle `.open` on `#sidebar-container`, block body scroll, and handle overlay
- Version bump service worker cache to refresh CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adac976410832ab991b7a6730042ca