### PR TITLE
Refatora layout do dashboard geral com sub-abas

### DIFF
--- a/dashboard-geral.html
+++ b/dashboard-geral.html
@@ -24,73 +24,82 @@
       <button class="tab-btn px-4 py-2 rounded bg-gray-300 text-gray-700" data-tab="estrategica">Perspectiva Estratégica</button>
     </div>
     <div id="tab-overview" class="space-y-6">
-      <div id="kpis" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <div class="bg-white rounded-2xl shadow-lg p-4">
-          <h2 class="text-xl font-semibold mb-2">Evolução de Vendas</h2>
-          <div class="chart-wrapper">
-            <canvas id="evolucaoChart"></canvas>
+      <div class="flex space-x-4">
+        <button class="subtab-btn px-4 py-2 rounded bg-blue-600 text-white" data-subtab="resumo">Resumo Executivo</button>
+        <button class="subtab-btn px-4 py-2 rounded bg-gray-300 text-gray-700" data-subtab="desempenho">Desempenho &amp; Rentabilidade</button>
+        <button class="subtab-btn px-4 py-2 rounded bg-gray-300 text-gray-700" data-subtab="previsao">Projeção &amp; Previsão</button>
+      </div>
+      <div id="subtab-resumo" class="space-y-6">
+        <div id="kpis" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div class="bg-white rounded-2xl shadow-lg p-4">
+            <h2 class="text-xl font-semibold mb-2">Evolução de Vendas</h2>
+            <div class="chart-wrapper">
+              <canvas id="evolucaoChart"></canvas>
+            </div>
           </div>
-        </div>
-        <div class="bg-white rounded-2xl shadow-lg p-4">
-          <h2 class="text-xl font-semibold mb-2">Dias em relação à Meta</h2>
-          <div class="chart-wrapper">
-            <canvas id="diasMetaChart"></canvas>
+          <div class="bg-white rounded-2xl shadow-lg p-4">
+            <h2 class="text-xl font-semibold mb-2">Evolução de Margem</h2>
+            <div class="chart-wrapper">
+              <canvas id="margemChart"></canvas>
+            </div>
           </div>
-        </div>
-        <div class="bg-white rounded-2xl shadow-lg p-4 lg:col-span-2">
-          <h2 class="text-xl font-semibold mb-2">Participação por Loja</h2>
-          <div class="chart-wrapper">
-            <canvas id="lojasPieChart"></canvas>
+          <div class="bg-white rounded-2xl shadow-lg p-4">
+            <h2 class="text-xl font-semibold mb-2">Dias em relação à Meta</h2>
+            <div class="chart-wrapper">
+              <canvas id="diasMetaChart"></canvas>
+            </div>
+          </div>
+          <div class="bg-white rounded-2xl shadow-lg p-4 lg:col-span-2">
+            <h2 class="text-xl font-semibold mb-2">Participação por Loja</h2>
+            <div class="chart-wrapper">
+              <canvas id="lojasPieChart"></canvas>
+            </div>
           </div>
         </div>
       </div>
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <div class="bg-white rounded-2xl shadow-lg p-4">
-          <h2 class="text-xl font-semibold mb-2">Evolução de Margem</h2>
-          <div class="chart-wrapper">
-            <canvas id="margemChart"></canvas>
-          </div>
-        </div>
+      <div id="subtab-desempenho" class="hidden space-y-6">
         <div class="bg-white rounded-2xl shadow-lg p-4">
           <h2 class="text-xl font-semibold mb-2">Comparativo Top 5 SKUs: Vendas x Margem</h2>
           <div class="chart-wrapper">
             <canvas id="topSkusMargemChart"></canvas>
           </div>
         </div>
-      </div>
-      <div class="bg-white rounded-2xl shadow-lg p-4">
-        <h2 class="text-xl font-semibold mb-2">Top 5 SKUs do mês</h2>
-        <ol id="topSkusList" class="list-decimal list-inside"></ol>
-      </div>
-      <div class="bg-white rounded-2xl shadow-lg p-4">
-        <h2 class="text-xl font-semibold mb-2">Análise de Rentabilidade</h2>
-        <div class="overflow-x-auto">
-          <table class="min-w-full divide-y divide-gray-200 text-sm">
-            <thead class="bg-gray-50">
-              <tr>
-                <th class="px-3 py-2 text-left">SKU</th>
-                <th class="px-3 py-2 text-right">Receita (R$)</th>
-                <th class="px-3 py-2 text-right">Custo Estimado (R$)</th>
-                <th class="px-3 py-2 text-right">Lucro Bruto (R$)</th>
-                <th class="px-3 py-2 text-right">Margem (%)</th>
-              </tr>
-            </thead>
-            <tbody id="tabelaRentabilidade"></tbody>
-          </table>
+        <div class="bg-white rounded-2xl shadow-lg p-4">
+          <h2 class="text-xl font-semibold mb-2">Top 5 SKUs do mês</h2>
+          <ol id="topSkusList" class="list-decimal list-inside"></ol>
         </div>
