### PR TITLE
Fix oversized charts on general dashboard

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1872,3 +1872,17 @@ body.dark .sidebar-link.active {
   .main-content { margin-left: var(--sidebar-width); }
 }
 
+/* Wrapper to keep charts responsive without overflowing */
+.chart-wrapper {
+  position: relative;
+  width: 100%;
+  max-width: 100%;
+  height: 16rem; /* Tailwind h-64 */
+  overflow: hidden;
+}
+
+.chart-wrapper canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+

--- a/dashboard-geral.html
+++ b/dashboard-geral.html
@@ -18,15 +18,21 @@
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
       <div class="bg-white rounded-2xl shadow-lg p-4">
         <h2 class="text-xl font-semibold mb-2">Evolução de Vendas</h2>
-        <canvas id="evolucaoChart" class="w-full h-64"></canvas>
+        <div class="chart-wrapper">
+          <canvas id="evolucaoChart"></canvas>
+        </div>
       </div>
       <div class="bg-white rounded-2xl shadow-lg p-4">
         <h2 class="text-xl font-semibold mb-2">Dias em relação à Meta</h2>
-        <canvas id="diasMetaChart" class="w-full h-64"></canvas>
+        <div class="chart-wrapper">
+          <canvas id="diasMetaChart"></canvas>
+        </div>
       </div>
       <div class="bg-white rounded-2xl shadow-lg p-4 lg:col-span-2">
         <h2 class="text-xl font-semibold mb-2">Participação por Loja</h2>
-        <canvas id="lojasPieChart" class="w-full h-64"></canvas>
+        <div class="chart-wrapper">
+          <canvas id="lojasPieChart"></canvas>
+        </div>
       </div>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- wrap dashboard charts in `.chart-wrapper` to enforce responsive dimensions
- add `.chart-wrapper` styles preventing canvases from overflowing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b26ef6d2e0832a84851abc904a142b