### PR TITLE
feat: add advanced filters for Tiny orders

### DIFF
--- a/pedidos-tiny.html
+++ b/pedidos-tiny.html
@@ -19,6 +19,45 @@
         <h2 class="text-xl font-bold">\uD83D\uDCE6 Pedidos Tiny</h2>
       </div>
       <div class="card-body">
+        <div class="form-row items-end mb-4">
+          <div class="form-group compact">
+            <label for="tipoData" class="block text-sm font-medium mb-1">Data</label>
+            <select id="tipoData" class="form-control">
+              <option value="dia">Dia único</option>
+              <option value="mes">Mês</option>
+              <option value="personalizado">Personalizado</option>
+            </select>
+          </div>
+          <div class="form-group compact" id="grupoDia">
+            <label for="dataDia" class="block text-sm font-medium mb-1">Dia</label>
+            <input type="date" id="dataDia" class="form-control">
+          </div>
+          <div class="form-group compact hidden" id="grupoMes">
+            <label for="dataMes" class="block text-sm font-medium mb-1">Mês</label>
+            <input type="month" id="dataMes" class="form-control">
+          </div>
+          <div class="form-group compact hidden" id="grupoInicio">
+            <label for="dataInicio" class="block text-sm font-medium mb-1">Início</label>
+            <input type="date" id="dataInicio" class="form-control">
+          </div>
+          <div class="form-group compact hidden" id="grupoFim">
+            <label for="dataFim" class="block text-sm font-medium mb-1">Fim</label>
+            <input type="date" id="dataFim" class="form-control">
+          </div>
+          <div class="form-group compact">
+            <label for="filtroLoja" class="block text-sm font-medium mb-1">Loja</label>
+            <select id="filtroLoja" class="form-control">
+              <option value="">Todas</option>
+            </select>
+          </div>
+          <div class="form-group compact">
+            <label for="filtroSku" class="block text-sm font-medium mb-1">SKU</label>
+            <input type="text" id="filtroSku" class="form-control" placeholder="SKU">
+          </div>
+          <div class="form-group compact">
+            <button id="aplicarFiltros" class="btn btn-primary w-full">Filtrar</button>
+          </div>
+        </div>
         <div class="overflow-x-auto">
           <table id="tabelaPedidosTiny" class="data-table">
             <thead>

--- a/pedidos-tiny.js
+++ b/pedidos-tiny.js
@@ -8,6 +8,8 @@ const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app);
 
+let todosPedidos = [];
+
 onAuthStateChanged(auth, async user => {
   if (!user) {
     window.location.href = 'index.html?login=1';
@@ -33,31 +35,118 @@ export async function carregarPedidosTiny() {
       }
       if (pedido) pedidos.push({ id: d.id, ...pedido });
     }
-    tbody.innerHTML = '';
-    pedidos.forEach(p => {
-      const tr = document.createElement('tr');
-      const data = p.data || p.dataPedido || p.date || '';
-      const loja = p.loja || p.store || '';
-      const sku = p.sku || (Array.isArray(p.itens) ? p.itens.map(i => i.sku).join(', ') : '');
-      const valor = p.valor || p.total || '';
-      const idPedido = p.idPedido || p.idpedido || p.id;
-      tr.innerHTML = `
-        <td data-label="Data">${data}</td>
-        <td data-label="ID">${idPedido}</td>
-        <td data-label="Loja">${loja}</td>
-        <td data-label="SKU">${sku}</td>
-        <td data-label="Valor">${valor}</td>
-      `;
-      tbody.appendChild(tr);
-    });
-    if (!tbody.children.length) {
-      tbody.innerHTML = '<tr><td colspan="5" class="text-center py-4 text-gray-500">Nenhum pedido encontrado</td></tr>';
-    }
+    todosPedidos = pedidos;
+    preencherFiltroLoja(pedidos);
+    aplicarFiltros();
   } catch (err) {
     console.error('Erro ao carregar pedidos', err);
     tbody.innerHTML = '<tr><td colspan="5" class="text-center py-4 text-red-500">Erro ao carregar pedidos</td></tr>';
   }
 }