-        <div class="mt-4">
-          <h3 class="font-semibold">Top 5 mais rentáveis</h3>
-          <ol id="topRentaveis" class="list-decimal list-inside"></ol>
+        <div class="bg-white rounded-2xl shadow-lg p-4">
+          <h2 class="text-xl font-semibold mb-2">Análise de Rentabilidade</h2>
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 text-sm">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-3 py-2 text-left">SKU</th>
+                  <th class="px-3 py-2 text-right">Receita (R$)</th>
+                  <th class="px-3 py-2 text-right">Custo Estimado (R$)</th>
+                  <th class="px-3 py-2 text-right">Lucro Bruto (R$)</th>
+                  <th class="px-3 py-2 text-right">Margem (%)</th>
+                </tr>
+              </thead>
+              <tbody id="tabelaRentabilidade"></tbody>
+            </table>
+          </div>
+          <div class="mt-4">
+            <h3 class="font-semibold">Top 5 mais rentáveis</h3>
+            <ol id="topRentaveis" class="list-decimal list-inside"></ol>
+          </div>
         </div>
       </div>
-      <div class="bg-white rounded-2xl shadow-lg p-4">
-        <h2 class="text-xl font-semibold mb-2">Previsão do Próximo Mês</h2>
-        <div id="cardsPrevisao" class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4"></div>
-        <div class="chart-wrapper mb-4">
-          <canvas id="previsaoChart"></canvas>
+      <div id="subtab-previsao" class="hidden space-y-6">
+        <div class="bg-white rounded-2xl shadow-lg p-4">
+          <h2 class="text-xl font-semibold mb-2">Previsão do Próximo Mês</h2>
+          <div id="cardsPrevisao" class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4"></div>
+          <div class="chart-wrapper mb-4">
+            <canvas id="previsaoChart"></canvas>
+          </div>
+          <div id="topSkusPrevisao" class="overflow-x-auto"></div>
         </div>
-        <div id="topSkusPrevisao" class="overflow-x-auto"></div>
       </div>
     </div>
     <div id="tab-meta" class="hidden space-y-6">

--- a/dashboard-geral.js
+++ b/dashboard-geral.js
@@ -207,6 +207,7 @@ async function carregarDashboard(user) {
   renderComparativoMeta(totalLiquido, meta, diarioLiquido, totalDiasMes, mesAtual);
   carregarPrevisaoDashboard(uid);
   setupTabs();
+  setupSubTabs();
   analisarEstrategiaGemini();
 }
 
@@ -481,6 +482,28 @@ function setupTabs() {
       btn.classList.remove('bg-gray-300', 'text-gray-700');
       Object.values(tabs).forEach(t => t.classList.add('hidden'));
       const alvo = tabs[btn.dataset.tab];
+      if (alvo) alvo.classList.remove('hidden');
+    });
+  });
+}
+
+function setupSubTabs() {
+  const buttons = document.querySelectorAll('.subtab-btn');
+  const tabs = {
+    resumo: document.getElementById('subtab-resumo'),
+    desempenho: document.getElementById('subtab-desempenho'),
+    previsao: document.getElementById('subtab-previsao')
+  };
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      buttons.forEach(b => {
+        b.classList.remove('bg-blue-600', 'text-white');
+        b.classList.add('bg-gray-300', 'text-gray-700');
+      });
+      btn.classList.add('bg-blue-600', 'text-white');
+      btn.classList.remove('bg-gray-300', 'text-gray-700');
+      Object.values(tabs).forEach(t => t.classList.add('hidden'));
+      const alvo = tabs[btn.dataset.subtab];
       if (alvo) alvo.classList.remove('hidden');
     });
   });


### PR DESCRIPTION
## Summary
- Divide a aba de visão geral em Resumo Executivo, Desempenho & Rentabilidade e Projeção & Previsão
- Agrupa indicadores, gráficos e tabelas em seções organizadas
- Adiciona lógica para navegação das novas sub-abas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b313f3e5a0832a93ed7aff8ac2e1c6