### PR TITLE
Salva dados de etiquetas processadas via OCR

### DIFF
--- a/etiquetas-ocr.html
+++ b/etiquetas-ocr.html
@@ -209,32 +209,11 @@ firebase.auth().onAuthStateChanged(async u => {
         const data = {
           sku: item.sku,
           quantidade: item.quantidade,
-          userUid: currentUser.uid,
-          userEmail: currentUser.email,
-          createdAt: firebase.firestore.FieldValue.serverTimestamp()
+          loja: item.loja || '',
+          data: firebase.firestore.FieldValue.serverTimestamp()
         };
-        batch.set(userDoc.collection('skuimpressos').doc(), data);
-        if (respDoc) batch.set(respDoc.collection('skuimpressos').doc(), data);
-      });
-      await batch.commit();
-    }
-
-    async function saveMercadoLivreData(items) {
-      if (!currentUser || !items || items.length === 0) return;
-      const batch = db.batch();
-      const userDoc = db.collection('uid').doc(currentUser.uid);
-      const respDoc = responsavelExpedicaoUid ? db.collection('uid').doc(responsavelExpedicaoUid) : null;
-      items.forEach(item => {
-        const data = {
-          sku: item.sku,
-          quantidade: item.quantidade,
-          loja: item.loja,
-          userUid: currentUser.uid,
-          userEmail: currentUser.email,
-          createdAt: firebase.firestore.FieldValue.serverTimestamp()
-        };
-        batch.set(userDoc.collection('skuimpressos').doc(), data);
-        if (respDoc) batch.set(respDoc.collection('skuimpressos').doc(), data);
+        batch.set(userDoc.collection('etiquetasimpressas').doc(), data);
+        if (respDoc) batch.set(respDoc.collection('etiquetasimpressas').doc(), data);
       });
       await batch.commit();
     }
@@ -502,7 +481,7 @@ completoCtx.drawImage(
           createdAt: firebase.firestore.FieldValue.serverTimestamp(),
           name: fileName
         });
-        const fileRef = storage.ref().child(`ml_pdfs/${currentUser.uid}/${docRef.id}.pdf`);
+        const fileRef = storage.ref().child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
         await fileRef.put(pdfFile);
         const url = await fileRef.getDownloadURL();
         await docRef.update({ url: url, storagePath: fileRef.fullPath });
@@ -521,7 +500,7 @@ completoCtx.drawImage(
             createdAt: firebase.firestore.FieldValue.serverTimestamp(),
             name: fileName
           });
-          const respFileRef = storage.ref().child(`ml_pdfs/${responsavelExpedicaoUid}/${respDocRef.id}.pdf`);
+          const respFileRef = storage.ref().child(`pdfs/${responsavelExpedicaoUid}/${respDocRef.id}.pdf`);
           await respFileRef.put(pdfFile);
           const respUrl = await respFileRef.getDownloadURL();
           await respDocRef.update({ url: respUrl, storagePath: respFileRef.fullPath });
@@ -535,7 +514,7 @@ completoCtx.drawImage(
         }
       }
 
-      await saveMercadoLivreData(allItems);
+      await savePrintedSkuQuantities(allItems);
       status.textContent = "✅ Etiquetas Mercado Livre processadas!";
     }
 


### PR DESCRIPTION
## Summary
- Guarda SKU, quantidade, loja e data das etiquetas OCR na coleção `etiquetasimpressas`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1a48494f0832ab88ba89dc9c0b411