### PR TITLE
Allow registering two financial responsibles

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -375,11 +375,16 @@ const API_URL = 'https://us-central1-matheus-35023.cloudfunctions.net/proxyDeepS
         const dadosUsuario = usuarioDoc.data() || {};
         const autorNome = dadosUsuario.nome || firebase.auth().currentUser?.email || '';
         const autorEmail = firebase.auth().currentUser?.email || '';
-        const respEmail = dadosUsuario.responsavelFinanceiroEmail;
-        if (!respEmail) return;
-        const respSnap = await db.collection('usuarios').where('email', '==', respEmail).limit(1).get();
-        if (respSnap.empty) return;
-        const responsavelUid = respSnap.docs[0].id;
+        const respEmails = Array.isArray(dadosUsuario.responsavelFinanceiroEmail)
+          ? dadosUsuario.responsavelFinanceiroEmail
+          : dadosUsuario.responsavelFinanceiroEmail ? [dadosUsuario.responsavelFinanceiroEmail] : [];
+        if (!respEmails.length) return;
+        const responsaveis = [];
+        for (const email of respEmails) {
+          const snap = await db.collection('usuarios').where('email', '==', email).limit(1).get();
+          if (!snap.empty) responsaveis.push(snap.docs[0].id);
+        }
+        if (!responsaveis.length) return;
         const descricao = `Faturamento de ${dataRef} da loja ${loja} atualizado. Bruto: R$ ${bruto.toFixed(2)}, Líquido: R$ ${liquido.toFixed(2)}, Vendas: ${qtdVendas}`;
         await db.collection('financeiroAtualizacoes').add({
           descricao,
@@ -387,7 +392,7 @@ const API_URL = 'https://us-central1-matheus-35023.cloudfunctions.net/proxyDeepS
           autorNome,
           autorEmail,
           dataFaturamento: dataRef,
-          destinatarios: [responsavelUid, usuarioLogado.uid],
+          destinatarios: [...responsaveis, usuarioLogado.uid],
           createdAt: firebase.firestore.FieldValue.serverTimestamp(),
           anexos: [],
           tipo: 'faturamento'
@@ -2999,7 +3004,7 @@ function filtrarPorSKU() {
 async function verificarGestorFinanceiro() {
   try {
     const snap = await db.collection('usuarios')
-      .where('responsavelFinanceiroEmail', '==', usuarioLogado.email)
+      .where('responsavelFinanceiroEmail', 'array-contains', usuarioLogado.email)
       .limit(1)
       .get();
     if (!snap.empty) {
@@ -3021,7 +3026,7 @@ async function carregarAcompanhamentoGestor() {
 
   try {
     const usuariosSnap = await db.collection('usuarios')
-      .where('responsavelFinanceiroEmail', '==', usuarioLogado.email)
+      .where('responsavelFinanceiroEmail', 'array-contains', usuarioLogado.email)
       .get();
     const usuarios = [];
     usuariosSnap.forEach(doc => usuarios.push({ uid: doc.id, ...doc.data() }));

--- a/atualizacoes.js
+++ b/atualizacoes.js
@@ -50,7 +50,7 @@ async function carregarUsuarios() {
   if (lista) lista.innerHTML = '';
   usuariosResponsaveis = [];
   try {
-    const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', currentUser.email)));
+    const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', 'array-contains', currentUser.email)));
     if (snap.empty) {
       card?.classList.add('hidden');
       return;

--- a/desempenho.js
+++ b/desempenho.js
@@ -18,7 +18,7 @@ onAuthStateChanged(auth, async user => {
   }
   usuarios = [{ uid: user.uid, nome: user.displayName || user.email }];
   try {
-    const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email)));
+    const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', 'array-contains', user.email)));
     if (!snap.empty) {
       usuarios = await Promise.all(
         snap.docs.map(async d => {

--- a/email-expedicao.html
+++ b/email-expedicao.html
@@ -18,7 +18,7 @@
     <h1 class="text-2xl font-bold mb-4">E-mails do Responsável pela Expedição</h1>
     <form id="emailForm" class="space-y-4 max-w-lg">
       <input type="text" id="emailExpedicao" placeholder="email@empresa.com, outro@empresa.com" class="w-full p-2 border rounded">
-      <input type="email" id="emailFinanceiro" placeholder="financeiro@empresa.com" class="w-full p-2 border rounded">
+      <input type="text" id="emailFinanceiro" placeholder="financeiro@empresa.com, outro@empresa.com" class="w-full p-2 border rounded">
       <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Salvar</button>
     </form>
     <p id="status" class="mt-4 text-green-600 hidden"></p>
@@ -65,7 +65,7 @@
         const data = doc.data() || {};
         const emails = data.gestoresExpedicaoEmails || data.responsavelExpedicaoEmail || '';
         input.value = Array.isArray(emails) ? emails.join(', ') : emails;
-        financeInput.value = data.responsavelFinanceiroEmail || '';
+        financeInput.value = Array.isArray(data.responsavelFinanceiroEmail) ? data.responsavelFinanceiroEmail.join(', ') : (data.responsavelFinanceiroEmail || '');
       } catch (e) {
         console.error('Erro ao carregar e-mail:', e);
       }
@@ -80,7 +80,7 @@
         });
       });
 
-      db.collection('usuarios').where('responsavelFinanceiroEmail', '==', user.email).onSnapshot(snap => {
+      db.collection('usuarios').where('responsavelFinanceiroEmail', 'array-contains', user.email).onSnapshot(snap => {
         financialUsersList.innerHTML = '';
         if (snap.empty) {
           financialUsersTitle.classList.add('hidden');
@@ -102,17 +102,17 @@
       statusEl.classList.add('hidden');
       const emailsRaw = input.value.trim();
       const emails = emailsRaw.split(',').map(e => e.trim()).filter(e => e);
-      const emailFinanceiro = financeInput.value.trim();
+      const financeEmails = financeInput.value.split(',').map(e => e.trim()).filter(e => e).slice(0,2);
       try {
         await db.collection('uid').doc(currentUser.uid).set({
           responsavelExpedicaoEmail: emails[0] || null,
           gestoresExpedicaoEmails: emails,
-          responsavelFinanceiroEmail: emailFinanceiro || null,
+          responsavelFinanceiroEmail: financeEmails,
           uid: currentUser.uid,
           email: currentUser.email
         }, { merge: true });
         await db.collection('usuarios').doc(currentUser.uid).set({
-          responsavelFinanceiroEmail: emailFinanceiro || null,
+          responsavelFinanceiroEmail: financeEmails,
           gestoresExpedicaoEmails: emails,
           email: currentUser.email
         }, { merge: true });

--- a/financeiro.js
+++ b/financeiro.js
@@ -24,7 +24,7 @@ onAuthStateChanged(auth, async user => {
   }
   let usuarios = [{ uid: user.uid, nome: user.displayName || user.email }];
   try {
-    const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email)));
+    const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', 'array-contains', user.email)));
     if (!snap.empty) {
       usuarios = await Promise.all(
         snap.docs.map(async d => {

--- a/mentoria.js
+++ b/mentoria.js
@@ -10,7 +10,7 @@ const auth = getAuth(app);
 function carregarUsuariosFinanceiros(user) {
   const tbody = document.getElementById('mentoradosList');
   const mesAtual = new Date().toISOString().slice(0, 7);
-  const q = query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email));
+  const q = query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', 'array-contains', user.email));
   onSnapshot(q, async snap => {
     tbody.innerHTML = '';
     if (snap.empty) {


### PR DESCRIPTION
## Summary
- Allow users to store up to two financial responsible emails
- Query finances using `array-contains` for multiple responsibles
- Notify all registered financial responsibles of updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aded0b02f0832abb4af7ab01383c98