### PR TITLE
feat: add paid marker and summary to saques

### DIFF
--- a/saques.html
+++ b/saques.html
@@ -76,7 +76,8 @@
                 <option value="0.04">4%</option>
                 <option value="0.05">5%</option>
               </select>
-              <button onclick="aplicarPercentualSelecionados()" class="btn btn-primary">Aplicar</button>
+              <button onclick="marcarComoPagoSelecionados()" class="btn btn-primary">Marcar como Pago</button>
+              <button onclick="mostrarResumoSelecionados()" class="btn btn-outline">Ver Resumo</button>
             </div>
           </div>
         </div>

--- a/saques.js
+++ b/saques.js
@@ -83,9 +83,14 @@ async function carregarSaques() {
   for (let i = 0; i < dados.length; i++) {
     const s = dados[i];
     const dia = s.data.substring(0, 10);
+    const pago = s.percentualPago > 0;
     const tr = document.createElement('tr');
+    if (pago) tr.className = 'bg-green-100';
     tr.innerHTML = `
-      <td class="px-4 py-2"><input type="checkbox" class="saque-select" data-id="${s.id}" onchange="toggleSelecao('${s.id}', this.checked)"></td>
+      <td class="px-4 py-2">
+        <input type="checkbox" class="saque-select" data-id="${s.id}" onchange="toggleSelecao('${s.id}', this.checked)">
+        ${pago ? `<span class=\"ml-2 px-2 py-1 bg-green-500 text-white text-xs font-bold rounded\">PAGO ${(s.percentualPago * 100).toFixed(0)}%</span>` : ''}
+      </td>
       <td class="px-4 py-2">${dia}</td>
       <td class="px-4 py-2">${s.origem || '-'}</td>
       <td class="px-4 py-2 text-right">R$ ${s.valor.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
@@ -158,7 +163,7 @@ function atualizarResumoSelecionados() {
   div.style.display = 'flex';
 }
 
-async function aplicarPercentualSelecionados() {
+async function marcarComoPagoSelecionados() {
   const perc = parseFloat(document.getElementById('percentualSelecionado').value);
   const anoMes = document.getElementById('filtroMes').value || anoMesBR();
   for (const id of selecionados) {
@@ -168,6 +173,11 @@ async function aplicarPercentualSelecionados() {
   }
   selecionados.clear();
   carregarSaques();
+}
+
+function mostrarResumoSelecionados() {
+  const texto = document.getElementById('resumoSelecionados');
+  if (texto) alert(texto.textContent);
 }
 
 function editarSaque(id) {
@@ -227,6 +237,7 @@ if (typeof window !== 'undefined') {
   window.fecharMes = fecharMes;
   window.toggleSelecao = toggleSelecao;
   window.toggleSelecaoTodos = toggleSelecaoTodos;
-  window.aplicarPercentualSelecionados = aplicarPercentualSelecionados;
+  window.marcarComoPagoSelecionados = marcarComoPagoSelecionados;
+  window.mostrarResumoSelecionados = mostrarResumoSelecionados;
 }
 


### PR DESCRIPTION
## Summary
- allow marking selected withdrawals as paid with a chosen percentage
- show a detailed summary of selected withdrawals
- highlight paid withdrawals in green with a PAGO badge

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adbdc195cc832ab72cdd3ae127cf41