### PR TITLE
feat: show next-month forecast on dashboard

### DIFF
--- a/dashboard-geral.html
+++ b/dashboard-geral.html
@@ -43,6 +43,11 @@
       <h2 class="text-xl font-semibold mb-2">Top 5 SKUs do mês</h2>
       <ol id="topSkusList" class="list-decimal list-inside"></ol>
     </div>
+    <div class="bg-white rounded-2xl shadow-lg p-4">
+      <h2 class="text-xl font-semibold mb-2">Previsão do Próximo Mês</h2>
+      <div id="cardsPrevisao" class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4"></div>
+      <div id="topSkusPrevisao" class="overflow-x-auto"></div>
+    </div>
   </main>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script type="module" src="firebase-config.js"></script>


### PR DESCRIPTION
## Summary
- display next-month forecast cards and top SKUs on general dashboard
- fetch forecast data and product metadata to compute pessimistic, base and optimistic scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b307417748832a8c45a4579b8e1df6