### PR TITLE
Fix duplicate variable declarations in PDF export

### DIFF
--- a/saques.js
+++ b/saques.js
@@ -212,13 +212,9 @@ function exportarSelecionadosPDF() {
   const doc = new jsPDF();
   doc.setFontSize(16);
   doc.text('Fechamento Comissão', 105, 15, { align: 'center' });
-  const body = [];
+  let totalSaque = 0;
   let totalComissao = 0;
-// antes do loop garanta as variáveis
-let totalSaque = 0;
-let totalComissao = 0;
-
-const body = [];
+  const body = [];
 
 selecionados.forEach(id => {
   const s = saquesCache[id];


### PR DESCRIPTION
## Summary
- Remove duplicated `totalSaque`, `totalComissao`, and `body` declarations in `exportarSelecionadosPDF`
- Prevents `Identifier 'totalComissao' has already been declared` runtime error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68add6992058832a954deae3004bcb97