### PR TITLE
feat: trigger Gemini analysis on demand

### DIFF
--- a/dashboard-geral.html
+++ b/dashboard-geral.html
@@ -117,24 +117,23 @@
       </div>
     </div>
     <div id="tab-estrategica" class="hidden space-y-6">
-      <div class="bg-white rounded-2xl shadow-lg p-4">
-        <h2 class="text-xl font-semibold mb-2">Principais pontos fortes do mês</h2>
-        <ul id="pontosFortes" class="list-disc list-inside space-y-1">
-          <li>Carregando análise...</li>
-        </ul>
-      </div>
-      <div class="bg-white rounded-2xl shadow-lg p-4">
-        <h2 class="text-xl font-semibold mb-2">Principais riscos</h2>
-        <ul id="principaisRiscos" class="list-disc list-inside space-y-1">
-          <li>Carregando análise...</li>
-        </ul>
-      </div>
-      <div class="bg-white rounded-2xl shadow-lg p-4">
-        <h2 class="text-xl font-semibold mb-2">Decisões/ações recomendadas para corrigir perdas</h2>
-        <ul id="acoesRecomendadas" class="list-disc list-inside space-y-1">
-          <li>Carregando análise...</li>
-        </ul>
-      </div>
+      <!-- BEGIN: Botão de Análise de IA -->
+      <button
+        id="btn-analise-ia"
+        class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-900
+               hover:bg-gray-50 active:bg-gray-100
+               focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2">
+        <svg id="icon-analise" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none"
+             viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+                d="M11 5h2m-1-2v2m6 5h2m-2 0v2M4 12H2m2 0v2m12.243 4.243l1.414-1.414M7.757 7.757 6.343 6.343M9 17l3-3-3-3" />
+        </svg>
+        Rodar análise de IA
+      </button>
+
+      <div id="analise-ia-alert" class="mt-3 text-sm text-gray-700"></div>
+      <div id="analise-ia-output" class="mt-4"></div>
+      <!-- END: Botão de Análise de IA -->
     </div>
   </main>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>


### PR DESCRIPTION
## Summary
- add accessible "Rodar análise de IA" button to dashboard
- queue and cache Gemini requests with rate limiting, retries and circuit breaker
- run strategic analysis only on button click with loading and error states

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3181af924832a86b759305b5ef74a