### PR TITLE
refactor: use rem units for border radius

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -36,7 +36,7 @@
   align-items: center;
   justify-content: center;
   gap: 0.5rem; /* gap-2 */
-  border-radius: 9999px; /* rounded-full */
+  border-radius: 624.9375rem; /* rounded-full */
   padding: 0.5rem 1rem; /* px-4 py-2 */
   font-weight: 500; /* font-medium */
   transition: background-color .2s, color .2s, box-shadow .2s;
@@ -193,7 +193,7 @@
 .progress {
   background-color: #e5e7eb;
   height: 6px;
-  border-radius: 9999px;
+  border-radius: 624.9375rem;
   overflow: hidden;
 }
 .progress .progress-bar {

--- a/css/styles.css
+++ b/css/styles.css
@@ -107,7 +107,7 @@ body.has-sidebar .content-wrapper {
 .card-header-icon {
   width: 50px;
   height: 50px;
-  border-radius: 10px;
+  border-radius: 0.625rem;
   display: flex;
   align-items: center;
  justify-content: center;
@@ -120,7 +120,7 @@ body.has-sidebar .content-wrapper {
 .alert-success {
   color: var(--success);
   padding: 12px 20px;
-  border-radius: 8px;
+  border-radius: 0.5rem;
   border-left: 4px solid var(--success);
   margin-bottom: 20px
 }
@@ -128,7 +128,7 @@ body.has-sidebar .content-wrapper {
   background-color: rgba(244,67,54,.1);
   color: var(--error);
   padding: 12px 20px;
-  border-radius: 8px;
+  border-radius: 0.5rem;
   border-left: 4px solid var(--error);
   margin-bottom: 20px
 }
@@ -141,7 +141,7 @@ body.has-sidebar .content-wrapper {
   bottom: 0;
   background-color: #ccc;
   transition: .4s;
-  border-radius: 24px
+  border-radius: 1.5rem
 }
 .dark-mode-slider:before {
   position: absolute;
@@ -386,7 +386,7 @@ h4 {
   background: #f8f9fa;
   padding: 20px;
   margin-top: 25px;
-  border-radius: 10px;
+  border-radius: 0.625rem;
   border-left: 4px solid var(--primary)
 }
 .result strong {
@@ -394,7 +394,7 @@ h4 {
 }
 .summary-box {
   background: #f8f9fa;
-  border-radius: 10px;
+  border-radius: 0.625rem;
   padding: 20px;
   margin-bottom: 20px;
   border-left: 4px solid var(--primary)
@@ -402,7 +402,7 @@ h4 {
 .resumo-container {
   padding: 25px;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: 0.75rem;
   background: #fff;
   box-shadow: 0 5px 15px rgba(0,0,0,.05);
   margin-top: 20px
@@ -417,7 +417,7 @@ h4 {
 
 .resumo-card {
   background: #f8f9fa;
-  border-radius: 8px;
+  border-radius: 0.5rem;
   padding: 1rem;
   text-align: center;
   box-shadow: 0 2px 4px rgba(0,0,0,.05);
@@ -468,7 +468,7 @@ h4 {
   select {
     padding: 12px;
     border: 1px solid var(--border);
-    border-radius: 8px;
+    border-radius: 0.5rem;
     font-size: 16px;
     transition: .3s;
     font-family: Inter,sans-serif;
@@ -491,7 +491,7 @@ h4 {
     color: #fff;
     border: none;
     padding: 12px 25px;
-    border-radius: 30px;
+    border-radius: 1.875rem;
     font-family: Inter,sans-serif;
     font-weight: 500;
     cursor: pointer;
@@ -618,7 +618,7 @@ h4 {
 }
 .dark-mode-toggle {
   background: #e0e0e0;
-  border-radius: 13px;
+  border-radius: 0.8125rem;
   cursor: pointer;
   transition: background .3s
 }
@@ -652,7 +652,7 @@ h4 {
   color: var(--primary);
   width: 50px;
   height: 50px;
-  border-radius: 12px;
+  border-radius: 0.75rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -664,7 +664,7 @@ h4 {
   gap: .5rem;
   margin-bottom: 2rem;
   background: #fff;
-  border-radius: 12px;
+  border-radius: 0.75rem;
   padding: .5rem;
   box-shadow: var(--card-shadow);
   justify-content: center;
@@ -675,7 +675,7 @@ h4 {
   background: #fff;
   border: none;
   color: var(--secondary);
-  border-radius: 8px;
+  border-radius: 0.5rem;
   font-weight: 600;
   transition: var(--transition);
   display: flex;
@@ -707,7 +707,7 @@ h4 {
 }
 .alert {
   padding: 1rem;
-  border-radius: 12px;
+  border-radius: 0.75rem;
   margin: 1rem 0;
   display: flex;
   align-items: center;
@@ -715,7 +715,7 @@ h4 {
 }
 .card-metric-novo {
   background: #fff;
-  border-radius: 16px;
+  border-radius: 1rem;
   padding: 1.5rem;
   box-shadow: 0 10px 25px rgba(0,0,0,.06);
   border-left: 5px solid var(--primary);
@@ -824,7 +824,7 @@ h4 {
 .form-control {
   padding: .8rem 1rem;
   border: 1px solid #e2e8f0;
-  border-radius: 10px;
+  border-radius: 0.625rem;
   width: 100%;
   font-size: 1rem;
   transition: var(--transition);
@@ -889,7 +889,7 @@ h4 {
 .badge {
   display: inline-block;
   padding: .4rem .8rem;
-  border-radius: 20px;
+  border-radius: 1.25rem;
   font-size: .85rem;
   font-weight: 600
 }
@@ -915,7 +915,7 @@ h4 {
 }
 .chart-container {
   background: #fff;
-  border-radius: 16px;
+  border-radius: 1rem;
   padding: 1.5rem;
   margin: 2rem 0;
   box-shadow: var(--card-shadow)
@@ -936,7 +936,7 @@ h4 {
   padding: 1rem;
   border-bottom: 1px solid #edf2f7;
   background: #fff;
-  border-radius: 10px;
+  border-radius: 0.625rem;
   margin-bottom: .5rem;
   transition: var(--transition)
 }
@@ -954,7 +954,7 @@ h4 {
   bottom: 1rem;
   right: 1rem;
   padding: .6rem 1.2rem;
-  border-radius: 50px;
+  border-radius: 3.125rem;
   font-size: .9rem;
   font-weight: 500;
   z-index: 1000;
@@ -1279,7 +1279,7 @@ body.dark-mode .data-table th {
 
 #sidebar::-webkit-scrollbar-thumb {
   background-color: rgba(0,0,0,0.3);
-  border-radius: 2px;
+  border-radius: 0.125rem;
 }
 
 .submenu {
@@ -1366,7 +1366,7 @@ body.dark-mode .data-table th {
 }
 .dashboard-card {
   background: var(--card);
-  border-radius: 12px;
+  border-radius: 0.75rem;
   padding: 20px;
   box-shadow: 0 4px 6px rgba(0,0,0,.05)
 }
@@ -1387,7 +1387,7 @@ body.dark-mode .data-table th {
   border: none;
   cursor: pointer;
   transition: .3s;
-  border-radius: 6px;
+  border-radius: 0.375rem;
   font-weight: 500;
   color: var(--text-light);
   position: relative
@@ -1407,7 +1407,7 @@ body.dark-mode .data-table th {
   right: 0;
   height: 3px;
   background: var(--primary);
-  border-radius: 3px 3px 0 0
+  border-radius: 0.1875rem 0.1875rem 0 0
 }
 @media (max-width:768px) {
   .tabs {
@@ -1440,7 +1440,7 @@ select {
   padding: 12px 15px;
   margin-bottom: 12px;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 0.5rem;
   background: var(--card);
   color: var(--text);
   font-size: 14px
@@ -1452,7 +1452,7 @@ select:focus {
   box-shadow: 0 0 0 3px rgba(244,92,0,.2)
 }
 .table-container {
-  border-radius: 8px;
+  border-radius: 0.5rem;
   overflow: hidden;
   border: 1px solid var(--border);
   background: var(--card)
@@ -1488,7 +1488,7 @@ body.dark-mode .table tr:nth-child(2n) {
 }
 .scenario-card {
   background: var(--card);
-  border-radius: 8px;
+  border-radius: 0.5rem;
   padding: 15px;
   margin-top: 10px;
   border-left: 4px solid
@@ -1517,7 +1517,7 @@ body.dark-mode .table tr:nth-child(2n) {
 .platform-tag {
   display: inline-block;
   padding: 3px 10px;
-  border-radius: 20px;
+  border-radius: 1.25rem;
   font-size: 12px;
   font-weight: 600
 }
@@ -1553,7 +1553,7 @@ body.dark-mode .table tr:nth-child(2n) {
   background-color: var(--card);
   margin: 5% auto;
   padding: 25px;
-  border-radius: 12px;
+  border-radius: 0.75rem;
   width: 90%;
   max-width: 700px;
   max-height: 90vh;
@@ -1594,7 +1594,7 @@ body.dark-mode .table tr:nth-child(2n) {
   bottom: 25px;
   right: 25px;
   padding: 15px 20px;
-  border-radius: 8px;
+  border-radius: 0.5rem;
   color: #fff;
   font-weight: 500;
   box-shadow: 0 4px 12px rgba(0,0,0,.15);
@@ -1635,7 +1635,7 @@ body.dark-mode .table tr:nth-child(2n) {
   background: linear-gradient(90deg,var(--border) 25%,rgba(0,0,0,.05) 50%,var(--border) 75%);
   background-size: 200% 100%;
   animation: 1.5s infinite loading;
-  border-radius: 4px
+  border-radius: 0.25rem
 }
 @keyframes loading {
   0% {
@@ -1655,7 +1655,7 @@ body.dark-mode .table tr:nth-child(2n) {
   background-color: var(--brand);
   color: #fff;
   text-align: center;
-  border-radius: 6px;
+  border-radius: 0.375rem;
   padding: 5px 0;
   position: absolute;
   z-index: 1;
@@ -1706,7 +1706,7 @@ body.dark-mode .table tr:nth-child(2n) {
   bottom: 0;
   background-color: #ccc;
   transition: .4s;
-  border-radius: 24px
+  border-radius: 1.5rem
 }
 .toggle-slider:before {
   position: absolute;
@@ -1832,7 +1832,7 @@ input:checked + .toggle-slider:before {
 
   .resumo-card {
     border: 1px solid #ccc;
-    border-radius: 6px;
+    border-radius: 0.375rem;
     padding: 10px;
   }
 }


### PR DESCRIPTION
## Summary
- use rem units for border radius values to ensure consistent scaling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aef6a4325c832ab334b85bfe1f5f28