### PR TITLE
Add Excel and PDF export for selected withdrawals

### DIFF
--- a/saques.html
+++ b/saques.html
@@ -78,12 +78,16 @@
               </select>
               <button onclick="marcarComoPagoSelecionados()" class="btn btn-primary">Marcar como Pago</button>
               <button onclick="mostrarResumoSelecionados()" class="btn btn-outline">Ver Resumo</button>
+              <button onclick="exportarSelecionadosExcel()" class="btn btn-outline">Exportar Excel</button>
+              <button onclick="exportarSelecionadosPDF()" class="btn btn-outline">Exportar PDF</button>
             </div>
           </div>
         </div>
       </section>
     </main>
 
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.25/jspdf.plugin.autotable.min.js"></script>
     <script type="module" src="firebase-config.js"></script>
     <script type="module" src="saques.js"></script>
     <script>window.CUSTOM_SIDEBAR_PATH = '/VendedorPro/partials/sidebar.html';</script>


### PR DESCRIPTION
## Summary
- add export buttons for selected withdrawals, allowing Excel or PDF generation
- implement CSV export and boleto-style PDF using jsPDF

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc006cb8c832ab859fd136b65fea1