### PR TITLE
Fix mobile sidebar opening across pages

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -402,7 +402,10 @@ function setupMobileSidebar() {
 
   btns.forEach(btn => {
     if (btn.dataset.sidebarReady) return;
-    btn.addEventListener('click', toggleSidebar);
+    // Avoid double triggering if an inline onclick already exists
+    if (!btn.getAttribute('onclick')) {
+      btn.addEventListener('click', toggleSidebar);
+    }
     btn.dataset.sidebarReady = 'true';
   });
   if (!overlay.dataset.sidebarReady) {


### PR DESCRIPTION
## Summary
- avoid double sidebar toggling when mobile button uses inline handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aee1f9eee0832ab10cfeba51d3d5bc