### PR TITLE
refactor: unify sidebar off canvas handling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -37,6 +37,10 @@ body {
 
 #sidebar-container {
   position: fixed;
+  top: 0;
+  left: 0;
+  width: var(--sidebar-width);
+  height: 100%;
   transform: translateX(-100%);
   transition: transform 0.3s ease;
   z-index: 50;
@@ -1927,12 +1931,7 @@ input:checked + .toggle-slider:before {
   color: #fff;
   width: var(--sidebar-width);
   min-height: 100vh;
-  position: fixed;
-  left: 0;
-  top: 0;
   padding-top: 1rem;
-  z-index: 50;
-  transition: transform 0.3s ease;
 }
 
 .sidebar-link {
@@ -1989,12 +1988,5 @@ body.dark .sidebar-link.active {
 /* Desktop sidebar beside content */
 @media (min-width:1024px){
   .main-content { margin-left: var(--sidebar-width); }
-}
-
-/* Mobile off-canvas handled by container; sidebar stays static */
-@media (max-width:768px){
-  .sidebar {
-    transform: none;
-  }
 }
 


### PR DESCRIPTION
## Summary
- centralize off-canvas styling in `#sidebar-container`
- remove redundant fixed/transform logic from `.sidebar`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aef1c8a384832a903c77cd59ef33a8