### PR TITLE
feat: add summary totals to Tiny orders

### DIFF
--- a/pedidos-tiny.html
+++ b/pedidos-tiny.html
@@ -19,6 +19,7 @@
         <h2 class="text-xl font-bold">\uD83D\uDCE6 Pedidos Tiny</h2>
       </div>
       <div class="card-body">
+        <div id="resumoPedidosTiny" class="resumo-grid mb-4 p-4 bg-white rounded-lg text-sm text-gray-700 shadow"></div>
         <div class="form-row items-end mb-4">
           <div class="form-group compact">
             <label for="tipoData" class="block text-sm font-medium mb-1">Data</label>

--- a/pedidos-tiny.js
+++ b/pedidos-tiny.js
@@ -125,6 +125,19 @@ function calcularLiquido(p) {
   return total - taxa;
 }
 
+function atualizarResumo(pedidos) {
+  const resumo = document.getElementById('resumoPedidosTiny');
+  if (!resumo) return;
+  const totalBruto = pedidos.reduce((s, p) => s + toNumber(p.valor || p.total || 0), 0);
+  const totalLiquido = pedidos.reduce((s, p) => s + calcularLiquido(p), 0);
+  const quantidade = pedidos.length;
+  resumo.innerHTML = `
+    <div class="resumo-card"><h4>Valor Bruto</h4><p>${formatCurrency(totalBruto)}</p></div>
+    <div class="resumo-card"><h4>Valor Líquido</h4><p>${formatCurrency(totalLiquido)}</p></div>
+    <div class="resumo-card"><h4>Pedidos</h4><p>${quantidade}</p></div>
+  `;
+}
+
 export function aplicarFiltros() {
   const tbody = document.querySelector('#tabelaPedidosTiny tbody');
   if (!tbody) return;
@@ -182,6 +195,7 @@ export function aplicarFiltros() {
   if (!tbody.children.length) {
     tbody.innerHTML = '<tr><td colspan="6" class="text-center py-4 text-gray-500">Nenhum pedido encontrado</td></tr>';
   }
+  atualizarResumo(filtrados);
 }
 
 function atualizarTipoData() {


### PR DESCRIPTION
## Summary
- add summary card above Tiny orders listing
- compute total gross, net and order count respecting filters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b266ba0f34832aaf82797d5d81e78f