### PR TITLE
Improve finance email update feedback

### DIFF
--- a/email-expedicao.html
+++ b/email-expedicao.html
@@ -165,11 +165,22 @@
       }
       try {
         const responsaveis = [];
+        const notFound = [];
         for (const email of financeEmails) {
           const snap = await db.collection('usuarios').where('email', '==', email).limit(1).get();
-          if (!snap.empty) responsaveis.push(snap.docs[0].id);
+          if (!snap.empty) {
+            responsaveis.push(snap.docs[0].id);
+          } else {
+            notFound.push(email);
+          }
         }
-        if (!responsaveis.length) throw new Error('Responsável não encontrado');
+        if (!responsaveis.length) {
+          statusEl.textContent = `Responsável não encontrado: ${notFound.join(', ')}`;
+          statusEl.classList.remove('hidden');
+          statusEl.classList.remove('text-green-600');
+          statusEl.classList.add('text-red-600');
+          return;
+        }
         const snap = await db.collection('financeiroAtualizacoes').where('destinatarios', 'array-contains', currentUser.uid).get();
         const batch = db.batch();
         snap.forEach(docSnap => {
@@ -178,10 +189,17 @@
           });
         });
         await batch.commit();
-        statusEl.textContent = 'Situação atualizada com sucesso!';
-        statusEl.classList.remove('hidden');
-        statusEl.classList.remove('text-red-600');
-        statusEl.classList.add('text-green-600');
+        if (notFound.length) {
+          statusEl.textContent = `Situação atualizada, mas não encontrados: ${notFound.join(', ')}`;
+          statusEl.classList.remove('hidden');
+          statusEl.classList.remove('text-green-600');
+          statusEl.classList.add('text-red-600');
+        } else {
+          statusEl.textContent = 'Situação atualizada com sucesso!';
+          statusEl.classList.remove('hidden');
+          statusEl.classList.remove('text-red-600');
+          statusEl.classList.add('text-green-600');
+        }
       } catch (err) {
         console.error('Erro ao atualizar situação:', err);
         statusEl.textContent = 'Erro ao atualizar situação';


### PR DESCRIPTION
## Summary
- handle missing finance emails when updating finance history
- notify which emails were not found and continue processing valid ones

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adf3834ae8832a93050a59e2801d60