### PR TITLE
Add WhatsApp-style chat windows to team list

### DIFF
--- a/comunicacao.html
+++ b/comunicacao.html
@@ -51,19 +51,21 @@
   </main>
 
 
-<div id="chatDock" class="fixed bottom-0 right-0 flex space-x-2 p-2"></div>
+  <div id="chatDock" class="fixed bottom-0 right-0 flex space-x-2 p-2"></div>
 
-<div id="chatModal" class="fixed bottom-14 right-4 w-80 max-h-[70vh] bg-white border rounded-lg shadow-lg hidden flex flex-col">
-  <div class="flex items-center bg-green-600 text-white p-2 rounded-t-lg">
-    <button id="closeChat" class="mr-2 text-white">–</button>
-    <span id="chatUserName" class="font-semibold"></span>
+<template id="chatWindowTemplate">
+  <div class="w-80 max-h-[70vh] bg-white border rounded-lg shadow-lg flex flex-col">
+    <div class="flex items-center bg-green-600 text-white p-2 rounded-t-lg">
+      <span class="chatUserName font-semibold flex-1"></span>
+      <button class="closeChat ml-2 text-white">×</button>
+    </div>
+    <div class="chatMessages flex-1 overflow-y-auto p-2 space-y-2 bg-gray-100"></div>
+    <div class="p-2 flex">
+      <input class="chatInput flex-1 border rounded-l px-2 py-1 text-sm" placeholder="Digite uma mensagem..." />
+      <button class="chatSend bg-green-600 text-white px-4 rounded-r text-sm">Enviar</button>
+    </div>
   </div>
-  <div id="chatMessages" class="flex-1 overflow-y-auto p-2 space-y-2 bg-gray-100"></div>
-  <div class="p-2 flex">
-    <input id="chatInput" class="flex-1 border rounded-l px-2 py-1 text-sm" placeholder="Digite uma mensagem..." />
-    <button id="chatSend" class="bg-green-600 text-white px-4 rounded-r text-sm">Enviar</button>
-  </div>
-</div>
+</template>
 
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="comunicacao.js"></script>


### PR DESCRIPTION
## Summary
- Add reusable chat window template on communication page
- Spawn chat windows when clicking a team member

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af0084ee5c832aababf168ce14c112