### PR TITLE
Unify main-content margin handling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -362,10 +362,6 @@ input:checked + .dark-mode-slider:before {
   margin-left: 5px
 }
 
-.main-content {
-  flex: 1;
-}
-
 .container {
   max-width: 1200px;
   margin: 0 auto;
@@ -1084,9 +1080,6 @@ tr:hover td {
     left: 0;
     justify-content: space-between;
   }
-  .main-content {
-    margin-left: 0;
-  }
   .menu-toggle {
     display: block;
   }
@@ -1436,12 +1429,6 @@ body.dark-mode th {
 .user-role {
   font-size: 12px;
   color: var(--text-light)
-}
-.main-content {
-  margin-top: 70px;
-  margin-left: var(--sidebar-width);
-  padding: 25px;
-  min-height: calc(100vh - 70px)
 }
 .card:hover {
   transform: translateY(-3px);
@@ -1831,10 +1818,10 @@ input:checked + .toggle-slider:before {
       display: block;
     }
     .main-content {
-      margin-left: 0;
-      padding-left: 1rem;
-      padding-right: 1rem;
-      padding-top: 60px;
+      padding: 1rem;
+    }
+    .sidebar {
+      transform: none;
     }
   }
 
@@ -1982,19 +1969,15 @@ body.dark .sidebar-link.active {
 
 /* Base layout spacing */
 .main-content {
+  flex: 1;
   margin-top: var(--navbar-height);
   margin-left: 0;
+  padding: 25px;
+  min-height: calc(100vh - var(--navbar-height));
 }
 
 /* Desktop sidebar beside content */
 @media (min-width:1024px){
   .main-content { margin-left: var(--sidebar-width); }
-}
-
-/* Mobile off-canvas handled by container; sidebar stays static */
-@media (max-width:768px){
-  .sidebar {
-    transform: none;
-  }
 }
 

--- a/equipes.html
+++ b/equipes.html
@@ -68,12 +68,6 @@
             text-align: center;
         }
 
-        /* Main Content e Vistas */
-        .main-content {
-            flex: 1;
-            margin-left: 260px;
-            padding: 24px;
-        }
         
         .view {
             display: none;
@@ -613,9 +607,6 @@
         @media (max-width: 900px) {
             .team-nav {
                 flex-direction: column;
-            }
-            .main-content {
-                margin-left: 0;
             }
             .board-table th, .board-table td {
                 padding: 8px 12px;

--- a/mentoria.html
+++ b/mentoria.html
@@ -17,9 +17,7 @@
 
   <!-- Layout padrão para TODAS as páginas -->
   <style>
-    :root { --sbw: 256px; } /* largura do sidebar */
     body { font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
-    @media (min-width:1024px){ .main-content { margin-left: var(--sbw); } } /* empurra o conteúdo no desktop */
     .mobile-menu-btn{ position:fixed; left:12px; top:12px; z-index:50; }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- consolidate `.main-content` spacing into one block and media queries for desktop and mobile
- drop page-specific margin overrides in `mentoria.html` and `equipes.html`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aef1da86a8832abb03076e8e4aa9ba