### PR TITLE
Fix off-canvas mobile sidebar behavior

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -35,6 +35,28 @@ body {
   font-family: 'Poppins', sans-serif;
 }
 
+#sidebar-container {
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  z-index: 40;
+}
+
+#sidebar-container.open {
+  transform: translateX(0);
+}
+
+#sidebar-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  z-index: 30;
+  display: none;
+}
+
+#sidebar-overlay.show {
+  display: block;
+}
+
 .section {
   background-color: var(--card-bg);
   border-radius: 1rem;
@@ -62,6 +84,15 @@ body.has-sidebar .navbar {
 
 body.has-sidebar .content-wrapper {
   margin-left: var(--sidebar-width);
+}
+
+@media (max-width:768px) {
+  body.has-sidebar .navbar {
+    left: 0;
+  }
+  body.has-sidebar .content-wrapper {
+    margin-left: 0;
+  }
 }
 
 
@@ -321,16 +352,6 @@ input:checked + .dark-mode-slider:before {
   }
   .sidebar-link .mr-3 {
     margin-right: 0.75rem;
-  }
-}
-@media (max-width:768px) {
-  /* Sidebar visibility is handled via #sidebar-container classes.
-     Removing legacy transforms prevents double translations on mobile. */
-  body.has-sidebar .navbar {
-    left: 0;
-  }
-  body.has-sidebar .content-wrapper {
-    margin-left: 0;
   }
 }
 .badge {

--- a/public/shared.js
+++ b/public/shared.js
@@ -275,8 +275,13 @@ const PARTIALS_VERSION = '2025-08-25-02'; // mude quando atualizar parciais
 
 function toggleSidebar(){
   const sb = document.getElementById('sidebar-container');
+  const overlay = document.getElementById('sidebar-overlay');
+  const btn = document.querySelector('.mobile-menu-btn');
   if (!sb) return;
-  sb.classList.toggle('-translate-x-full');
+  const isOpen = sb.classList.toggle('open');
+  if (overlay) overlay.classList.toggle('show', isOpen);
+  document.body.style.overflow = isOpen ? 'hidden' : '';
+  if (btn) btn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
 }
 
 async function loadPartial(selector, path){
@@ -287,7 +292,7 @@ async function loadPartial(selector, path){
     const id = selector.replace('#', '');
     el.id = id;
     if (id === 'sidebar-container') {
-      el.className = 'fixed inset-y-0 left-0 w-64 max-w-[80vw] bg-purple-700 text-white overflow-auto z-40 transition-transform duration-200 ease-out -translate-x-full lg:translate-x-0 shadow-lg';
+      el.className = 'fixed inset-y-0 left-0 w-64 max-w-[80vw] bg-purple-700 text-white overflow-auto z-40 transition-transform duration-200 ease-out shadow-lg';
       document.body.prepend(el);
       // garante margem do conteúdo no desktop
       document.querySelector('.main-content')?.classList.add('lg:ml-64');
@@ -330,7 +335,7 @@ async function loadPartial(selector, path){
 
     // no desktop, sempre aberto
     if (selector === '#sidebar-container' && matchMedia('(min-width:1024px)').matches) {
-      el.classList.remove('-translate-x-full','hidden');
+      el.classList.add('open');
       // limpa qualquer estado salvo que esconda
       try { localStorage.removeItem('sidebarClosed'); } catch(e){}
       document.cookie = 'sidebarClosed=; Max-Age=0; path=/';
@@ -363,8 +368,11 @@ mo.observe(document.documentElement, { childList: true, subtree: true });
 // ao redimensionar para desktop, garante aberto
 window.addEventListener('resize', ()=>{
   const sb = document.getElementById('sidebar-container');
+  const overlay = document.getElementById('sidebar-overlay');
   if (sb && matchMedia('(min-width:1024px)').matches) {
-    sb.classList.remove('-translate-x-full','hidden');
+    sb.classList.add('open');
+    overlay?.classList.remove('show');
+    document.body.style.overflow = '';
   }
 });
 
@@ -374,47 +382,49 @@ window.ensureLayout  = ensureLayout;
 
 function setupMobileSidebar() {
   const container = document.getElementById('sidebar-container');
-  const sidebar = document.getElementById('sidebar');
   const btn = document.querySelector('.mobile-menu-btn');
-  if (!container || !sidebar || !btn || btn.dataset.sidebarReady) return;
+  if (!container || !btn || btn.dataset.sidebarReady) return;
 
-  const open = () => {
-    container.classList.remove('-translate-x-full');
-    sidebar.classList.add('active');
-    document.body.style.overflow = 'hidden';
-    btn.setAttribute('aria-expanded', 'true');
-  };
-  const close = () => {
-    container.classList.add('-translate-x-full');
-    sidebar.classList.remove('active');
-    document.body.style.overflow = '';
-    btn.setAttribute('aria-expanded', 'false');
-  };
+  let overlay = document.getElementById('sidebar-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'sidebar-overlay';
+    document.body.appendChild(overlay);
+  }
 
-  btn.addEventListener('click', () => {
-    container.classList.contains('-translate-x-full') ? open() : close();
-  });
+  btn.addEventListener('click', toggleSidebar);
+  overlay.addEventListener('click', toggleSidebar);
 
   document.addEventListener('click', (e) => {
     if (window.innerWidth > 768) return;
-    if (!container.contains(e.target) && !btn.contains(e.target)) close();
-  });
-
-  sidebar.querySelectorAll('a').forEach(a => a.addEventListener('click', close));
-
-  window.addEventListener('resize', () => {
-    if (window.innerWidth > 768) {
-      container.classList.remove('-translate-x-full');
-      sidebar.classList.remove('active');
+    if (!container.contains(e.target) && !btn.contains(e.target)) {
+      container.classList.remove('open');
+      overlay.classList.remove('show');
       document.body.style.overflow = '';
       btn.setAttribute('aria-expanded', 'false');
-    } else {
-      close();
     }
   });
 
-  if (window.innerWidth <= 768) {
-    close();
+  container.querySelectorAll('a').forEach(a => a.addEventListener('click', () => {
+    if (window.innerWidth <= 768) toggleSidebar();
+  }));
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth > 768) {
+      container.classList.add('open');
+      overlay.classList.remove('show');
+      document.body.style.overflow = '';
+      btn.setAttribute('aria-expanded', 'false');
+    } else {
+      container.classList.remove('open');
+      overlay.classList.remove('show');
+      document.body.style.overflow = '';
+      btn.setAttribute('aria-expanded', 'false');
+    }
+  });
+
+  if (window.innerWidth > 768) {
+    container.classList.add('open');
   }
 
   btn.dataset.sidebarReady = 'true';

--- a/shared.js
+++ b/shared.js
@@ -275,8 +275,13 @@ const PARTIALS_VERSION = '2025-08-25-02'; // mude quando atualizar parciais
 
 function toggleSidebar(){
   const sb = document.getElementById('sidebar-container');
+  const overlay = document.getElementById('sidebar-overlay');
+  const btn = document.querySelector('.mobile-menu-btn');
   if (!sb) return;
-  sb.classList.toggle('-translate-x-full');
+  const isOpen = sb.classList.toggle('open');
+  if (overlay) overlay.classList.toggle('show', isOpen);
+  document.body.style.overflow = isOpen ? 'hidden' : '';
+  if (btn) btn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
 }
 
 async function loadPartial(selector, path){
@@ -287,7 +292,7 @@ async function loadPartial(selector, path){
     el = document.createElement(selector.startsWith('#') ? 'div' : 'aside');
     el.id = id;
     if (id === 'sidebar-container') {
-      el.className = 'fixed inset-y-0 left-0 w-64 max-w-[80vw] bg-purple-700 text-white overflow-auto z-40 transition-transform duration-200 ease-out -translate-x-full lg:translate-x-0 shadow-lg';
+      el.className = 'fixed inset-y-0 left-0 w-64 max-w-[80vw] bg-purple-700 text-white overflow-auto z-40 transition-transform duration-200 ease-out shadow-lg';
       document.body.prepend(el);
       // garante margem do conteúdo no desktop
       document.querySelector('.main-content')?.classList.add('lg:ml-64');
@@ -298,7 +303,7 @@ async function loadPartial(selector, path){
     }
   } else {
     if (id === 'sidebar-container') {
-      el.classList.add('fixed','inset-y-0','left-0','w-64','max-w-[80vw]','bg-purple-700','text-white','overflow-auto','z-40','transition-transform','duration-200','ease-out','-translate-x-full','lg:translate-x-0','shadow-lg');
+      el.classList.add('fixed','inset-y-0','left-0','w-64','max-w-[80vw]','bg-purple-700','text-white','overflow-auto','z-40','transition-transform','duration-200','ease-out','shadow-lg');
       document.querySelector('.main-content')?.classList.add('lg:ml-64');
     } else {
       el.classList.add('lg:pl-64');
@@ -337,7 +342,7 @@ async function loadPartial(selector, path){
 
     // no desktop, sempre aberto
     if (selector === '#sidebar-container' && matchMedia('(min-width:1024px)').matches) {
-      el.classList.remove('-translate-x-full','hidden');
+      el.classList.add('open');
       // limpa qualquer estado salvo que esconda
       try { localStorage.removeItem('sidebarClosed'); } catch(e){}
       document.cookie = 'sidebarClosed=; Max-Age=0; path=/';
@@ -370,8 +375,11 @@ mo.observe(document.documentElement, { childList: true, subtree: true });
 // ao redimensionar para desktop, garante aberto
 window.addEventListener('resize', ()=>{
   const sb = document.getElementById('sidebar-container');
+  const overlay = document.getElementById('sidebar-overlay');
   if (sb && matchMedia('(min-width:1024px)').matches) {
-    sb.classList.remove('-translate-x-full','hidden');
+    sb.classList.add('open');
+    overlay?.classList.remove('show');
+    document.body.style.overflow = '';
   }
 });
 
@@ -381,47 +389,49 @@ window.ensureLayout  = ensureLayout;
 
 function setupMobileSidebar() {
   const container = document.getElementById('sidebar-container');
-  const sidebar = document.getElementById('sidebar');
   const btn = document.querySelector('.mobile-menu-btn');
-  if (!container || !sidebar || !btn || btn.dataset.sidebarReady) return;
+  if (!container || !btn || btn.dataset.sidebarReady) return;
 
-  const open = () => {
-    container.classList.remove('-translate-x-full');
-    sidebar.classList.add('active');
-    document.body.style.overflow = 'hidden';
-    btn.setAttribute('aria-expanded', 'true');
-  };
-  const close = () => {
-    container.classList.add('-translate-x-full');
-    sidebar.classList.remove('active');
-    document.body.style.overflow = '';
-    btn.setAttribute('aria-expanded', 'false');
-  };
+  let overlay = document.getElementById('sidebar-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'sidebar-overlay';
+    document.body.appendChild(overlay);
+  }
 
-  btn.addEventListener('click', () => {
-    container.classList.contains('-translate-x-full') ? open() : close();
-  });
+  btn.addEventListener('click', toggleSidebar);
+  overlay.addEventListener('click', toggleSidebar);
 
   document.addEventListener('click', (e) => {
     if (window.innerWidth > 768) return;
-    if (!container.contains(e.target) && !btn.contains(e.target)) close();
-  });
-
-  sidebar.querySelectorAll('a').forEach(a => a.addEventListener('click', close));
-
-  window.addEventListener('resize', () => {
-    if (window.innerWidth > 768) {
-      container.classList.remove('-translate-x-full');
-      sidebar.classList.remove('active');
+    if (!container.contains(e.target) && !btn.contains(e.target)) {
+      container.classList.remove('open');
+      overlay.classList.remove('show');
       document.body.style.overflow = '';
       btn.setAttribute('aria-expanded', 'false');
-    } else {
-      close();
     }
   });
 
-  if (window.innerWidth <= 768) {
-    close();
+  container.querySelectorAll('a').forEach(a => a.addEventListener('click', () => {
+    if (window.innerWidth <= 768) toggleSidebar();
+  }));
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth > 768) {
+      container.classList.add('open');
+      overlay.classList.remove('show');
+      document.body.style.overflow = '';
+      btn.setAttribute('aria-expanded', 'false');
+    } else {
+      container.classList.remove('open');
+      overlay.classList.remove('show');
+      document.body.style.overflow = '';
+      btn.setAttribute('aria-expanded', 'false');
+    }
+  });
+
+  if (window.innerWidth > 768) {
+    container.classList.add('open');
   }
 
   btn.dataset.sidebarReady = 'true';


### PR DESCRIPTION
## Summary
- Hide sidebar off-canvas by default and show when `.open` is toggled, with a new overlay and mobile layout fixes
- Rework sidebar scripts to toggle the `.open` class, manage overlay and scroll lock, and ensure desktop always displays the sidebar
- Update public assets to mirror the new sidebar logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adac976410832ab991b7a6730042ca