### PR TITLE
Add autocomplete attributes to password fields

### DIFF
--- a/login.html
+++ b/login.html
@@ -13,8 +13,8 @@
     <div id="offlineNotice" class="hidden mb-4 text-center text-red-600">Sem conexão com o servidor.</div>
       <form onsubmit="login(); return false;">
         <input id="loginEmail" type="email" placeholder="E-mail" class="w-full p-2 mb-3 border rounded">
-        <input id="loginPassword" type="password" placeholder="Senha" class="w-full p-2 mb-3 border rounded">
-        <input id="loginPassphrase" type="password" placeholder="Passphrase (opcional)" class="w-full p-2 mb-3 border rounded">
+        <input id="loginPassword" type="password" placeholder="Senha" class="w-full p-2 mb-3 border rounded" autocomplete="current-password">
+        <input id="loginPassphrase" type="password" placeholder="Passphrase (opcional)" class="w-full p-2 mb-3 border rounded" autocomplete="current-password">
 
         <div class="flex items-center justify-between mb-3">
           <label class="flex items-center">

--- a/partials/auth-modals.html
+++ b/partials/auth-modals.html
@@ -41,7 +41,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75A4.5 4.5 0 0 0 12 2.25a4.5 4.5 0 0 0-4.5 4.5v3.75M6.75 21.75h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75A2.25 2.25 0 0 0 17.25 10.5h-10.5A2.25 2.25 0 0 0 4.5 12.75v6.75a2.25 2.25 0 0 0 2.25 2.25Z"/>
             </svg>
           </div>
-          <input type="password" id="loginPassword" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
+          <input type="password" id="loginPassword" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••" autocomplete="current-password">
         </div>
       </div>
       <div>
@@ -53,7 +53,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
             </svg>
           </div>
-          <input type="password" id="loginPassphrase" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
+          <input type="password" id="loginPassphrase" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••" autocomplete="current-password">
         </div>
       </div>
       <button type="submit" class="btn-primary w-full py-3.5">
@@ -124,7 +124,7 @@
     </div>
 
     <form class="space-y-6" onsubmit="savePassphrase(); return false;">
-      <input type="password" id="passphraseInput" class="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
+      <input type="password" id="passphraseInput" class="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••" autocomplete="current-password">
       <button type="submit" class="btn-primary w-full py-3.5">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75 10.5 18.75 19.5 5.25"/>

--- a/public/partials/auth-modals.html
+++ b/public/partials/auth-modals.html
@@ -35,7 +35,7 @@
           <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
             <i class="fas fa-lock text-gray-400"></i>
           </div>
-          <input type="password" id="loginPassword" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
+          <input type="password" id="loginPassword" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••" autocomplete="current-password">
         </div>
       </div>
       <div>
@@ -44,7 +44,7 @@
           <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
             <i class="fas fa-eye text-gray-400"></i>
           </div>
-          <input type="password" id="loginPassphrase" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
+          <input type="password" id="loginPassphrase" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••" autocomplete="current-password">
         </div>
       </div>
       <button type="submit" class="btn-primary w-full py-3.5">
@@ -105,7 +105,7 @@
     </div>
 
     <form class="space-y-6" onsubmit="savePassphrase(); return false;">
-      <input type="password" id="passphraseInput" class="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
+      <input type="password" id="passphraseInput" class="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••" autocomplete="current-password">
       <button type="submit" class="btn-primary w-full py-3.5">
         <i class="fas fa-check mr-2"></i> Confirmar
       </button>


### PR DESCRIPTION
## Summary
- Silence browser warnings by adding `autocomplete` to login password fields
- Apply same `autocomplete` to modal passphrase inputs for consistent autofill

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae0674cd44832a9a6ac4cfa3e68774