### PR TITLE
Handle missing finance responsible without console error

### DIFF
--- a/email-expedicao.html
+++ b/email-expedicao.html
@@ -200,14 +200,18 @@
           statusEl.classList.remove('text-red-600');
           statusEl.classList.add('text-green-600');
         }
-      } catch (err) {
-        console.error('Erro ao atualizar situação:', err);
-        statusEl.textContent = 'Erro ao atualizar situação';
-        statusEl.classList.remove('hidden');
-        statusEl.classList.remove('text-green-600');
-        statusEl.classList.add('text-red-600');
-      }
-    });
+        } catch (err) {
+          // Exibe a mensagem de erro ao usuário sem interromper o fluxo
+          const message = err?.message || 'Erro ao atualizar situação';
+          if (message !== 'Responsável não encontrado') {
+            console.error('Erro ao atualizar situação:', err);
+          }
+          statusEl.textContent = message;
+          statusEl.classList.remove('hidden');
+          statusEl.classList.remove('text-green-600');
+          statusEl.classList.add('text-red-600');
+        }
+      });
 
   </script>
   <script src="shared.js"></script>


### PR DESCRIPTION
## Summary
- Avoid logging errors when finance responsible email is not found
- Show meaningful status message to the user instead

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adf5483a60832a8e8932cb0caf8666