### PR TITLE
feat: allow financial managers to view tiny orders

### DIFF
--- a/pedidos-tiny.html
+++ b/pedidos-tiny.html
@@ -21,6 +21,10 @@
       <div class="card-body">
         <div id="resumoPedidosTiny" class="resumo-grid mb-4 p-4 bg-white rounded-lg text-sm text-gray-700 shadow"></div>
         <div class="form-row items-end mb-4">
+          <div class="form-group compact hidden" id="grupoUsuario">
+            <label for="usuarioFiltro" class="block text-sm font-medium mb-1">Usuário</label>
+            <select id="usuarioFiltro" class="form-control"></select>
+          </div>
           <div class="form-group compact">
             <label for="tipoData" class="block text-sm font-medium mb-1">Data</label>
             <select id="tipoData" class="form-control">


### PR DESCRIPTION
## Summary
- show Tiny orders tab for both users and managers
- allow financial managers to view Tiny orders for accounts they manage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b59cfc8598832aabd03cb69d59f7e6