### PR TITLE
feat: exporta fechamento mensal no dashboard

### DIFF
--- a/dashboard-geral.html
+++ b/dashboard-geral.html
@@ -8,12 +8,16 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/styles.css?v=20240826">
   <link rel="stylesheet" href="css/components.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
 </head>
 <body class="bg-gray-100 text-gray-800">
   <div id="sidebar-container"></div>
   <div id="navbar-container"></div>
   <main class="main-content p-4 space-y-6">
-    <h1 class="text-2xl font-bold">Dashboard Geral</h1>
+    <div class="flex justify-between items-center">
+      <h1 class="text-2xl font-bold">Dashboard Geral</h1>
+      <button id="exportarFechamentoBtn" class="bg-blue-600 text-white px-4 py-2 rounded">Exportar Fechamento</button>
+    </div>
     <div id="kpis" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4"></div>
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
       <div class="bg-white rounded-2xl shadow-lg p-4">


### PR DESCRIPTION
## Summary
- allow exporting monthly closing report from dashboard
- gather product ranking, cancellations and month comparison for export

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2fff5fbb0832a9a5abab82cb3da15