### PR TITLE
Oculta mensagens do histórico de comunicação

### DIFF
--- a/comunicacao.js
+++ b/comunicacao.js
@@ -34,12 +34,11 @@ function addUserOption(user) {
 }
 
 function renderComm(c) {
+  if (c.tipo === 'mensagem') return;
   const li = document.createElement('li');
   li.className = 'border p-2 rounded';
   if (c.tipo === 'arquivo') {
     li.innerHTML = `<strong>Arquivo:</strong> <a href="${c.arquivoUrl}" target="_blank" class="text-blue-600 underline">${c.arquivoNome || 'Arquivo'}</a>`;
-  } else if (c.tipo === 'mensagem') {
-    li.innerHTML = `<strong>Mensagem:</strong> ${c.texto}`;
   } else if (c.tipo === 'alerta') {
     li.innerHTML = `<strong>Alerta:</strong> ${c.texto}`;
   }
@@ -131,7 +130,10 @@ async function loadComms(uid) {
   const snap = await getDocs(collection(db, 'comunicacao'));
   snap.forEach(docSnap => {
     const c = docSnap.data();
-    if ((Array.isArray(c.destinatarios) && c.destinatarios.includes(uid)) || c.remetente === uid) {
+    if (
+      c.tipo !== 'mensagem' &&
+      ((Array.isArray(c.destinatarios) && c.destinatarios.includes(uid)) || c.remetente === uid)
+    ) {
       renderComm(c);
     }
   });


### PR DESCRIPTION
## Summary
- Ignora mensagens ao preencher a lista de histórico da aba Comunicação
- Evita que mensagens apareçam no histórico renderizando apenas arquivos e alertas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af025cb088832ab93091bd74c719fc