### PR TITLE
Allow clients to access communication tab

### DIFF
--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -36,7 +36,7 @@
       </a>
     </li>
     <li>
-      <a href="/VendedorPro/comunicacao.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-comunicacao" data-perfil="usuario,gestor,mentor">
+      <a href="/VendedorPro/comunicacao.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-comunicacao" data-perfil="cliente,usuario,gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m21.75 0-9.423 6.615a2.25 2.25 0 0 1-2.654 0L1.5 6.75" />
         </svg>

--- a/public/shared.js
+++ b/public/shared.js
@@ -459,6 +459,7 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-gestao',
     'menu-financeiro',
     'menu-atualizacoes',
+    'menu-comunicacao',
     'menu-saques',
     'menu-acompanhamento-gestor',
     'menu-mentoria',
@@ -467,6 +468,8 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-produtos',
     'menu-desempenho',
   ];
+
+  const CLIENTE_HIDDEN_MENU_IDS = ADMIN_GESTOR_MENU_IDS.filter(id => id !== 'menu-comunicacao');
 
   function showOnly(ids) {
     document.querySelectorAll('#sidebar .sidebar-link').forEach(a => {
@@ -501,10 +504,10 @@ document.addEventListener('sidebarLoaded', async () => {
       if (isADM || isGestor) {
         showOnly(ADMIN_GESTOR_MENU_IDS);
       } else if (isCliente) {
-        hideIds(ADMIN_GESTOR_MENU_IDS);
+        hideIds(CLIENTE_HIDDEN_MENU_IDS);
         document.querySelectorAll('#sidebar .sidebar-link').forEach(a => {
           const li = a.closest('li') || a.parentElement;
-          if (li && !ADMIN_GESTOR_MENU_IDS.includes(a.id)) li.style.display = '';
+          if (li && !CLIENTE_HIDDEN_MENU_IDS.includes(a.id)) li.style.display = '';
         });
       }
     } catch (e) {

--- a/shared.js
+++ b/shared.js
@@ -489,6 +489,8 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-desempenho',
   ];
 
+  const CLIENTE_HIDDEN_MENU_IDS = ADMIN_GESTOR_MENU_IDS.filter(id => id !== 'menu-comunicacao');
+
   function showOnly(ids) {
     document.querySelectorAll('#sidebar .sidebar-link').forEach(a => {
       const li = a.closest('li') || a.parentElement;
@@ -521,10 +523,10 @@ document.addEventListener('sidebarLoaded', async () => {
       if (isADM || isGestor) {
         showOnly(ADMIN_GESTOR_MENU_IDS);
       } else if (isCliente) {
-        hideIds(ADMIN_GESTOR_MENU_IDS);
+        hideIds(CLIENTE_HIDDEN_MENU_IDS);
         document.querySelectorAll('#sidebar .sidebar-link').forEach(a => {
           const li = a.closest('li') || a.parentElement;
-          if (li && !ADMIN_GESTOR_MENU_IDS.includes(a.id)) li.style.display = '';
+          if (li && !CLIENTE_HIDDEN_MENU_IDS.includes(a.id)) li.style.display = '';
         });
       }
     } catch (e) {


### PR DESCRIPTION
## Summary
- Include cliente in communication menu data-perfil so customer accounts see the tab
- Adjust sidebar permission logic to keep communication tab visible for clients
- Sync public build with the same communication tab permissions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aef3a544f8832a858f4a3369f99596