### PR TITLE
Evita mensagens no histórico de comunicação

### DIFF
--- a/comunicacao.js
+++ b/comunicacao.js
@@ -131,6 +131,7 @@ async function loadComms(uid) {
   const snap = await getDocs(collection(db, 'comunicacao'));
   snap.forEach(docSnap => {
     const c = docSnap.data();
+    if (c.tipo === 'mensagem') return;
     if ((Array.isArray(c.destinatarios) && c.destinatarios.includes(uid)) || c.remetente === uid) {
       renderComm(c);
     }


### PR DESCRIPTION
## Summary
- Evita que mensagens de chat apareçam no histórico da página de comunicação

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af025cb088832ab93091bd74c719fc