### PR TITLE
fix: restore print closing button on dashboard

### DIFF
--- a/dashboard-geral.html
+++ b/dashboard-geral.html
@@ -19,7 +19,7 @@
       <h1 class="text-lg md:text-xl font-semibold text-slate-900">Dashboard Geral</h1>
       <div class="flex items-center gap-3">
         <input type="month" id="filtroMes" class="h-10 rounded-xl border-slate-300 text-sm text-slate-700 focus:ring-2 focus:ring-indigo-500" />
-        <button id="exportarFechamentoBtn" class="btn-primary h-10">Exportar Fechamento</button>
+        <button id="imprimirFechamentoBtn" class="btn-primary h-10">Imprimir Fechamento</button>
       </div>
     </div>
   </header>

--- a/dashboard-geral.js
+++ b/dashboard-geral.js
@@ -693,7 +693,10 @@ function renderPrevisaoTopSkus(container, previsao, precos, metas) {
   container.innerHTML = `<div class="grid grid-cols-1 md:grid-cols-3 gap-4">${tabelas}</div>`;
 }
 
-document.getElementById('exportarFechamentoBtn')?.addEventListener('click', exportarFechamentoMes);
+document.getElementById('imprimirFechamentoBtn')?.addEventListener('click', exportarFechamentoMes);
+
+// Expose function globally in case the button is rendered dynamically
+window.exportarFechamentoMes = exportarFechamentoMes;
 
 async function exportarFechamentoMes() {
   const filtro = document.getElementById('filtroMes');


### PR DESCRIPTION
## Summary
- restore missing closing print button on the general dashboard
- expose export function globally for dynamic rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5f471dfd0832aa2aa24676107423e