### PR TITLE
refactor: improve mobile metric card layout

### DIFF
--- a/atualizacoes.js
+++ b/atualizacoes.js
@@ -151,13 +151,13 @@ async function carregarHistoricoFaturamento() {
     const dias = fatSnap.docs.map(d => d.id).sort().slice(-3);
     let ultimoLiquido = 0;
     const col = document.createElement('div');
-    col.className = 'card p-4 min-w-[200px] text-sm';
-    col.innerHTML = `<h3 class="font-bold mb-1">${u.nome}</h3><div class="text-xs text-gray-500 mb-2">META LÍQUIDA R$ ${metaDiaria.toLocaleString('pt-BR')}</div>`;
+    col.className = 'card metric-card text-sm';
+    col.innerHTML = `<h3 class="font-bold mb-1">${u.nome}</h3><div class="text-xs text-gray-500 mb-2">META LÍQUIDA <span class="metric-value">R$ ${metaDiaria.toLocaleString('pt-BR')}</span></div>`;
     for (const dia of dias) {
       const { liquido, bruto } = await calcularFaturamentoDiaDetalhado(u.uid, dia);
       ultimoLiquido = liquido;
       const vendas = await calcularVendasDia(u.uid, dia);
-      col.innerHTML += `\n        <div class="mt-2">${formatarData(dia)}</div>\n        <div>Bruto R$ ${bruto.toLocaleString('pt-BR')}</div>\n        <div>Líquido R$ ${liquido.toLocaleString('pt-BR')}</div>\n        <div>Vendas ${vendas}</div>`;
+      col.innerHTML += `\n        <div class="metric-item mt-2">${formatarData(dia)}</div>\n        <div class="metric-item">Bruto <span class="metric-value">R$ ${bruto.toLocaleString('pt-BR')}</span></div>\n        <div class="metric-item">Líquido <span class="metric-value">R$ ${liquido.toLocaleString('pt-BR')}</span></div>\n        <div class="metric-item">Vendas <span class="metric-value">${vendas}</span></div>`;
     }
     const diff = metaDiaria - ultimoLiquido;
     const atingido = diff <= 0;

--- a/css/styles.css
+++ b/css/styles.css
@@ -792,6 +792,28 @@ tr:hover {
   gap: .5rem;
   flex-wrap: wrap
 }
+
+/* Metric cards on Atualizações page */
+.card.metric-card {
+  min-width: 200px;
+  background: linear-gradient(135deg, #f8fafc, #e2e8f0);
+}
+.card.metric-card .metric-item + .metric-item {
+  margin-top: 0.5rem;
+}
+.card.metric-card .metric-value {
+  font-weight: 700;
+  font-size: 1.125rem;
+}
+@media (max-width: 768px) {
+  .card.metric-card {
+    min-width: 150px;
+    padding: 2rem;
+  }
+  .card.metric-card .metric-value {
+    font-size: 1.25rem;
+  }
+}
 .form-group {
   margin-bottom: 1.2rem
 }


### PR DESCRIPTION
## Summary
- enhance Atualizações metric cards for mobile with tighter layout and spacing
- highlight monetary and sales figures with bold typography and soft gradient background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aee24a4650832aa1f453cc167946d9