### PR TITLE
fix: ensure Tiny orders filters apply

### DIFF
--- a/pedidos-tiny.html
+++ b/pedidos-tiny.html
@@ -55,7 +55,7 @@
             <input type="text" id="filtroSku" class="form-control" placeholder="SKU">
           </div>
           <div class="form-group compact">
-            <button id="aplicarFiltros" class="btn btn-primary w-full">Filtrar</button>
+            <button id="aplicarFiltros" type="button" class="btn btn-primary w-full">Filtrar</button>
           </div>
         </div>
         <div class="overflow-x-auto">

--- a/pedidos-tiny.js
+++ b/pedidos-tiny.js
@@ -139,7 +139,10 @@ function atualizarTipoData() {
   document.getElementById('grupoFim')?.classList.toggle('hidden', perso);
 }
 
-document.getElementById('aplicarFiltros')?.addEventListener('click', aplicarFiltros);
+document.getElementById('aplicarFiltros')?.addEventListener('click', e => {
+  e.preventDefault();
+  aplicarFiltros();
+});
 ['tipoData', 'dataDia', 'dataMes', 'dataInicio', 'dataFim', 'filtroLoja'].forEach(id => {
   document.getElementById(id)?.addEventListener('change', aplicarFiltros);
 });


### PR DESCRIPTION
## Summary
- prevent Tiny orders filter button from submitting forms
- ensure filter button and inputs update orders list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2578ea550832a8f26a1ec5cb9609b