### PR TITLE
Fix sidebar overlay blocking clicks on mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -50,11 +50,14 @@ body {
   inset: 0;
   background: rgba(0,0,0,0.5);
   z-index: 30;
-  display: none;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
 }
 
 #sidebar-overlay.show {
-  display: block;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .section {

--- a/public/shared.js
+++ b/public/shared.js
@@ -391,6 +391,7 @@ function setupMobileSidebar() {
     overlay.id = 'sidebar-overlay';
     document.body.appendChild(overlay);
   }
+  overlay.classList.remove('show');
 
   btn.addEventListener('click', toggleSidebar);
   overlay.addEventListener('click', toggleSidebar);

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'financeiro-cache-v1';
+const CACHE_NAME = 'financeiro-cache-v2';
 const URLS_TO_CACHE = [
   'financeiro.html',
   'financeiro.js',
@@ -11,6 +11,16 @@ const URLS_TO_CACHE = [
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))
+      )
+    )
   );
 });
 

--- a/shared.js
+++ b/shared.js
@@ -398,6 +398,7 @@ function setupMobileSidebar() {
     overlay.id = 'sidebar-overlay';
     document.body.appendChild(overlay);
   }
+  overlay.classList.remove('show');
 
   btn.addEventListener('click', toggleSidebar);
   overlay.addEventListener('click', toggleSidebar);


### PR DESCRIPTION
## Summary
- prevent sidebar overlay from intercepting clicks after closing
- tweak overlay CSS to use opacity/pointer events for visibility
- version service worker cache and clean up old caches

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ade808e494832aaf209f025378da8a