### PR TITLE
Add Dashboard Geral with summary metrics and charts

### DIFF
--- a/dashboard-geral.html
+++ b/dashboard-geral.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dashboard Geral</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css?v=20240826">
+  <link rel="stylesheet" href="css/components.css">
+</head>
+<body class="bg-gray-100 text-gray-800">
+  <div id="sidebar-container"></div>
+  <div id="navbar-container"></div>
+  <main class="main-content p-4 space-y-6">
+    <h1 class="text-2xl font-bold">Dashboard Geral</h1>
+    <div id="kpis" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4"></div>
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <div class="bg-white rounded-2xl shadow-lg p-4">
+        <h2 class="text-xl font-semibold mb-2">Evolução de Vendas</h2>
+        <canvas id="evolucaoChart" class="w-full h-64"></canvas>
+      </div>
+      <div class="bg-white rounded-2xl shadow-lg p-4">
+        <h2 class="text-xl font-semibold mb-2">Dias em relação à Meta</h2>
+        <canvas id="diasMetaChart" class="w-full h-64"></canvas>
+      </div>
+      <div class="bg-white rounded-2xl shadow-lg p-4 lg:col-span-2">
+        <h2 class="text-xl font-semibold mb-2">Participação por Loja</h2>
+        <canvas id="lojasPieChart" class="w-full h-64"></canvas>
+      </div>
+    </div>
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script type="module" src="firebase-config.js"></script>
+  <script type="module" src="dashboard-geral.js"></script>
+  <script>window.CUSTOM_SIDEBAR_PATH = '/VendedorPro/partials/sidebar.html';</script>
+  <script src="shared.js"></script>
+</body>
+</html>

