### PR TITLE
Use Gemini analysis with PDF dashboard

### DIFF
--- a/dashboard-geral.js
+++ b/dashboard-geral.js
@@ -109,29 +109,6 @@ export async function analisarEstrategiaGemini(payload) {
   return p;
 }
 
-// === Batching de requisições para o Gemini ===
-const GEMINI_BATCH_INTERVAL_MS = 5000;
-const geminiBatchQueue = [];
-setInterval(processGeminiBatch, GEMINI_BATCH_INTERVAL_MS);
-
-function solicitarAnaliseGemini(dados) {
-  return new Promise((resolve, reject) => {
-    geminiBatchQueue.push({ dados, resolve, reject });
-  });
-}
-
-async function processGeminiBatch() {
-  if (!geminiBatchQueue.length) return;
-  const batch = geminiBatchQueue.splice(0, geminiBatchQueue.length);
-  const payload = montarPayloadGemini(batch.map(i => i.dados));
-  try {
-    const resp = await analisarEstrategiaGemini(payload);
-    batch.forEach(item => item.resolve(resp));
-  } catch (e) {
-    batch.forEach(item => item.reject(e));
-  }
-}
-
 onAuthStateChanged(auth, async user => {
   if (!user) {
     window.location.href = 'index.html?login=1';
@@ -974,38 +951,61 @@ function coletarResumoKPIsDoDashboard() {
   };
 }
 
-function montarPayloadGemini(resumos) {
-  const contents = resumos.map(resumo => ({
-    role: 'user',
-    parts: [{
-      text:
-`Você é um analista de performance de Shopee. Com base nos dados abaixo, responda em 5 itens:
-1) 3 pontos fortes do mês
-2) 3 riscos
-3) 5 ações práticas (curto prazo)
-4) Oportunidades em Ads (CTR, CPC, CPA, ROAS)
-5) Alertas urgentes
-
-DADOS:
-${JSON.stringify(resumo)}`
-    }]
-  }));
-  return { contents, generationConfig: { temperature: 0.4, maxOutputTokens: 1024 } };
+function montarPayloadGemini(pdfBase64) {
+  return {
+    contents: [
+      {
+        role: 'user',
+        parts: [
+          {
+            text:
+'ATRAVÉS DAS INFORMAÇÕES DESSA ABA, VOCÊ CONSEGUE TIRAR OS Principais pontos fortes do mês, OS Principais riscos, E aS Decisões/ações recomendadas para corrigir perdas?'
+          },
+          {
+            inlineData: {
+              mimeType: 'application/pdf',
+              data: pdfBase64
+            }
+          }
+        ]
+      }
+    ],
+    generationConfig: {
+      temperature: 0.4,
+      maxOutputTokens: 1024
+    }
+  };
 }
 
-btnAnalise?.addEventListener('click', async () => {
-  if (btnAnalise.disabled) return;
-  setLoading(true); outBox.innerHTML = '';
+async function solicitarAnaliseGeminiComPDF() {
   try {
-    const resumo = coletarResumoKPIsDoDashboard();
-    const resultado = await solicitarAnaliseGemini(resumo);
+    const elementoDoDashboard = document.querySelector('main');
+    const pdfBlob = await html2pdf().from(elementoDoDashboard).outputPdf('blob');
+    const pdfBase64 = await new Promise(resolve => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(reader.result.split(',')[1]);
+      reader.readAsDataURL(pdfBlob);
+    });
+
+    const payload = montarPayloadGemini(pdfBase64);
+    const resultado = await analisarEstrategiaGemini(payload);
 
     if (resultado.skipped) return renderAviso('Análise pulada (aba em segundo plano).', 'warn');
 
     renderAviso(resultado.cached ? 'Exibindo resultado em cache (últimos 20 min).' : 'Análise concluída!', resultado.cached ? 'info' : 'success');
     renderResultadoGemini(resultado);
-  } catch (e) {
-    if (e?.rateLimited) { renderAviso('Limite por minuto atingido. Tente novamente em instantes.', 'warn'); }
-    else { renderAviso('Não foi possível gerar a análise agora.', 'error'); console.error('[AI] erro:', e); }
-  } finally { setLoading(false); }
+  } catch (erro) {
+    renderAviso('Não foi possível gerar a análise agora.', 'error');
+    console.error('Erro na requisição da análise de PDF:', erro);
+  } finally {
+    setLoading(false);
+  }
+}
+
+btnAnalise?.addEventListener('click', () => {
+  if (btnAnalise.disabled) return;
+  setLoading(true); outBox.innerHTML = '';
+  renderAviso('Analisando o dashboard via PDF, por favor aguarde...', 'info');
+
+  solicitarAnaliseGeminiComPDF();
 });


### PR DESCRIPTION
## Summary
- generate dashboard PDF with html2pdf and convert to Base64
- send single Gemini request with PDF inline data and show results
- remove batching code for previous JSON summary analysis

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b31fdf32c8832a85cbb8d52121f1cb