### PR TITLE
Automatically create missing finance users

### DIFF
--- a/email-expedicao.html
+++ b/email-expedicao.html
@@ -300,21 +300,14 @@
       }
       try {
         const responsaveis = [];
-        const notFound = [];
         for (const email of financeEmails) {
           const snap = await db.collection('usuarios').where('email', '==', email).limit(1).get();
           if (!snap.empty) {
             responsaveis.push(snap.docs[0].id);
           } else {
-            notFound.push(email);
+            const newDoc = await db.collection('usuarios').add({ email });
+            responsaveis.push(newDoc.id);
           }
-        }
-        if (!responsaveis.length) {
-          statusEl.textContent = `Responsável não encontrado: ${notFound.join(', ')}`;
-          statusEl.classList.remove('hidden');
-          statusEl.classList.remove('text-green-600');
-          statusEl.classList.add('text-red-600');
-          return;
         }
         const snap = await db
           .collection('financeiroAtualizacoes')
@@ -330,23 +323,14 @@
         await syncFaturamento(responsaveis);
         await syncSobras(responsaveis);
         await syncSaques(responsaveis);
-        if (notFound.length) {
-          statusEl.textContent = `Situação atualizada, mas não encontrados: ${notFound.join(', ')}`;
-          statusEl.classList.remove('hidden');
-          statusEl.classList.remove('text-green-600');
-          statusEl.classList.add('text-red-600');
-        } else {
-          statusEl.textContent = 'Situação atualizada com sucesso!';
-          statusEl.classList.remove('hidden');
-          statusEl.classList.remove('text-red-600');
-          statusEl.classList.add('text-green-600');
-        }
+        statusEl.textContent = 'Situação atualizada com sucesso!';
+        statusEl.classList.remove('hidden');
+        statusEl.classList.remove('text-red-600');
+        statusEl.classList.add('text-green-600');
         } catch (err) {
           // Exibe a mensagem de erro ao usuário sem interromper o fluxo
+          console.error('Erro ao atualizar situação:', err);
           const message = err?.message || 'Erro ao atualizar situação';
-          if (message !== 'Responsável não encontrado') {
-            console.error('Erro ao atualizar situação:', err);
-          }
           statusEl.textContent = message;
           statusEl.classList.remove('hidden');
           statusEl.classList.remove('text-green-600');


### PR DESCRIPTION
## Summary
- ensure finance history updates when provided emails aren't registered by creating user documents automatically
- simplify success/error messaging for finance history updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adf85b244c832aae68e0a0818e1406