### PR TITLE
Add top 5 SKU list to dashboard

### DIFF
--- a/dashboard-geral.html
+++ b/dashboard-geral.html
@@ -39,6 +39,10 @@
         </div>
       </div>
     </div>
+    <div class="bg-white rounded-2xl shadow-lg p-4">
+      <h2 class="text-xl font-semibold mb-2">Top 5 SKUs do mês</h2>
+      <ol id="topSkusList" class="list-decimal list-inside"></ol>
+    </div>
   </main>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script type="module" src="firebase-config.js"></script>

--- a/dashboard-geral.js
+++ b/dashboard-geral.js
@@ -114,6 +114,7 @@ async function carregarDashboard(user) {
 
   let topProdutos = [];
   let produtosCriticos = [];
+  let topSkus = [];
   try {
     const prodSnap = await getDocs(collection(db, `uid/${uid}/produtos`));
     const arr = [];
@@ -128,9 +129,11 @@ async function carregarDashboard(user) {
         }
         if (txt) d = JSON.parse(txt);
       }
-      arr.push({ nome: d.nome || p.id, vendas: Number(d.vendas) || 0, estoque: Number(d.estoque) || 0 });
+      arr.push({ nome: d.nome || p.id, sku: d.sku || p.id, vendas: Number(d.vendas) || 0, estoque: Number(d.estoque) || 0 });
     }
-    topProdutos = arr.filter(p => p.vendas > 0).sort((a, b) => b.vendas - a.vendas).slice(0, 10);
+    topProdutos = arr.filter(p => p.vendas > 0).sort((a, b) => b.vendas - a.vendas);
+    topSkus = topProdutos.slice(0, 5);
+    topProdutos = topProdutos.slice(0, 10);
     produtosCriticos = arr.filter(p => p.estoque > 0 && p.vendas === 0);
   } catch (err) {
     console.error('Erro ao carregar produtos', err);
@@ -152,12 +155,14 @@ async function carregarDashboard(user) {
     cancelamentosDiario,
     comparativo,
     topProdutos,
-    produtosCriticos
+    produtosCriticos,
+    topSkus
   };
   window.dashboardData = dashboardData;
 
   renderKpis(totalBruto, totalLiquido, totalUnidades, ticketMedio, meta, diasAcima, diasAbaixo, totalSaques);
   renderCharts(diarioBruto, diarioLiquido, diasAcima, diasAbaixo, porLoja);
+  renderTopSkus(topSkus);
 }
 
 function renderKpis(bruto, liquido, unidades, ticket, meta, diasAcima, diasAbaixo, saques) {
@@ -268,6 +273,14 @@ function renderCharts(diarioBruto, diarioLiquido, diasAcima, diasAbaixo, porLoja
       options: { responsive: true, maintainAspectRatio: false }
     });
   }
+}
+
+function renderTopSkus(lista) {
+  const el = document.getElementById('topSkusList');
+  if (!el) return;
+  el.innerHTML = lista
+    .map(p => `<li>${p.sku} - ${p.vendas}</li>`)
+    .join('');
 }
 
 document.getElementById('exportarFechamentoBtn')?.addEventListener('click', exportarFechamentoMes);


### PR DESCRIPTION
## Summary
- show top five monthly SKUs on dashboard
- compute and render top SKU list from product data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3064331d8832a96f48b36d72e7d16