### PR TITLE
Refatora cards de histórico de faturamento com layout de metas

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -814,6 +814,50 @@ tr:hover {
     font-size: 1.25rem;
   }
 }
+
+/* Layout for histórico de faturamento cards */
+.faturamento-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.faturamento-header {
+  width: 160px;
+  text-align: center;
+  background: linear-gradient(135deg, #e000ff, #ff8b8b);
+  color: #fff;
+  font-weight: 700;
+  border-radius: 0.5rem;
+  padding: 0.5rem;
+}
+
+.faturamento-dia {
+  width: 160px;
+  background: linear-gradient(135deg, #e5e7eb, #ffffff);
+  border-radius: 0.5rem;
+  padding: 0.5rem;
+  text-align: center;
+  font-size: 0.875rem;
+}
+
+.faturamento-dia .valor {
+  font-weight: 700;
+}
+
+.faturamento-dia .resultado {
+  margin-top: 0.5rem;
+  font-weight: 700;
+}
+
+.faturamento-dia .resultado.positivo {
+  color: #16a34a;
+}
+
+.faturamento-dia .resultado.negativo {
+  color: #dc2626;
+}
 .form-group {
   margin-bottom: 1.2rem
 }


### PR DESCRIPTION
## Summary
- Exibe histórico de faturamento em colunas por vendedor com cards diários e meta mensal
- Aplica estilos em gradiente para cabeçalho e cards de cada dia

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aee721d54c832a91fad7b9426934bd