### PR TITLE
fix: use Tiny order ID field

### DIFF
--- a/pedidos-tiny.js
+++ b/pedidos-tiny.js
@@ -40,7 +40,7 @@ export async function carregarPedidosTiny() {
       const loja = p.loja || p.store || '';
       const sku = p.sku || (Array.isArray(p.itens) ? p.itens.map(i => i.sku).join(', ') : '');
       const valor = p.valor || p.total || '';
-      const idPedido = p.idpedido || p.id;
+      const idPedido = p.idPedido || p.idpedido || p.id;
       tr.innerHTML = `
         <td data-label="Data">${data}</td>
         <td data-label="ID">${idPedido}</td>


### PR DESCRIPTION
## Summary
- ensure Tiny orders table shows idPedido from document data instead of Firestore document ID

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e71ae160832aa28fa99fd913a188