--- a/dashboard-geral.js
+++ b/dashboard-geral.js
@@ -1,0 +1,181 @@
+import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { getFirestore, collection, getDocs, doc, getDoc } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { firebaseConfig, getPassphrase } from './firebase-config.js';
+import { decryptString } from './crypto.js';
+
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+const db = getFirestore(app);
+const auth = getAuth(app);
+
+onAuthStateChanged(auth, async user => {
+  if (!user) {
+    window.location.href = 'index.html?login=1';
+    return;
+  }
+  await carregarDashboard(user.uid);
+});
+
+async function carregarDashboard(uid) {
+  const hoje = new Date();
+  const mesAtual = hoje.toISOString().slice(0,7);
+  const totalDiasMes = new Date(hoje.getFullYear(), hoje.getMonth() + 1, 0).getDate();
+
+  let totalBruto = 0;
+  let totalLiquido = 0;
+  let totalUnidades = 0;
+  const diarioBruto = {};
+  const diarioLiquido = {};
+  const porLoja = {};
+
+  const snap = await getDocs(collection(db, `uid/${uid}/faturamento`));
+  for (const docSnap of snap.docs) {
+    if (!docSnap.id.startsWith(mesAtual)) continue;
+    const lojasSnap = await getDocs(collection(db, `uid/${uid}/faturamento/${docSnap.id}/lojas`));
+    for (const lojaDoc of lojasSnap.docs) {
+      let dados = lojaDoc.data();
+      if (dados.encrypted) {
+        const pass = getPassphrase() || `chave-${uid}`;
+        let txt;
+        try {
+          txt = await decryptString(dados.encrypted, pass);
+        } catch (e) {
+          try { txt = await decryptString(dados.encrypted, uid); } catch (_) {}
+        }
+        if (txt) dados = JSON.parse(txt);
+      }
+      const bruto = Number(dados.valorBruto) || 0;
+      const liquido = Number(dados.valorLiquido) || 0;
+      const qtd = Number(dados.qtdVendas || dados.quantidade) || 0;
+      totalBruto += bruto;
+      totalLiquido += liquido;
+      totalUnidades += qtd;
+      diarioBruto[docSnap.id] = (diarioBruto[docSnap.id] || 0) + bruto;
+      diarioLiquido[docSnap.id] = (diarioLiquido[docSnap.id] || 0) + liquido;
+      porLoja[lojaDoc.id] = (porLoja[lojaDoc.id] || 0) + liquido;
+    }
+  }
+
+  const ticketMedio = totalUnidades ? totalLiquido / totalUnidades : 0;
+
+  let meta = 0;
+  try {
+    const metaDoc = await getDoc(doc(db, `uid/${uid}/metasFaturamento`, mesAtual));
+    if (metaDoc.exists()) meta = Number(metaDoc.data().valor) || 0;
+  } catch (err) {
+    console.error('Erro ao buscar meta:', err);
+  }
+
+  const metaDiaria = meta / totalDiasMes;
+  let diasAcima = 0;
+  let diasAbaixo = 0;
+  Object.keys(diarioLiquido).forEach(dia => {
+    if (diarioLiquido[dia] >= metaDiaria) diasAcima++;
+    else diasAbaixo++;
+  });
+
+  renderKpis(totalBruto, totalLiquido, totalUnidades, ticketMedio, meta, diasAcima, diasAbaixo);
+  renderCharts(diarioBruto, diarioLiquido, diasAcima, diasAbaixo, porLoja);
+}
+
+function renderKpis(bruto, liquido, unidades, ticket, meta, diasAcima, diasAbaixo) {
+  const pctBruto = meta ? (bruto / meta) * 100 : 0;
+  const pctLiquido = meta ? (liquido / meta) * 100 : 0;
+  const kpis = document.getElementById('kpis');
+  if (!kpis) return;
+  kpis.innerHTML = `
+    <div class="bg-white rounded-2xl shadow-lg p-4">
+      <h3 class="text-sm text-gray-500">Faturamento Bruto</h3>
+      <p class="text-2xl font-semibold text-blue-600">R$ ${bruto.toLocaleString('pt-BR')}</p>
+    </div>
+    <div class="bg-white rounded-2xl shadow-lg p-4">
+      <h3 class="text-sm text-gray-500">Faturamento Líquido</h3>
+      <p class="text-2xl font-semibold text-blue-600">R$ ${liquido.toLocaleString('pt-BR')}</p>
+    </div>
+    <div class="bg-white rounded-2xl shadow-lg p-4">
+      <h3 class="text-sm text-gray-500">Unidades Vendidas</h3>
+      <p class="text-2xl font-semibold text-orange-500">${unidades}</p>
+    </div>
+    <div class="bg-white rounded-2xl shadow-lg p-4">
+      <h3 class="text-sm text-gray-500">Ticket Médio</h3>
+      <p class="text-2xl font-semibold text-gray-700">R$ ${ticket.toLocaleString('pt-BR', {minimumFractionDigits:2, maximumFractionDigits:2})}</p>
+    </div>
+    <div class="bg-white rounded-2xl shadow-lg p-4">
+      <h3 class="text-sm text-gray-500">% Meta Atingida Bruto</h3>
+      <p class="text-2xl font-semibold ${pctBruto >= 100 ? 'text-green-600' : 'text-red-600'}">${pctBruto.toFixed(1)}%</p>
+    </div>
+    <div class="bg-white rounded-2xl shadow-lg p-4">
+      <h3 class="text-sm text-gray-500">% Meta Atingida Líquido</h3>
+      <p class="text-2xl font-semibold ${pctLiquido >= 100 ? 'text-green-600' : 'text-red-600'}">${pctLiquido.toFixed(1)}%</p>
+    </div>
+    <div class="bg-white rounded-2xl shadow-lg p-4">
+      <h3 class="text-sm text-gray-500">Dias Acima da Meta</h3>
+      <p class="text-2xl font-semibold text-green-600">${diasAcima}</p>
+    </div>
+    <div class="bg-white rounded-2xl shadow-lg p-4">
+      <h3 class="text-sm text-gray-500">Dias Abaixo da Meta</h3>
+      <p class="text-2xl font-semibold text-red-600">${diasAbaixo}</p>
+    </div>
+  `;
+}
+
+function renderCharts(diarioBruto, diarioLiquido, diasAcima, diasAbaixo, porLoja) {
+  const dias = Object.keys(diarioBruto).sort();
+  const ctxLinhas = document.getElementById('evolucaoChart');
+  if (ctxLinhas) {
+    new Chart(ctxLinhas, {
+      type: 'line',
+      data: {
+        labels: dias.map(d => new Date(d).toLocaleDateString('pt-BR')),
+        datasets: [
+          {
+            label: 'Bruto',
+            data: dias.map(d => diarioBruto[d]),
+            borderColor: '#3b82f6',
+            backgroundColor: 'rgba(59,130,246,0.2)',
+            tension: 0.3
+          },
+          {
+            label: 'Líquido',
+            data: dias.map(d => diarioLiquido[d]),
+            borderColor: '#f97316',
+            backgroundColor: 'rgba(249,115,22,0.2)',
+            tension: 0.3
+          }
+        ]
+      },
+      options: { responsive: true, maintainAspectRatio: false }
+    });
+  }
+
+  const ctxBar = document.getElementById('diasMetaChart');
+  if (ctxBar) {
+    new Chart(ctxBar, {
+      type: 'bar',
+      data: {
+        labels: ['Acima da Meta', 'Abaixo da Meta'],
+        datasets: [{
+          data: [diasAcima, diasAbaixo],
+          backgroundColor: ['#86efac', '#fca5a5']
+        }]
+      },
+      options: { responsive: true, maintainAspectRatio: false }
+    });
+  }
+
+  const ctxPie = document.getElementById('lojasPieChart');
+  if (ctxPie) {
+    const lojas = Object.keys(porLoja);
+    new Chart(ctxPie, {
+      type: 'pie',
+      data: {
+        labels: lojas,
+        datasets: [{
+          data: lojas.map(l => porLoja[l]),
+          backgroundColor: ['#3b82f6','#f97316','#6366f1','#10b981','#f59e0b','#ef4444']
+        }]
+      },
+      options: { responsive: true, maintainAspectRatio: false }
+    });
+  }
+}

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -12,6 +12,15 @@
 
   <ul class="sidebar-menu py-4">
     <li>
