### PR TITLE
fix: handle Tiny auth

### DIFF
--- a/tiny.html
+++ b/tiny.html
@@ -13,6 +13,7 @@
 <body class="bg-gray-100 text-gray-800">
   <div id="sidebar-container"></div>
   <div id="navbar-container"></div>
+  <div id="auth-modals-container"></div>
   <div class="main-content p-4">
     <section id="aba-tiny" class="p-4">
       <div class="mb-4 flex items-center gap-2">

--- a/tiny.js
+++ b/tiny.js
@@ -7,6 +7,21 @@ const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app);
 
+// Garante que os modais de autenticação estejam disponíveis
+if (typeof window !== 'undefined' && window.loadAuthModals) {
+  window.loadAuthModals();
+}
+
+function showLoginModal() {
+  const modal = document.getElementById('loginModal');
+  if (modal) {
+    modal.style.display = 'block';
+  } else {
+    // Re-tenta após um pequeno atraso caso os modais ainda não tenham sido carregados
+    setTimeout(showLoginModal, 500);
+  }
+}
+
 async function getIdToken() {
   const user = auth.currentUser;
   if (!user) throw new Error("Não logado");
@@ -14,10 +29,10 @@ async function getIdToken() {
 }
 
 // URLs públicas das Cloud Functions
-const URL_CONNECT = "https://southamerica-east1-matheus-35023.cloudfunctions.net/connectTiny";
-const URL_DISCONNECT = "https://southamerica-east1-matheus-35023.cloudfunctions.net/disconnectTiny";
-const URL_SYNC_PRODUCTS = "https://southamerica-east1-matheus-35023.cloudfunctions.net/syncTinyProducts";
-const URL_SYNC_ORDERS   = "https://southamerica-east1-matheus-35023.cloudfunctions.net/syncTinyOrders";
+const URL_CONNECT = "https://connecttiny-g6u4niudyq-uc.a.run.app";
+const URL_DISCONNECT = "https://disconnecttiny-g6u4niudyq-uc.a.run.app";
+const URL_SYNC_PRODUCTS = "https://synctinyproducts-g6u4niudyq-uc.a.run.app";
+const URL_SYNC_ORDERS   = "https://synctinyorders-g6u4niudyq-uc.a.run.app";
 
 const stateTiny = {
   produtos: { pageSize: 30, lastDoc: null, stack: [], search: '', page: 1 },
@@ -26,7 +41,7 @@ const stateTiny = {
 
 onAuthStateChanged(auth, user => {
   if (!user) {
-    window.location.href = 'index.html?login=1';
+    showLoginModal();
     return;
   }
   carregarProdutos();


### PR DESCRIPTION
## Summary
- load auth modals and display login modal for unauthorized users
- update Tiny Cloud Function endpoints for Tiny integration
- add auth modal container to Tiny page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b08a7a90e8832a9eaab4c101c19bbf