### PR TITLE
Add autocomplete attributes to password fields

### DIFF
--- a/configuracao-perfil.html
+++ b/configuracao-perfil.html
@@ -52,7 +52,7 @@
           <h3 class="text-lg font-semibold">🔑 Credenciais de acesso</h3>
           <input id="login" class="form-control" placeholder="Usuário / Login">
           <div class="flex items-center space-x-2">
-            <input type="password" id="senha" class="form-control" placeholder="Senha" disabled>
+            <input type="password" id="senha" class="form-control" placeholder="Senha" disabled autocomplete="current-password">
             <button type="button" id="resetPasswordBtn" class="btn btn-secondary">Redefinir Senha</button>
           </div>
           <select id="perfilFuncao" class="form-control">

--- a/login.html
+++ b/login.html
@@ -13,8 +13,8 @@
     <div id="offlineNotice" class="hidden mb-4 text-center text-red-600">Sem conexão com o servidor.</div>
       <form onsubmit="login(); return false;">
         <input id="loginEmail" type="email" placeholder="E-mail" class="w-full p-2 mb-3 border rounded">
-        <input id="loginPassword" type="password" placeholder="Senha" class="w-full p-2 mb-3 border rounded">
-        <input id="loginPassphrase" type="password" placeholder="Passphrase (opcional)" class="w-full p-2 mb-3 border rounded">
+        <input id="loginPassword" type="password" placeholder="Senha" class="w-full p-2 mb-3 border rounded" autocomplete="current-password">
+        <input id="loginPassphrase" type="password" placeholder="Passphrase (opcional)" class="w-full p-2 mb-3 border rounded" autocomplete="current-password">
 
         <div class="flex items-center justify-between mb-3">
           <label class="flex items-center">

--- a/partials/auth-modals.html
+++ b/partials/auth-modals.html
@@ -41,7 +41,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75A4.5 4.5 0 0 0 12 2.25a4.5 4.5 0 0 0-4.5 4.5v3.75M6.75 21.75h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75A2.25 2.25 0 0 0 17.25 10.5h-10.5A2.25 2.25 0 0 0 4.5 12.75v6.75a2.25 2.25 0 0 0 2.25 2.25Z"/>
             </svg>
           </div>
-          <input type="password" id="loginPassword" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
+          <input type="password" id="loginPassword" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••" autocomplete="current-password">
         </div>
       </div>
       <div>
@@ -53,7 +53,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
             </svg>
           </div>
-          <input type="password" id="loginPassphrase" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
+          <input type="password" id="loginPassphrase" class="w-full pl-10 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••" autocomplete="current-password">
         </div>
       </div>
       <button type="submit" class="btn-primary w-full py-3.5">
@@ -124,7 +124,7 @@
     </div>
 
     <form class="space-y-6" onsubmit="savePassphrase(); return false;">
-      <input type="password" id="passphraseInput" class="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••">
+      <input type="password" id="passphraseInput" class="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-orange-500" placeholder="••••••••" autocomplete="current-password">
       <button type="submit" class="btn-primary w-full py-3.5">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75 10.5 18.75 19.5 5.25"/>

--- a/precificacao-tabs/configuracoes.html
+++ b/precificacao-tabs/configuracoes.html
@@ -15,7 +15,7 @@
                   </div>
                   <div>
                     <label class="block text-sm font-medium mb-1">Client Secret</label>
-                    <input type="password" id="mlClientSecret" class="w-full p-2 border rounded" value="">
+                    <input type="password" id="mlClientSecret" class="w-full p-2 border rounded" value="" autocomplete="current-password">
                   </div>
                   <button onclick="testMlConnection()" class="btn-outline">
                     Testar Conexão
@@ -131,7 +131,7 @@
         <div class="space-y-4">
           <input type="text" id="newUserName" class="w-full p-2 border rounded" placeholder="Nome">
           <input type="email" id="newUserEmail" class="w-full p-2 border rounded" placeholder="E-mail">
-          <input type="password" id="newUserPassword" class="w-full p-2 border rounded" placeholder="Senha">
+          <input type="password" id="newUserPassword" class="w-full p-2 border rounded" placeholder="Senha" autocomplete="new-password">
           <select id="newUserProfile" class="w-full p-2 border rounded">
             <option value="operador">Operador</option>
             <option value="admin">Admin</option>

--- a/shopee-hotline-autofill-extension/popup.html
+++ b/shopee-hotline-autofill-extension/popup.html
@@ -21,7 +21,7 @@
   <!-- Login simples -->
   <div id="loginBox">
     <label>Email (Firebase) <input id="authEmail" type="email" /></label>
-    <label>Senha <input id="authPass" type="password" /></label>
+    <label>Senha <input id="authPass" type="password" autocomplete="current-password" /></label>
     <button id="doLogin">Entrar</button>
   </div>
 

--- a/shopee-sync-extension/popup.html
+++ b/shopee-sync-extension/popup.html
@@ -13,8 +13,8 @@
 <body>
   <div id="loginSection">
     <input type="email" id="email" placeholder="Email" />
-    <input type="password" id="password" placeholder="Senha" />
-    <input type="password" id="passphrase" placeholder="Senha para criptografia" />
+    <input type="password" id="password" placeholder="Senha" autocomplete="current-password" />
+    <input type="password" id="passphrase" placeholder="Senha para criptografia" autocomplete="current-password" />
     <button id="loginBtn">Login</button>
   </div>
   <div id="userSection" style="display:none;">


### PR DESCRIPTION
## Summary
- specify autocomplete on login and passphrase inputs
- annotate all password fields across extensions and configuration pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae08ee96b4832aa98876d3a5109104