### PR TITLE
Add strategic perspective tab to dashboard

### DIFF
--- a/dashboard-geral.html
+++ b/dashboard-geral.html
@@ -21,6 +21,7 @@
     <div class="flex space-x-4">
       <button class="tab-btn px-4 py-2 rounded bg-blue-600 text-white" data-tab="overview">Visão Geral</button>
       <button class="tab-btn px-4 py-2 rounded bg-gray-300 text-gray-700" data-tab="meta">Comparativo com a Meta</button>
+      <button class="tab-btn px-4 py-2 rounded bg-gray-300 text-gray-700" data-tab="estrategica">Perspectiva Estratégica</button>
     </div>
     <div id="tab-overview" class="space-y-6">
       <div id="kpis" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
@@ -104,6 +105,29 @@
         <div class="chart-wrapper">
           <canvas id="progressoSemanalChart"></canvas>
         </div>
+      </div>
+    </div>
+    <div id="tab-estrategica" class="hidden space-y-6">
+      <div class="bg-white rounded-2xl shadow-lg p-4">
+        <h2 class="text-xl font-semibold mb-2">Principais pontos fortes do mês</h2>
+        <ul class="list-disc list-inside space-y-1">
+          <li>SKU T6 foi responsável por mais de 59% da receita, mas margem muito baixa 2,4%.</li>
+        </ul>
+      </div>
+      <div class="bg-white rounded-2xl shadow-lg p-4">
+        <h2 class="text-xl font-semibold mb-2">Principais riscos</h2>
+        <ul class="list-disc list-inside space-y-1">
+          <li>Dependência de poucos SKUs.</li>
+          <li>Margens negativas em muitos produtos.</li>
+        </ul>
+      </div>
+      <div class="bg-white rounded-2xl shadow-lg p-4">
+        <h2 class="text-xl font-semibold mb-2">Decisões/ações recomendadas para corrigir perdas</h2>
+        <ul class="list-disc list-inside space-y-1">
+          <li>Revisar precificação.</li>
+          <li>Promoções.</li>
+          <li>Cortes de SKUs deficitários.</li>
+        </ul>
       </div>
     </div>
   </main>

--- a/dashboard-geral.js
+++ b/dashboard-geral.js
@@ -467,7 +467,8 @@ function setupTabs() {
   const buttons = document.querySelectorAll('.tab-btn');
   const tabs = {
     overview: document.getElementById('tab-overview'),
-    meta: document.getElementById('tab-meta')
+    meta: document.getElementById('tab-meta'),
+    estrategica: document.getElementById('tab-estrategica')
   };
   buttons.forEach(btn => {
     btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add Perspectiva Estratégica tab with highlights, risks, and recommended actions
- wire up new tab in dashboard script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b30f623964832ab79fe8299ce80b3e