### PR TITLE
Fix dark mode initialization after layout reload

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -223,9 +223,8 @@
 function initShared() {
   function start() {
     if (window.ensureLayout) {
-      window.ensureLayout().then(function () {
-        window.initDarkMode();
-      });
+      // ensureLayout will initialize dark mode after loading partials
+      window.ensureLayout();
     } else {
       window.initDarkMode();
     }
@@ -365,6 +364,10 @@ async function ensureLayout(){
     loadPartial('#sidebar-container', window.CUSTOM_SIDEBAR_PATH),
     loadPartial('#navbar-container',  window.CUSTOM_NAVBAR_PATH),
   ]);
+  // Reapply dark mode listeners after layout reloads
+  if (typeof window.initDarkMode === 'function') {
+    window.initDarkMode();
+  }
 }
 
 // roda em várias fases para cobrir login/redirect/back-forward-cache


### PR DESCRIPTION
## Summary
- Ensure dark mode toggle is re-bound whenever layout partials load
- Simplify shared startup to rely on layout loader for dark mode setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aef12faa90832a8ab48cd21aa2c1cb