### PR TITLE
Allow financial responsibles to view faturamento data

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -57,6 +57,22 @@ service cloud.firestore {
       allow update, delete: if request.auth != null && resource.data.autorUid == request.auth.uid;
     }
 
+    match /uid/{uid}/faturamento/{dia} {
+      allow read: if request.auth.uid == uid
+                   || isGestorOrADM(request.auth.uid)
+                   || (request.auth.token.email != null
+                       && request.auth.token.email in get(/databases/$(database)/documents/usuarios/$(uid))
+                          .data.responsavelFinanceiroEmail);
+
+      match /lojas/{lojaId} {
+        allow read: if request.auth.uid == uid
+                     || isGestorOrADM(request.auth.uid)
+                     || (request.auth.token.email != null
+                         && request.auth.token.email in get(/databases/$(database)/documents/usuarios/$(uid))
+                            .data.responsavelFinanceiroEmail);
+      }
+    }
+
     match /contasfechamento/{docId} {
       allow read, write: if request.auth != null;
     }


### PR DESCRIPTION
## Summary
- permit reading daily faturamento records for financial responsibles and managers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adf9c96960832a8ba3b3dca62dc695