### PR TITLE
Fix dashboard PDF export layout

### DIFF
--- a/dashboard-geral.js
+++ b/dashboard-geral.js
@@ -694,6 +694,7 @@ async function exportarFechamentoMes() {
   container.style.width = '190mm';
   container.style.margin = '0 auto';
   container.style.boxSizing = 'border-box';
+  container.style.backgroundColor = '#fff';
   container.innerHTML = gerarHTMLFechamento();
   document.body.appendChild(container);
 
@@ -799,7 +800,8 @@ async function exportarFechamentoMes() {
     html2pdf().set({
       margin: 10,
       filename: `fechamento-${dashboardData.mesAtual}.pdf`,
-      html2canvas: { scale: 2 },
+      pagebreak: { mode: ['css', 'legacy'] },
+      html2canvas: { scale: 1, useCORS: true, backgroundColor: '#fff' },
       jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' }
     }).from(container).save().then(() => container.remove());
   }, 1000);


### PR DESCRIPTION
## Summary
- ensure PDF container uses white background
- reduce html2canvas scale and enable page break options to avoid clipped exports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b592f2af3c832a91453e7396c6f625