### PR TITLE
feat: show user update notifications in navbar bell

### DIFF
--- a/atualizacoes.js
+++ b/atualizacoes.js
@@ -223,6 +223,7 @@ async function enviarAtualizacao(e) {
     autorUid: currentUser.uid,
     autorNome: currentUser.displayName || currentUser.email,
     destinatarios,
+    tipo: 'atualizacao',
     createdAt: serverTimestamp(),
     anexos: []
   });

--- a/login.js
+++ b/login.js
@@ -29,6 +29,7 @@ let explicitLogout = false;
 let isExpedicao = false;
 let notifUnsub = null;
 let expNotifUnsub = null;
+let updNotifUnsub = null;
 let selectedRole = null;
 window.isFinanceiroResponsavel = false;
 
@@ -391,13 +392,15 @@ function initNotificationListener(uid) {
   if (!btn || !badge || !list) return;
   if (notifUnsub) notifUnsub();
   if (expNotifUnsub) expNotifUnsub();
+  if (updNotifUnsub) updNotifUnsub();
 
   let finNotifs = [];
   let expNotifs = [];
+  let updNotifs = [];
 
   const render = () => {
     list.innerHTML = '';
-    const all = [...finNotifs, ...expNotifs].sort((a, b) => b.ts - a.ts);
+    const all = [...finNotifs, ...expNotifs, ...updNotifs].sort((a, b) => b.ts - a.ts);
     let count = 0;
     all.forEach(n => {
       const item = document.createElement('div');
@@ -432,6 +435,25 @@ function initNotificationListener(uid) {
     render();
   }, err => {
     console.error('Erro no listener de notificações:', err);
+  });
+
+  const qUpd = query(
+    collection(db, 'financeiroAtualizacoes'),
+    where('destinatarios', 'array-contains', uid),
+    where('tipo', '==', 'atualizacao'),
+    orderBy('createdAt', 'desc')
+  );
+  updNotifUnsub = onSnapshot(qUpd, snap => {
+    updNotifs = [];
+    snap.forEach(docSnap => {
+      const d = docSnap.data();
+      if (d.autorUid === uid) return;
+      const texto = `${d.autorNome || d.autorEmail || ''}: ${d.descricao || ''}`;
+      updNotifs.push({ text: texto, ts: d.createdAt?.toDate ? d.createdAt.toDate().getTime() : 0 });
+    });
+    render();
+  }, err => {
+    console.error('Erro no listener de notificações de atualizações:', err);
   });
 
   const qExp = query(
@@ -471,6 +493,8 @@ function checkLogin() {
       wasLoggedIn = false;
       hideUserArea();
       if (notifUnsub) { notifUnsub(); notifUnsub = null; }
+      if (expNotifUnsub) { expNotifUnsub(); expNotifUnsub = null; }
+      if (updNotifUnsub) { updNotifUnsub(); updNotifUnsub = null; }
       if (!onLoginPage) window.location.href = 'login.html';
     }
   });


### PR DESCRIPTION
## Summary
- show user update notifications in navbar bell
- include update docs in notification listener and logout cleanup
- tag updates with tipo `atualizacao`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0352632e0832abdd538d351dca4b7