### PR TITLE
Allow financial responsibles to view commissions

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -6,13 +6,43 @@ service cloud.firestore {
         get(/databases/$(database)/documents/usuarios/$(uid)).data.perfil in ['Gestor', 'ADM'];
     }
 
-    match /usuarios/{uid}/comissoes/{anoMes} {
-      allow read, write: if request.auth != null && (request.auth.uid == uid || isGestorOrADM(request.auth.uid));
-      match /saques/{saqueId} {
-        allow read, write: if request.auth != null && (request.auth.uid == uid || isGestorOrADM(request.auth.uid));
-      }
-      match /ajustes/{ajusteId} {
-        allow read, write: if request.auth != null && (request.auth.uid == uid || isGestorOrADM(request.auth.uid));
+    function isResponsavelFinanceiro(uid) {
+      return request.auth.token.email != null &&
+        get(/databases/$(database)/documents/usuarios/$(uid)).data.responsavelFinanceiroEmail == request.auth.token.email;
+    }
+
+    match /usuarios/{uid} {
+      allow read: if request.auth != null && (
+        request.auth.uid == uid ||
+        isGestorOrADM(request.auth.uid) ||
+        (request.auth.token.email != null && request.auth.token.email == resource.data.responsavelFinanceiroEmail)
+      );
+      allow write: if request.auth != null && (request.auth.uid == uid || isGestorOrADM(request.auth.uid));
+
+      match /comissoes/{anoMes} {
+        allow read: if request.auth != null && (
+          request.auth.uid == uid ||
+          isGestorOrADM(request.auth.uid) ||
+          isResponsavelFinanceiro(uid)
+        );
+        allow write: if request.auth != null && (request.auth.uid == uid || isGestorOrADM(request.auth.uid));
+
+        match /saques/{saqueId} {
+          allow read: if request.auth != null && (
+            request.auth.uid == uid ||
+            isGestorOrADM(request.auth.uid) ||
+            isResponsavelFinanceiro(uid)
+          );
+          allow write: if request.auth != null && (request.auth.uid == uid || isGestorOrADM(request.auth.uid));
+        }
+        match /ajustes/{ajusteId} {
+          allow read: if request.auth != null && (
+            request.auth.uid == uid ||
+            isGestorOrADM(request.auth.uid) ||
+            isResponsavelFinanceiro(uid)
+          );
+          allow write: if request.auth != null && (request.auth.uid == uid || isGestorOrADM(request.auth.uid));
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Permit designated financial responsibles to read users' commission and withdrawal records
- Add helper to check financial responsibility in Firestore rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ade8596e3c832a80cfdc25f6deb3b2