### PR TITLE
Refine sidebar and nav media queries

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -94,15 +94,6 @@ body.has-sidebar .content-wrapper {
   margin-left: var(--sidebar-width);
 }
 
-@media (max-width:768px) {
-  body.has-sidebar .navbar {
-    left: 0;
-  }
-  body.has-sidebar .content-wrapper {
-    margin-left: 0;
-  }
-}
-
 
 .card-header-icon {
   width: 50px;
@@ -995,18 +986,6 @@ h4 {
     transform: rotate(360deg)
   }
 }
-@media (max-width:992px) {
-  .navbar {
-    left: 0;
-    justify-content: space-between;
-  }
-  .main-content {
-    margin-left: 0;
-  }
-  .menu-toggle {
-    display: block;
-  }
-}
 @media (max-width:768px) {
   .tab-bar {
     gap: .3rem
@@ -1189,6 +1168,13 @@ h4 {
   cursor: pointer
 }
 @media (max-width:992px) {
+  .navbar {
+    left: 0;
+    justify-content: space-between;
+  }
+  .main-content {
+    margin-left: 0;
+  }
   .menu-toggle {
     display: block
   }
@@ -1264,7 +1250,8 @@ body.dark-mode .data-table th {
 
 @media (max-width:768px) {
   /* Sidebar visibility handled by container; remove legacy transforms */
-  .content-wrapper {
+  .content-wrapper,
+  body.has-sidebar .content-wrapper {
     margin-left: 0;
   }
 }


### PR DESCRIPTION
## Summary
- Consolidate 992px breakpoint into a single media query for navbar, main content and menu toggle
- Simplify 768px breakpoint to consistently remove sidebar offset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aefb3fe3a0832a8dcfd552d686e3a1