### PR TITLE
feat: add persistent chat dock with unread indicators

### DIFF
--- a/comunicacao.html
+++ b/comunicacao.html
@@ -51,20 +51,19 @@
   </main>
 
 
-<div id="chatModal" class="fixed inset-0 bg-gray-800 bg-opacity-50 hidden justify-center items-center">
-  <div class="bg-white w-full max-w-md h-full md:h-[80%] md:rounded-lg flex flex-col">
-    <div class="flex items-center bg-green-600 text-white p-4">
-      <button id="closeChat" class="mr-2 text-white">←</button>
-      <span id="chatUserName" class="font-semibold"></span>
-    </div>
-    <div id="chatMessages" class="flex-1 overflow-y-auto p-4 space-y-2 bg-gray-100"></div>
-    <div class="p-2 flex">
-      <input id="chatInput" class="flex-1 border rounded-l px-2 py-1 text-sm" placeholder="Digite uma mensagem..." />
-      <button id="chatSend" class="bg-green-600 text-white px-4 rounded-r text-sm">Enviar</button>
-    </div>
+<div id="chatDock" class="fixed bottom-0 right-0 flex space-x-2 p-2"></div>
+
+<div id="chatModal" class="fixed bottom-14 right-4 w-80 max-h-[70vh] bg-white border rounded-lg shadow-lg hidden flex flex-col">
+  <div class="flex items-center bg-green-600 text-white p-2 rounded-t-lg">
+    <button id="closeChat" class="mr-2 text-white">–</button>
+    <span id="chatUserName" class="font-semibold"></span>
+  </div>
+  <div id="chatMessages" class="flex-1 overflow-y-auto p-2 space-y-2 bg-gray-100"></div>
+  <div class="p-2 flex">
+    <input id="chatInput" class="flex-1 border rounded-l px-2 py-1 text-sm" placeholder="Digite uma mensagem..." />
+    <button id="chatSend" class="bg-green-600 text-white px-4 rounded-r text-sm">Enviar</button>
   </div>
 </div>
-
 
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="comunicacao.js"></script>

--- a/comunicacao.js
+++ b/comunicacao.js
@@ -22,6 +22,18 @@ const closeChat = document.getElementById('closeChat');
 let chatUnsub = null;
 let currentChatUser = null;
 const usersMap = {};
+const chatDock = document.getElementById('chatDock');
+const chatButtons = {};
+const openChatUsers = new Set(JSON.parse(localStorage.getItem('openChatUsers') || '[]'));
+const chatLastOpened = JSON.parse(localStorage.getItem('chatLastOpened') || '{}');
+
+function saveOpenChats() {
+  localStorage.setItem('openChatUsers', JSON.stringify([...openChatUsers]));
+}
+
+function saveLastOpened() {
+  localStorage.setItem('chatLastOpened', JSON.stringify(chatLastOpened));
+}
 
 function addUserOption(user) {
   const li = document.createElement('li');
@@ -66,14 +78,54 @@ function renderChatMessage(msg) {
   chatMessages.appendChild(div);
 }
 
+function ensureChatButton(userInfo) {
+  const cid = getConversationId(auth.currentUser.uid, userInfo.id);
+  if (chatButtons[cid]) return chatButtons[cid];
+  const wrapper = document.createElement('div');
+  wrapper.className = 'relative';
+  const btn = document.createElement('button');
+  btn.className = 'bg-green-600 text-white px-3 py-1 rounded-t';
+  btn.textContent = userInfo.nome || userInfo.email || userInfo.id;
+  const dot = document.createElement('span');
+  dot.className = 'absolute top-0 right-0 w-3 h-3 bg-green-400 rounded-full hidden';
+  wrapper.appendChild(btn);
+  wrapper.appendChild(dot);
+  chatDock.appendChild(wrapper);
+  btn.addEventListener('click', () => openChat(userInfo));
+  const q = query(
+    collection(db, 'comunicacao'),
+    where('tipo', '==', 'mensagem'),
+    where('conversa', '==', cid),
+    orderBy('timestamp')
+  );
+  onSnapshot(q, snap => {
+    const msgs = [];
+    snap.forEach(d => msgs.push(d.data()));
+    if (msgs.length === 0) return;
+    const last = msgs[msgs.length - 1];
+    const ts = last.timestamp ? last.timestamp.toMillis() : Date.now();
+    if (ts > (chatLastOpened[cid] || 0) && last.remetente !== auth.currentUser.uid) {
+      dot.classList.remove('hidden');
+    }
+  });
+  openChatUsers.add(userInfo.id);
+  saveOpenChats();
+  chatButtons[cid] = { button: btn, dot };
+  return chatButtons[cid];
+}
+
 function openChat(userInfo) {
+  ensureChatButton(userInfo);
   currentChatUser = userInfo;
   chatUserName.textContent = userInfo.nome || userInfo.email || userInfo.id;
   chatModal.classList.remove('hidden');
-  chatModal.classList.add('flex');
   if (chatUnsub) chatUnsub();
   chatMessages.innerHTML = '';
   const cid = getConversationId(auth.currentUser.uid, userInfo.id);
+  chatLastOpened[cid] = Date.now();
+  saveLastOpened();
+  if (chatButtons[cid]) chatButtons[cid].dot.classList.add('hidden');
+  localStorage.setItem('activeChatUser', userInfo.id);
   const q = query(
     collection(db, 'comunicacao'),
     where('tipo', '==', 'mensagem'),
@@ -84,6 +136,9 @@ function openChat(userInfo) {
     chatMessages.innerHTML = '';
     snap.forEach(d => renderChatMessage(d.data()));
     chatMessages.scrollTop = chatMessages.scrollHeight;
+    chatLastOpened[cid] = Date.now();
+    saveLastOpened();
+    if (chatButtons[cid]) chatButtons[cid].dot.classList.add('hidden');
   });
 }
 
@@ -114,9 +169,18 @@ async function loadComms(uid) {
   });
 }
 
+function restoreChats() {
+  openChatUsers.forEach(uid => {
+    if (usersMap[uid]) ensureChatButton(usersMap[uid]);
+  });
+  const activeId = localStorage.getItem('activeChatUser');
+  if (activeId && usersMap[activeId]) openChat(usersMap[activeId]);
+}
+
 closeChat.addEventListener('click', () => {
   chatModal.classList.add('hidden');
   if (chatUnsub) chatUnsub();
+  localStorage.removeItem('activeChatUser');
 });
 
 chatSend.addEventListener('click', async () => {
@@ -145,6 +209,7 @@ onAuthStateChanged(auth, async user => {
   const perfil = (data.perfil || '').toLowerCase();
   await loadTeam(user, perfil, data);
   await loadComms(user.uid);
+  restoreChats();
 
   document.getElementById('sendFileBtn').addEventListener('click', async () => {
     const file = document.getElementById('fileInput').files[0];


### PR DESCRIPTION
## Summary
- persist open chat state and read timestamps across reloads
- restore conversation dock and active chat on page load
- keep unread indicators accurate between sessions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aefa121c6c832a95f225b135db531d