### PR TITLE
feat: redesign dashboard closing pdf layout

### DIFF
--- a/dashboard-geral.html
+++ b/dashboard-geral.html
@@ -140,6 +140,7 @@
     </div>
   </main>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="dashboard-geral.js"></script>
   <script>window.CUSTOM_SIDEBAR_PATH = '/VendedorPro/partials/sidebar.html';</script>


### PR DESCRIPTION
## Summary
- overhaul closing PDF with three-page executive summary, product analysis and projection sections
- add Chart.js datalabel plugin and register it for showing projection values
- include chart titles for daily revenue and cumulative vs. goal graphs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5a70cc8c0832aa3728bb531741efc