### PR TITLE
Remove tab-bar from sobras system

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -55,36 +55,7 @@
         </button>
       </div>
       
-      <!-- Barra de navegação por abas -->
-      <div class="tab-bar">
-        <button class="tab-btn active" onclick="trocarAba('importar')">
-          <i class="fas fa-box-open"></i> Conferir Pedidos
-        </button>
-        <button class="tab-btn" onclick="trocarAba('historico')">
-          <i class="fas fa-history"></i> Histórico
-        </button>
-        <button class="tab-btn" onclick="trocarAba('faturamento')">
-          <i class="fas fa-cash-register"></i> Faturamento Diário
-        </button>
-        <button class="tab-btn" onclick="trocarAba('registroFaturamento'); carregarRegistrosFaturamento('listaFaturamentoRegistro', 'filtroMesRegistro')">
-          <i class="fas fa-file-alt"></i> Registro de Faturamento
-        </button>
-        <button class="tab-btn" onclick="trocarAba('controleVendas'); carregarControleVendas()">
-          <i class="fas fa-boxes"></i> Controle de Vendas
-         </button>
-        <button class="tab-btn" onclick="trocarAba('sobras'); carregarSobras()">
-          <i class="fas fa-exclamation-circle"></i> Sobras
-        </button>
-        <button class="tab-btn" onclick="trocarAba('previsao'); carregarPrevisao()">
-          <i class="fas fa-chart-area"></i> 📈 Previsão
-        </button>
-        <button class="tab-btn" onclick="trocarAba('acompanhamento'); carregarAcompanhamento()">
-          <i class="fas fa-chart-line"></i> Acompanhamento
-        </button>
-        <button id="btnAcompanhamentoGestor" class="tab-btn hidden" onclick="trocarAba('acompanhamentoGestor'); carregarAcompanhamentoGestor()">
-          <i class="fas fa-users"></i> Acompanhamento Sobras
-        </button>
-      </div>
+      <!-- Tab bar removida -->
 
       <!-- Aba de Importação/Conferência -->
       <div id="importar" class="tab-content active">
@@ -456,32 +427,19 @@ const API_URL = 'https://us-central1-matheus-35023.cloudfunctions.net/proxyDeepS
     // =============================================
     
     window.trocarAba = function trocarAba(id) {
-      // Remove a classe 'active' de todas as abas
-      document.querySelectorAll('.tab-content').forEach(aba => aba.classList.remove('active'));
-      
-      // Remove a classe 'active' de todos os botões de aba
-      document.querySelectorAll('.tab-btn').forEach(btn => btn.classList.remove('active'));
+        // Remove a classe 'active' de todas as abas
+        document.querySelectorAll('.tab-content').forEach(aba => aba.classList.remove('active'));
 
-      // Ativa a aba correspondente, se existir
-      const abaSelecionada = document.getElementById(id);
-      if (abaSelecionada) {
-        abaSelecionada.classList.add('active');
-      } else {
-        console.warn(`❌ Aba com ID '${id}' não encontrada.`);
-        return;
-      }
+        // Ativa a aba correspondente, se existir
+        const abaSelecionada = document.getElementById(id);
+        if (abaSelecionada) {
+          abaSelecionada.classList.add('active');
+        } else {
+          console.warn(`❌ Aba com ID '${id}' não encontrada.`);
+          return;
+        }
 
-      // Ativa o botão correspondente
-      const botao = Array.from(document.querySelectorAll('.tab-btn'))
-        .find(btn => btn.getAttribute('onclick')?.includes(`trocarAba('${id}')`));
-      
-      if (botao) {
-        botao.classList.add('active');
-      } else {
-        console.warn(`❌ Botão com onclick trocarAba('${id}') não encontrado.`);
-      }
-
-      // Atualiza gráficos, se necessário
+        // Atualiza gráficos, se necessário
       if (id === 'graficos') {
         setTimeout(atualizarGraficos, 100);
       }

--- a/css/styles.css
+++ b/css/styles.css
@@ -649,17 +649,6 @@ h4 {
   justify-content: center;
   font-size: 1.5rem
 }
-.tab-bar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: .5rem;
-  margin-bottom: 2rem;
-  background: #fff;
-  border-radius: 0.75rem;
-  padding: .5rem;
-  box-shadow: var(--card-shadow);
-  justify-content: center;
-}
 .tab-btn {
   padding: .8rem 1.5rem;
   cursor: pointer;
@@ -987,9 +976,6 @@ h4 {
   }
 }
 @media (max-width:768px) {
-  .tab-bar {
-    gap: .3rem
-  }
   .tab-btn {
     padding: .6rem 1rem;
     font-size: .9rem
@@ -1014,9 +1000,6 @@ h4 {
     flex-direction: column;
     align-items: flex-start;
     gap: .8rem
-  }
-  .tab-bar {
-    justify-content: center
   }
   .tab-btn {
     flex: 1;
@@ -1196,7 +1179,6 @@ body.dark-mode {
 }
 body.dark-mode .card,
 body.dark-mode .chart-container,
-body.dark-mode .tab-bar,
 body.dark-mode .tab-content,
 body.dark-mode .table-container {
   background: var(--card-bg);
@@ -1768,7 +1750,6 @@ input:checked + .toggle-slider:before {
   /* Oculta elementos de navegação e botões */
   .sidebar,
   .navbar,
-  .tab-bar,
   .tab-btn,
   .btn,
   .connection-status,


### PR DESCRIPTION
## Summary
- remove unused tab-bar navigation from sobr as conference page
- simplify tab switching logic to rely solely on sidebar links
- drop tab-bar styling from main stylesheet

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0359f16bc832aacd1cd9cdfec645e