### PR TITLE
Show withdraws and commissions to financial manager

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -63,6 +63,38 @@
     </div>
 
     <div id="cardsContainer"></div>
+
+    <section id="saquesGestor" class="card hidden">
+      <div class="card-header flex justify-between items-center">
+        <h2 class="text-xl font-bold">Saques e Comissões</h2>
+        <div class="flex items-center gap-2">
+          <select id="percentualMarcar" class="form-control">
+            <option value="0">0%</option>
+            <option value="0.03">3%</option>
+            <option value="0.04">4%</option>
+            <option value="0.05">5%</option>
+          </select>
+          <button id="btnMarcarPago" class="btn btn-primary text-sm">Marcar como Pago</button>
+        </div>
+      </div>
+      <div class="card-body overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="px-4 py-2"><input type="checkbox" id="chkSaquesFinanceiro" /></th>
+              <th class="px-4 py-2 text-left">Data</th>
+              <th class="px-4 py-2 text-left">Loja</th>
+              <th class="px-4 py-2 text-right">Saque</th>
+              <th class="px-4 py-2 text-right">%</th>
+              <th class="px-4 py-2 text-right">Comissão</th>
+              <th class="px-4 py-2 text-center">Status</th>
+            </tr>
+          </thead>
+          <tbody id="tbodySaquesFinanceiro" class="divide-y divide-gray-200"></tbody>
+        </table>
+      </div>
+      <div class="card-footer text-right text-sm" id="resumoSaquesFinanceiro"></div>
+    </section>
   </main>
   <div id="faturamentoUpdatesCard" class="card card-orange fixed top-20 right-4 w-72 max-h-96 overflow-y-auto hidden">
     <div class="card-header">


### PR DESCRIPTION
## Summary
- add financial manager section listing each withdraw and commission with status and bulk pay option
- load commissions from Firestore `comissoes` path and expose totals
- hook up actions so managers can mark selected withdrawals as paid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adde3f351c832a96e1bc4454f9fc9b