### PR TITLE
Fix sidebar visibility for mobile users

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1911,13 +1911,10 @@ body.dark .sidebar-link.active {
   .main-content { margin-left: var(--sidebar-width); }
 }
 
-/* Mobile off-canvas sidebar */
+/* Mobile off-canvas handled by container; sidebar stays static */
 @media (max-width:768px){
   .sidebar {
-    transform: translateX(-100%);
-  }
-  .sidebar.active {
-    transform: translateX(0);
+    transform: none;
   }
 }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -1891,6 +1891,10 @@ body.dark .sidebar {
   background-color: #4c1d95;
 }
 
+body.dark .sidebar-link {
+  color: #fff;
+}
+
 body.dark .sidebar-link:hover,
 body.dark .sidebar-link.active {
   background-color: #3b0c70;

--- a/public/shared.js
+++ b/public/shared.js
@@ -497,8 +497,6 @@ document.addEventListener('sidebarLoaded', async () => {
           const li = a.closest('li') || a.parentElement;
           if (li && !ADMIN_GESTOR_MENU_IDS.includes(a.id)) li.style.display = '';
         });
-      } else {
-        showOnly([]);
       }
     } catch (e) {
       console.error('Erro ao aplicar permissões do sidebar:', e);
@@ -508,6 +506,5 @@ document.addEventListener('sidebarLoaded', async () => {
   const auth = getAuth();
   onAuthStateChanged(auth, user => {
     if (user) applySidebarPermissions(user.uid);
-    else showOnly([]);
   });
 });

--- a/shared.js
+++ b/shared.js
@@ -513,8 +513,6 @@ document.addEventListener('sidebarLoaded', async () => {
           const li = a.closest('li') || a.parentElement;
           if (li && !ADMIN_GESTOR_MENU_IDS.includes(a.id)) li.style.display = '';
         });
-      } else {
-        showOnly([]);
       }
     } catch (e) {
       console.error('Erro ao aplicar permissões do sidebar:', e);
@@ -524,6 +522,5 @@ document.addEventListener('sidebarLoaded', async () => {
   const auth = getAuth(app);
   onAuthStateChanged(auth, user => {
     if (user) applySidebarPermissions(user.uid);
-    else showOnly([]);
   });
 });


### PR DESCRIPTION
## Summary
- Ensure sidebar permission filter only runs after user profile loads
- Keep sidebar link text readable in dark mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adedaeb4f8832a8b45b5d2d73ebfa7