+      <a href="/VendedorPro/dashboard-geral.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-dashboard" data-perfil="gestor,mentor">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 3.001a.75.75 0 0 0-.75.75V11.25H3.75a.75.75 0 0 0-.75.75 9 9 0 1 0 9-9Z" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12.75 2.243A9.004 9.004 0 0 1 21.757 11.25H12.75V2.243Z" />
+        </svg>
+        <span class="link-text">Dashboard Geral</span>
+      </a>
+    </li>
+    <li>
       <a href="/VendedorPro/gestor.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao" data-perfil="gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9 12H12.75M9 15H12.75M9 18H12.75M15.75 18.75H18A2.25 2.25 0 0 0 20.25 16.5V6.108A2.25 2.25 0 0 0 18.273 3.916c-.374-.031-.748-.058-1.123-.08M11.35 3.836A2.251 2.251 0 0 1 13.5 2.25h1.5a2.25 2.25 0 0 1 2.151 1.586M11.35 3.836c-.376.022-.75.049-1.124.08A2.25 2.25 0 0 0 8.25 6.108V8.25M8.25 8.25H4.875a1.125 1.125 0 0 0-1.125 1.125V20.625c0 .621.504 1.125 1.125 1.125H14.625a1.125 1.125 0 0 0 1.125-1.125V9.375A1.125 1.125 0 0 0 14.625 8.25H8.25ZM6.75 12h.007v.008H6.75V12Zm0 3h.007v.008H6.75V15Zm0 3h.007v.008H6.75V18Z"/>


### PR DESCRIPTION
## Summary
- create Dashboard Geral page summarizing sales metrics
- load monthly data from Firestore and render KPI cards and charts
- add Dashboard Geral link to sidebar navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b26d017944832aa8bf2091e694a1c3