### PR TITLE
fix: avoid html2pdf InvalidStateError

### DIFF
--- a/dashboard-geral.js
+++ b/dashboard-geral.js
@@ -966,7 +966,17 @@ function montarPayloadGemini(pdfBase64) {
 async function solicitarAnaliseGeminiComPDF() {
   try {
     const elementoDoDashboard = document.getElementById('dashboard-completo');
-    const pdfBlob = await html2pdf().from(elementoDoDashboard).outputPdf('blob');
+    const htmlContent = elementoDoDashboard.outerHTML;
+
+    const pdfBlob = await html2pdf()
+      .set({
+        filename: 'dashboard.pdf',
+        image: { type: 'jpeg', quality: 0.98 },
+        html2canvas: { scale: 2 },
+        jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' }
+      })
+      .from(htmlContent)
+      .outputPdf('blob');
     const pdfBase64 = await new Promise(resolve => {
       const reader = new FileReader();
       reader.onloadend = () => resolve(reader.result.split(',')[1]);


### PR DESCRIPTION
## Summary
- ensure dashboard PDF generation uses HTML string with proper rendering options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b322bd5a54832a81700682b9e00c25