### PR TITLE
add previsao tab to vendas sidebar

### DIFF
--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -148,6 +148,7 @@
         <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=controleVendas" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Vendas</a></li>
         <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamento" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Mensal</a></li>
         <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=sobras" class="sidebar-link block py-2 px-4 transition-colors">Sobras</a></li>
+        <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=previsao" class="sidebar-link block py-2 px-4 transition-colors">Previsão</a></li>
         <li><a href="/VendedorPro/saques.html" class="sidebar-link block py-2 px-4 transition-colors">Saques</a></li>
         <li><a href="/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a></li>
       </ul>


### PR DESCRIPTION
## Summary
- add Previsão link in Vendas sidebar group

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b305fb9ef4832a850bad4a8bda3cbb