### PR TITLE
fix: improve mobile theme and sidebar

### DIFF
--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,6 +1,6 @@
   <div class="navbar">
       <div class="flex items-center">
-        <button class="mobile-menu-btn hamburger mr-4 text-gray-200" aria-label="Abrir menu" aria-expanded="false">
+        <button class="mobile-menu-btn hamburger mr-4 text-gray-200" aria-label="Abrir menu" aria-expanded="false" onclick="toggleSidebar()">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5" />
           </svg>

--- a/public/shared.js
+++ b/public/shared.js
@@ -163,9 +163,8 @@
 
     var toggle = document.getElementById(toggleId);
     var savedTheme = localStorage.getItem('theme');
-    var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
 
-    if (savedTheme === 'dark' || (!savedTheme && prefersDark)) {
+    if (savedTheme === 'dark') {
       document.body.classList.add(darkClass);
       if (toggle) toggle.checked = true;
     }
@@ -275,11 +274,19 @@ const PARTIALS_VERSION = '2025-08-25-02'; // mude quando atualizar parciais
 
 function toggleSidebar(){
   const sb = document.getElementById('sidebar-container');
-  const overlay = document.getElementById('sidebar-overlay');
-  const btn = document.querySelector('.mobile-menu-btn');
   if (!sb) return;
+
+  let overlay = document.getElementById('sidebar-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'sidebar-overlay';
+    document.body.appendChild(overlay);
+    overlay.addEventListener('click', toggleSidebar);
+  }
+
+  const btn = document.querySelector('.mobile-menu-btn');
   const isOpen = sb.classList.toggle('open');
-  if (overlay) overlay.classList.toggle('show', isOpen);
+  overlay.classList.toggle('show', isOpen);
   document.body.style.overflow = isOpen ? 'hidden' : '';
   if (btn) btn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
 }

--- a/shared.js
+++ b/shared.js
@@ -163,9 +163,8 @@
 
     var toggle = document.getElementById(toggleId);
     var savedTheme = localStorage.getItem('theme');
-    var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
 
-    if (savedTheme === 'dark' || (!savedTheme && prefersDark)) {
+    if (savedTheme === 'dark') {
       document.body.classList.add(darkClass);
       if (toggle) toggle.checked = true;
     }
@@ -275,11 +274,19 @@ const PARTIALS_VERSION = '2025-08-25-02'; // mude quando atualizar parciais
 
 function toggleSidebar(){
   const sb = document.getElementById('sidebar-container');
-  const overlay = document.getElementById('sidebar-overlay');
-  const btn = document.querySelector('.mobile-menu-btn');
   if (!sb) return;
+
+  let overlay = document.getElementById('sidebar-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'sidebar-overlay';
+    document.body.appendChild(overlay);
+    overlay.addEventListener('click', toggleSidebar);
+  }
+
+  const btn = document.querySelector('.mobile-menu-btn');
   const isOpen = sb.classList.toggle('open');
-  if (overlay) overlay.classList.toggle('show', isOpen);
+  overlay.classList.toggle('show', isOpen);
   document.body.style.overflow = isOpen ? 'hidden' : '';
   if (btn) btn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
 }


### PR DESCRIPTION
## Summary
- stop forcing dark mode based on device preference
- ensure sidebar toggle works everywhere and creates its own overlay
- hook mobile menu button directly to sidebar toggle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeec9a270c832a9f04535490011565