### PR TITLE
feat: add strategic analysis via gemini

### DIFF
--- a/dashboard-geral.html
+++ b/dashboard-geral.html
@@ -110,23 +110,20 @@
     <div id="tab-estrategica" class="hidden space-y-6">
       <div class="bg-white rounded-2xl shadow-lg p-4">
         <h2 class="text-xl font-semibold mb-2">Principais pontos fortes do mês</h2>
-        <ul class="list-disc list-inside space-y-1">
-          <li>SKU T6 foi responsável por mais de 59% da receita, mas margem muito baixa 2,4%.</li>
+        <ul id="pontosFortes" class="list-disc list-inside space-y-1">
+          <li>Carregando análise...</li>
         </ul>
       </div>
       <div class="bg-white rounded-2xl shadow-lg p-4">
         <h2 class="text-xl font-semibold mb-2">Principais riscos</h2>
-        <ul class="list-disc list-inside space-y-1">
-          <li>Dependência de poucos SKUs.</li>
-          <li>Margens negativas em muitos produtos.</li>
+        <ul id="principaisRiscos" class="list-disc list-inside space-y-1">
+          <li>Carregando análise...</li>
         </ul>
       </div>
       <div class="bg-white rounded-2xl shadow-lg p-4">
         <h2 class="text-xl font-semibold mb-2">Decisões/ações recomendadas para corrigir perdas</h2>
-        <ul class="list-disc list-inside space-y-1">
-          <li>Revisar precificação.</li>
-          <li>Promoções.</li>
-          <li>Cortes de SKUs deficitários.</li>
+        <ul id="acoesRecomendadas" class="list-disc list-inside space-y-1">
+          <li>Carregando análise...</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- send dashboard data to Gemini API and display strategic insights
- add placeholders for strengths, risks and actions sections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b311306e74832a8fcc6c8a93503f0a