### PR TITLE
refactor: use border color variable consistently

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -1,7 +1,7 @@
 /* Consolidated component styles without Tailwind's @apply */
 .card {
   background-color: var(--card, #ffffff);
-  border: 1px solid var(--border, #e5e7eb);
+  border: 1px solid var(--border);
   border-left: 4px solid var(--primary);
   border-radius: 1.25rem; /* rounded-3xl */
   box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -2px rgba(0,0,0,0.05);
@@ -23,7 +23,7 @@
 .card-header {
   display: flex;
   align-items: center;
-  border-bottom: 1px solid var(--border, #e5e7eb);
+  border-bottom: 1px solid var(--border);
   padding: 0.75rem 1rem;
   background: linear-gradient(135deg, #4F46E5, #9333EA);
   color: #fff;
@@ -87,7 +87,7 @@
   top: 100%;
   left: 0;
   background: #fff;
-  border: 1px solid var(--border, #e5e7eb);
+  border: 1px solid var(--border);
   border-radius: 0.5rem;
   min-width: 150px;
   z-index: 100;
@@ -125,14 +125,14 @@
   text-align: left;
   font-weight: 600;
   color: var(--dark);
-  border-bottom: 2px solid var(--border, #e9ecef);
+  border-bottom: 2px solid var(--border);
   position: sticky;
   top: 0;
 }
 
 .data-table td {
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--border, #e9ecef);
+  border-bottom: 1px solid var(--border);
 }
 
 .data-table tr:nth-child(even) {
@@ -191,7 +191,7 @@
 }
 
 .progress {
-  background-color: #e5e7eb;
+  background-color: var(--border);
   height: 6px;
   border-radius: 9999px;
   overflow: hidden;
@@ -203,7 +203,7 @@
 
 .progress-wrapper {
   width: 100%;
-  background-color: #e5e7eb;
+  background-color: var(--border);
   border-radius: 0.5rem;
   overflow: hidden;
   height: 0.5rem;

--- a/css/styles.css
+++ b/css/styles.css
@@ -16,7 +16,7 @@
   --bg-light: #F5F7FA;
   --background: #FAFAFA;
   --bg: #FAFAFA;
-  --border: #E0E0E0;
+  --border: #e5e7eb;
   --card: #FFFFFF;
   --card-bg: #FFFFFF;
   --card-shadow: 0 4px 6px rgba(0,0,0,0.1);
@@ -201,7 +201,7 @@ input:checked + .dark-mode-slider:before {
 }
 
 .introjs-prevbutton {
-  background-color: #e5e7eb;
+  background-color: var(--border);
   color: #333;
 }
 
@@ -242,7 +242,7 @@ input:checked + .dark-mode-slider:before {
 
 #tarefasCard .progress-wrapper {
   width: 100%;
-  background-color: #e5e7eb;
+  background-color: var(--border);
   border-radius: 0.5rem;
   overflow: hidden;
   height: 0.5rem;
@@ -295,7 +295,7 @@ input:checked + .dark-mode-slider:before {
 }
 
 #tarefasCard .task-actions button {
-  background-color: #e5e7eb;
+  background-color: var(--border);
   padding: 0.25rem 0.5rem;
   border-radius: 0.25rem;
   transition: background-color .2s;
@@ -795,7 +795,7 @@ h4 {
 
 .faturamento-dia {
   width: 160px;
-  background: linear-gradient(135deg, #e5e7eb, #ffffff);
+  background: linear-gradient(135deg, var(--border), #ffffff);
   border-radius: 0.5rem;
   padding: 0.5rem;
   text-align: center;
@@ -1576,7 +1576,7 @@ body.dark-mode .table tr:nth-child(2n) {
   border-radius: 0.5rem;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   padding: 1.5rem;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--border);
 }
 
 .product-card:hover {

--- a/gestao-contas.html
+++ b/gestao-contas.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="css/components.css">
   <style>
     body{font-family:system-ui,Segoe UI,Roboto,Arial;margin:24px;max-width:920px}
-    .card{border:1px solid #e5e7eb;border-radius:14px;padding:16px;margin:12px 0}
+    .card{border:1px solid var(--border);border-radius:14px;padding:16px;margin:12px 0}
     .row{display:flex;gap:12px;flex-wrap:wrap}
     label{font-weight:600}
     input,button,select{padding:10px;border:1px solid #d1d5db;border-radius:10px}

--- a/manual.html
+++ b/manual.html
@@ -32,8 +32,8 @@
     }
     /* Tabela responsiva simples */
     .table { width:100%; border-collapse: collapse; }
-    .table th, .table td { border-bottom:1px solid #e5e7eb; text-align:left; padding:10px; font-size: 0.95rem; }
-    .kbd { background:#f3f4f6; border:1px solid #e5e7eb; border-bottom-width:2px; border-radius:6px; padding:2px 6px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: 0.8rem; }
+    .table th, .table td { border-bottom:1px solid var(--border); text-align:left; padding:10px; font-size: 0.95rem; }
+    .kbd { background:#f3f4f6; border:1px solid var(--border); border-bottom-width:2px; border-radius:6px; padding:2px 6px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: 0.8rem; }
     .badge { background:#fff7ed; color:#9a3412; border:1px solid #fed7aa; border-radius:999px; padding:2px 10px; font-size: .75rem; font-weight:600; }
     .section h2 { scroll-margin-top: 100px; }
   </style>


### PR DESCRIPTION
## Summary
- replace direct `#e5e7eb` colors with `var(--border)`
- remove fallbacks and rely on shared `--border` value

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aef7045dc0832a99622db3f7a67dfc