### PR TITLE
feat: add saques card to dashboard

### DIFF
--- a/dashboard-geral.html
+++ b/dashboard-geral.html
@@ -18,7 +18,7 @@
       <h1 class="text-2xl font-bold">Dashboard Geral</h1>
       <button id="exportarFechamentoBtn" class="bg-blue-600 text-white px-4 py-2 rounded">Exportar Fechamento</button>
     </div>
-    <div id="kpis" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4"></div>
+    <div id="kpis" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
       <div class="bg-white rounded-2xl shadow-lg p-4">
         <h2 class="text-xl font-semibold mb-2">Evolução de Vendas</h2>

--- a/dashboard-geral.js
+++ b/dashboard-geral.js
@@ -89,6 +89,16 @@ async function carregarDashboard(user) {
     else diasAbaixo++;
   });
 
+  let totalSaques = 0;
+  try {
+    const resumoDoc = await getDoc(doc(db, 'usuarios', uid, 'comissoes', mesAtual));
+    if (resumoDoc.exists()) {
+      totalSaques = Number(resumoDoc.data().totalSacado) || 0;
+    }
+  } catch (err) {
+    console.error('Erro ao carregar saques', err);
+  }
+
   let nomeEmpresa = '';
   let responsavel = user.email || '';
   try {
@@ -126,6 +136,7 @@ async function carregarDashboard(user) {
     totalUnidades,
     ticketMedio,
     meta,
+    totalSaques,
     diarioBruto,
     diarioLiquido,
     porLoja,
@@ -136,11 +147,11 @@ async function carregarDashboard(user) {
   };
   window.dashboardData = dashboardData;
 
-  renderKpis(totalBruto, totalLiquido, totalUnidades, ticketMedio, meta, diasAcima, diasAbaixo);
+  renderKpis(totalBruto, totalLiquido, totalUnidades, ticketMedio, meta, diasAcima, diasAbaixo, totalSaques);
   renderCharts(diarioBruto, diarioLiquido, diasAcima, diasAbaixo, porLoja);
 }
 
-function renderKpis(bruto, liquido, unidades, ticket, meta, diasAcima, diasAbaixo) {
+function renderKpis(bruto, liquido, unidades, ticket, meta, diasAcima, diasAbaixo, saques) {
   const pctBruto = meta ? (bruto / meta) * 100 : 0;
   const pctLiquido = meta ? (liquido / meta) * 100 : 0;
   const kpis = document.getElementById('kpis');
@@ -177,6 +188,14 @@ function renderKpis(bruto, liquido, unidades, ticket, meta, diasAcima, diasAbaix
     <div class="bg-white rounded-2xl shadow-lg p-4">
       <h3 class="text-sm text-gray-500">Dias Abaixo da Meta</h3>
       <p class="text-2xl font-semibold text-red-600">${diasAbaixo}</p>
+    </div>
+    <div class="bg-white rounded-2xl shadow-lg overflow-hidden">
+      <div class="bg-gray-100 px-4 py-2">
+        <h3 class="text-sm text-gray-500">Total Saques</h3>
+      </div>
+      <div class="p-4">
+        <p class="text-2xl font-semibold text-gray-700">R$ ${saques.toLocaleString('pt-BR', {minimumFractionDigits:2, maximumFractionDigits:2})}</p>
+      </div>
     </div>
   `;
 }


### PR DESCRIPTION
## Summary
- show dashboard KPI cards in three-column layout
- include Total Saques card fed from monthly commission data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b303fabb98832a994e32d8526d7f80