### PR TITLE
feat: add persistent chat dock with unread indicators

### DIFF
--- a/comunicacao.html
+++ b/comunicacao.html
@@ -51,20 +51,19 @@
   </main>
 
 
-<div id="chatModal" class="fixed inset-0 bg-gray-800 bg-opacity-50 hidden justify-center items-center">
-  <div class="bg-white w-full max-w-md h-full md:h-[80%] md:rounded-lg flex flex-col">
-    <div class="flex items-center bg-green-600 text-white p-4">
-      <button id="closeChat" class="mr-2 text-white">←</button>
-      <span id="chatUserName" class="font-semibold"></span>
-    </div>
-    <div id="chatMessages" class="flex-1 overflow-y-auto p-4 space-y-2 bg-gray-100"></div>
-    <div class="p-2 flex">
-      <input id="chatInput" class="flex-1 border rounded-l px-2 py-1 text-sm" placeholder="Digite uma mensagem..." />
-      <button id="chatSend" class="bg-green-600 text-white px-4 rounded-r text-sm">Enviar</button>
-    </div>
+<div id="chatDock" class="fixed bottom-0 right-0 flex space-x-2 p-2"></div>
+
+<div id="chatModal" class="fixed bottom-14 right-4 w-80 max-h-[70vh] bg-white border rounded-lg shadow-lg hidden flex flex-col">
+  <div class="flex items-center bg-green-600 text-white p-2 rounded-t-lg">
+    <button id="closeChat" class="mr-2 text-white">–</button>
+    <span id="chatUserName" class="font-semibold"></span>
+  </div>
+  <div id="chatMessages" class="flex-1 overflow-y-auto p-2 space-y-2 bg-gray-100"></div>
+  <div class="p-2 flex">
+    <input id="chatInput" class="flex-1 border rounded-l px-2 py-1 text-sm" placeholder="Digite uma mensagem..." />
+    <button id="chatSend" class="bg-green-600 text-white px-4 rounded-r text-sm">Enviar</button>
   </div>
 </div>
-
 
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="comunicacao.js"></script>


### PR DESCRIPTION
## Summary
- fix chat modal layout and introduce dock for active conversations
- show unread message indicator and update chat state on open

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aefa121c6c832a95f225b135db531d