+
+function preencherFiltroLoja(pedidos) {
+  const select = document.getElementById('filtroLoja');
+  if (!select) return;
+  const lojas = [...new Set(pedidos.map(p => p.loja || p.store || '').filter(Boolean))].sort();
+  lojas.forEach(loja => {
+    const opt = document.createElement('option');
+    opt.value = loja;
+    opt.textContent = loja;
+    select.appendChild(opt);
+  });
+}
+
+function parseDate(str) {
+  if (!str) return new Date('');
+  const parts = str.split(/[\/\-]/);
+  if (parts.length === 3) {
+    if (str.includes('-') && parts[0].length === 4) {
+      return new Date(str);
+    }
+    const [d, m, y] = parts;
+    return new Date(`${y}-${m}-${d}`);
+  }
+  return new Date(str);
+}
+
+function sameDay(a, b) {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+}
+
+export function aplicarFiltros() {
+  const tbody = document.querySelector('#tabelaPedidosTiny tbody');
+  if (!tbody) return;
+  let filtrados = [...todosPedidos];
+  const tipo = document.getElementById('tipoData')?.value;
+  const dia = document.getElementById('dataDia')?.value;
+  const mes = document.getElementById('dataMes')?.value;
+  const inicio = document.getElementById('dataInicio')?.value;
+  const fim = document.getElementById('dataFim')?.value;
+  const loja = document.getElementById('filtroLoja')?.value;
+  const skuFiltro = document.getElementById('filtroSku')?.value?.toLowerCase();
+
+  filtrados = filtrados.filter(p => {
+    const dataStr = p.data || p.dataPedido || p.date || '';
+    const data = parseDate(dataStr);
+    if (tipo === 'dia' && dia) {
+      const d = parseDate(dia);
+      if (!sameDay(data, d)) return false;
+    } else if (tipo === 'mes' && mes) {
+      const m = parseDate(`${mes}-01`);
+      if (data.getFullYear() !== m.getFullYear() || data.getMonth() !== m.getMonth()) return false;
+    } else if (tipo === 'personalizado' && inicio && fim) {
+      const i = parseDate(inicio);
+      const f = parseDate(fim);
+      if (data < i || data > f) return false;
+    }
+
+    const lojaPedido = (p.loja || p.store || '').toLowerCase();
+    if (loja && lojaPedido !== loja.toLowerCase()) return false;
+
+    const sku = (p.sku || (Array.isArray(p.itens) ? p.itens.map(i => i.sku).join(', ') : '')).toLowerCase();
+    if (skuFiltro && !sku.includes(skuFiltro)) return false;
+    return true;
+  });
+
+  tbody.innerHTML = '';
+  filtrados.forEach(p => {
+    const tr = document.createElement('tr');
+    const data = p.data || p.dataPedido || p.date || '';
+    const lojaPedido = p.loja || p.store || '';
+    const sku = p.sku || (Array.isArray(p.itens) ? p.itens.map(i => i.sku).join(', ') : '');
+    const valor = p.valor || p.total || '';
+    const idPedido = p.idPedido || p.idpedido || p.id;
+    tr.innerHTML = `
+        <td data-label="Data">${data}</td>
+        <td data-label="ID">${idPedido}</td>
+        <td data-label="Loja">${lojaPedido}</td>
+        <td data-label="SKU">${sku}</td>
+        <td data-label="Valor">${valor}</td>
+      `;
+    tbody.appendChild(tr);
+  });
+  if (!tbody.children.length) {
+    tbody.innerHTML = '<tr><td colspan="5" class="text-center py-4 text-gray-500">Nenhum pedido encontrado</td></tr>';
+  }
+}
+
+function atualizarTipoData() {
+  const tipo = document.getElementById('tipoData')?.value;
+  document.getElementById('grupoDia')?.classList.toggle('hidden', tipo !== 'dia');
+  document.getElementById('grupoMes')?.classList.toggle('hidden', tipo !== 'mes');
+  const perso = tipo !== 'personalizado';
+  document.getElementById('grupoInicio')?.classList.toggle('hidden', perso);
+  document.getElementById('grupoFim')?.classList.toggle('hidden', perso);
+}
+
+document.getElementById('aplicarFiltros')?.addEventListener('click', aplicarFiltros);
+['tipoData', 'dataDia', 'dataMes', 'dataInicio', 'dataFim', 'filtroLoja'].forEach(id => {
+  document.getElementById(id)?.addEventListener('change', aplicarFiltros);
+});
+document.getElementById('filtroSku')?.addEventListener('input', aplicarFiltros);
+document.getElementById('tipoData')?.addEventListener('change', atualizarTipoData);
+
+atualizarTipoData();
 
 if (typeof window !== 'undefined') {
   window.carregarPedidosTiny = carregarPedidosTiny;


### PR DESCRIPTION
## Summary
- add date (day, month, custom range), store and SKU filters to Pedidos Tiny page
- implement client-side filtering and populate store options dynamically

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1eb1530bc832a9dec369f0a306c8f