### PR TITLE
feat: allow editing and store tracking for withdrawals

### DIFF
--- a/comissoes-service.js
+++ b/comissoes-service.js
@@ -29,6 +29,26 @@ export async function registrarSaque({ db, uid, dataISO, valor, percentualPago, 
   await recalcularResumoMes({ db, uid, anoMes });
 }
 
+export async function atualizarSaque({ db, uid, anoMes, saqueId, dataISO, valor, percentualPago, origem }) {
+  if (!uid) throw new Error('uid obrigatório');
+  if (!anoMes) throw new Error('anoMes obrigatório');
+  if (!saqueId) throw new Error('saqueId obrigatório');
+  const ref = doc(db, 'usuarios', uid, 'comissoes', anoMes, 'saques', saqueId);
+  const comissaoPaga = valor * percentualPago;
+  await setDoc(
+    ref,
+    {
+      data: dataISO,
+      valor,
+      percentualPago,
+      comissaoPaga,
+      ...(origem ? { origem } : {})
+    },
+    { merge: true }
+  );
+  await recalcularResumoMes({ db, uid, anoMes });
+}
+
 export async function recalcularResumoMes({ db, uid, anoMes }) {
   const col = collection(db, 'usuarios', uid, 'comissoes', anoMes, 'saques');
   const snap = await getDocs(col);

--- a/saques.html
+++ b/saques.html
@@ -22,12 +22,13 @@
       <div class="card-body flex flex-col md:flex-row gap-4 items-end">
         <input type="date" id="dataSaque" class="form-control" />
         <input type="number" id="valorSaque" placeholder="Valor (R$)" step="0.01" class="form-control" />
+        <input type="text" id="lojaSaque" placeholder="Loja" class="form-control" />
         <select id="percentualSaque" class="form-control">
           <option value="0.03">3%</option>
           <option value="0.04">4%</option>
           <option value="0.05">5%</option>
         </select>
-        <button onclick="registrarSaque()" class="btn btn-primary">
+        <button id="btnRegistrar" onclick="registrarSaque()" class="btn btn-primary">
           <i class="fas fa-plus mr-1"></i> Registrar
         </button>
       </div>
@@ -56,6 +57,7 @@
           <thead class="bg-gray-50">
             <tr>
               <th class="px-4 py-2 text-left">Data</th>
+              <th class="px-4 py-2 text-left">Loja</th>
               <th class="px-4 py-2 text-right">Valor</th>
               <th class="px-4 py-2 text-right">% Pago</th>
               <th class="px-4 py-2 text-right">Comissão Paga</th>


### PR DESCRIPTION
## Summary
- add store field and edit capability to withdrawal page
- show daily totals across stores
- support updating withdrawals in comissoes service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adb4e21014832abb3cc7fd55a8cd8e