### PR TITLE
feat: add additional dashboard charts

### DIFF
--- a/dashboard-geral.html
+++ b/dashboard-geral.html
@@ -44,6 +44,20 @@
           </div>
         </div>
       </div>
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div class="bg-white rounded-2xl shadow-lg p-4">
+          <h2 class="text-xl font-semibold mb-2">Evolução de Margem</h2>
+          <div class="chart-wrapper">
+            <canvas id="margemChart"></canvas>
+          </div>
+        </div>
+        <div class="bg-white rounded-2xl shadow-lg p-4">
+          <h2 class="text-xl font-semibold mb-2">Comparativo Top 5 SKUs: Vendas x Margem</h2>
+          <div class="chart-wrapper">
+            <canvas id="topSkusMargemChart"></canvas>
+          </div>
+        </div>
+      </div>
       <div class="bg-white rounded-2xl shadow-lg p-4">
         <h2 class="text-xl font-semibold mb-2">Top 5 SKUs do mês</h2>
         <ol id="topSkusList" class="list-decimal list-inside"></ol>
@@ -72,6 +86,9 @@
       <div class="bg-white rounded-2xl shadow-lg p-4">
         <h2 class="text-xl font-semibold mb-2">Previsão do Próximo Mês</h2>
         <div id="cardsPrevisao" class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4"></div>
+        <div class="chart-wrapper mb-4">
+          <canvas id="previsaoChart"></canvas>
+        </div>
         <div id="topSkusPrevisao" class="overflow-x-auto"></div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- track monthly margin evolution in dashboard
- compare top 5 SKUs sales vs margin
- visualize next month projection scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b30ea00bf0832a91e9c2b77b2f16dd