### PR TITLE
fix: safeguard user area and avoid firebase redeclaration

### DIFF
--- a/login.js
+++ b/login.js
@@ -1,4 +1,4 @@
-import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { initializeApp as firebaseInitializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
 
 import { getAuth, setPersistence, browserLocalPersistence, signInWithEmailAndPassword, signOut, sendPasswordResetEmail, onAuthStateChanged, updateProfile } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 
@@ -20,7 +20,7 @@ import {
 import { firebaseConfig, setPassphrase, getPassphrase, clearPassphrase } from './firebase-config.js';
 import { encryptString, decryptString } from './crypto.js';
 
-const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+const app = getApps().length ? getApps()[0] : firebaseInitializeApp(firebaseConfig);
 const auth = getAuth(app);
 const db = getFirestore(app);
 let wasLoggedIn = false;
@@ -215,6 +215,10 @@ window.sendRecovery = () => {
 
 async function showUserArea(user) {
   const nameEl = document.getElementById('currentUser');
+  if (!nameEl) {
+    console.warn('Elemento #currentUser não encontrado');
+    return;
+  }
   nameEl.textContent = user.email;
   nameEl.onclick = () => {
     const input = document.getElementById('displayNameInput');
@@ -300,6 +304,10 @@ async function showUserArea(user) {
 
 function hideUserArea() {
   const nameEl = document.getElementById('currentUser');
+  if (!nameEl) {
+    console.warn('Elemento #currentUser não encontrado');
+    return;
+  }
   nameEl.textContent = 'Usuário';
   nameEl.onclick = null;
   // Oculta o botão de logout apenas se ele existir

--- a/public/login.js
+++ b/public/login.js
@@ -1,4 +1,4 @@
-import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { initializeApp as firebaseInitializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
 
 import { getAuth, setPersistence, browserLocalPersistence, signInWithEmailAndPassword, signOut, sendPasswordResetEmail, onAuthStateChanged, updateProfile } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 
@@ -20,7 +20,7 @@ import {
 import { firebaseConfig, setPassphrase, getPassphrase, clearPassphrase } from './firebase-config.js';
 import { encryptString, decryptString } from './crypto.js';
 
-const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+const app = getApps().length ? getApps()[0] : firebaseInitializeApp(firebaseConfig);
 const auth = getAuth(app);
 const db = getFirestore(app);
 let wasLoggedIn = false;
@@ -192,6 +192,10 @@ window.sendRecovery = () => {
 
 async function showUserArea(user) {
   const nameEl = document.getElementById('currentUser');
+  if (!nameEl) {
+    console.warn('Elemento #currentUser não encontrado');
+    return;
+  }
   nameEl.textContent = user.email;
   nameEl.onclick = () => {
     const input = document.getElementById('displayNameInput');
@@ -267,6 +271,10 @@ async function showUserArea(user) {
 
 function hideUserArea() {
   const nameEl = document.getElementById('currentUser');
+  if (!nameEl) {
+    console.warn('Elemento #currentUser não encontrado');
+    return;
+  }
   nameEl.textContent = 'Usuário';
   nameEl.onclick = null;
   // Oculta o botão de logout apenas se ele existir

--- a/public/tiny.js
+++ b/public/tiny.js
@@ -1,9 +1,9 @@
-import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { initializeApp as firebaseInitializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
 import { getFirestore, collection, query, orderBy, limit, startAfter, startAt, endAt, getDocs } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
 import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 import { firebaseConfig } from './firebase-config.js';
 
-const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+const app = getApps().length ? getApps()[0] : firebaseInitializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app);
 

--- a/tiny.js
+++ b/tiny.js
@@ -1,9 +1,9 @@
-import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { initializeApp as firebaseInitializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
 import { getFirestore, collection, query, orderBy, limit, startAfter, startAt, endAt, getDocs } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
 import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 import { firebaseConfig } from './firebase-config.js';
 
-const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+const app = getApps().length ? getApps()[0] : firebaseInitializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app);
 


### PR DESCRIPTION
## Summary
- alias Firebase `initializeApp` in tiny and login scripts to avoid duplicate declarations
- guard user area updates when `#currentUser` element is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b03d2db77c832a80d596f4b717226a