### PR TITLE
Refine mobile navbar for smaller screens

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1331,6 +1331,9 @@ body.dark-mode th {
   padding: 0 25px;
  justify-content: space-between
 }
+.navbar .hamburger {
+  display: none;
+}
 .navbar-right {
   display: flex;
   align-items: center;
@@ -1739,24 +1742,33 @@ input:checked + .toggle-slider:before {
 }
 
     
-@media (max-width:768px) {
-  .grid-cols-2 {
-    grid-template-columns: 1fr
+  @media (max-width:768px) {
+    .grid-cols-2 {
+      grid-template-columns: 1fr
+    }
+    .modal-content {
+      width: 95%;
+      margin: 10px auto
+    }
+    .navbar {
+      left: 0;
+      height: 50px;
+      padding: 0 10px;
+      background-color: rgba(0,0,0,0.8);
+    }
+    .navbar .menu-item {
+      display: none;
+    }
+    .navbar .hamburger {
+      display: block;
+    }
+    .main-content {
+      margin-left: 0;
+      padding-left: 1rem;
+      padding-right: 1rem;
+      padding-top: 60px;
+    }
   }
-  .modal-content {
-    width: 95%;
-    margin: 10px auto
-  }
-  .navbar {
-    left: 0;
-  }
-  .main-content {
-    margin-left: 0;
-    padding-left: 1rem;
-    padding-right: 1rem;
-    padding-top: 70px;
-  }
-}
 
 .sidebar-item {
   display: flex;

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,31 +1,30 @@
   <div class="navbar">
       <div class="flex items-center">
-        <button class="mobile-menu-btn mr-4 text-gray-200 md:hidden" aria-label="Abrir menu" aria-expanded="false">
+        <button class="mobile-menu-btn hamburger mr-4 text-gray-200" aria-label="Abrir menu" aria-expanded="false">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5" />
           </svg>
         </button>
         <h2 class="text-lg font-semibold text-white">Dashboard</h2>
       </div>
-      
+
       <div class="flex items-center space-x-5">
-        <!-- Botão de login -->
-        <a href="cadastro-interesse.html" class="btn btn-primary">
+        <!-- Botão de cadastro -->
+        <a href="cadastro-interesse.html" class="menu-item text-gray-200 hover:text-white" title="Cadastre-se">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3M12.75 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3.001 19.234c-.001-.037-.001-.074-.001-.111 0-3.52 2.854-6.375 6.375-6.375S15.75 15.604 15.75 19.125v.003a12.318 12.318 0 0 1-6.375 1.872A12.32 12.32 0 0 1 3.001 19.234Z"/>
           </svg>
-          Cadastre-se
         </a>
 
         <!-- Login button -->
-        <button id="loginBtn" class="bg-orange-500 text-white p-2 rounded hover:bg-orange-600 transition flex items-center">
+        <button id="loginBtn" class="menu-item text-gray-200 hover:text-white" title="Login">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.118a8.999 8.999 0 0 1 15 0"/>
           </svg>
         </button>
 
         <!-- Notificações -->
-        <div id="notificationWrapper" class="relative tooltip" data-tooltip="Notificações">
+        <div id="notificationWrapper" class="relative tooltip menu-item" data-tooltip="Notificações">
           <button id="notificationBtn" class="text-gray-200 hover:text-white">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082A23.86 23.86 0 0 0 20.312 15.772 8.966 8.966 0 0 1 18 9.75V9a6 6 0 1 0-12 0v.75a8.966 8.966 0 0 1-2.312 6.021A23.86 23.86 0 0 0 9.143 17.082M14.857 17.082A24.255 24.255 0 0 1 12 17.25c-1.035 0-2.06-.068-3.057-.199M14.857 17.082c.092.29.143.599.143.918a3 3 0 1 1-6 0c0-.319.051-.628.143-.918"/>
@@ -36,14 +35,14 @@
         </div>
 
         <!-- Modo Introdução -->
-        <button id="startTourBtn" class="text-gray-200 hover:text-white hidden tooltip" data-tooltip="Introdução">
+        <button id="startTourBtn" class="menu-item text-gray-200 hover:text-white hidden tooltip" data-tooltip="Introdução">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519a3.75 3.75 0 1 1 4.243 6.212c-.203.178-.43.325-.67.441-.555.26-.903.816-.903 1.43V16.5m0 2.25h.008v.008H12v-.008Z"/>
           </svg>
         </button>
 
         <!-- Perfil do usuário -->
-        <div class="flex items-center space-x-3">
+        <div class="flex items-center space-x-3 menu-item">
           <div class="bg-gray-200 rounded-xl w-10 h-10 overflow-hidden flex items-center justify-center">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-gray-400">
               <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.118a8.999 8.999 0 0 1 15 0"/>
@@ -56,6 +55,6 @@
             </svg>
           </button>
         </div>
-          
+
       </div>
     </div>


### PR DESCRIPTION
## Summary
- shrink navbar height and reveal a hamburger menu on small screens
- convert topbar buttons to compact icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aedf32b4e4832aa9af2fe5a9079d68