### PR TITLE
chore: use gemini-2.0-flash-lite for ZPL import

### DIFF
--- a/zpl-import.html
+++ b/zpl-import.html
@@ -426,7 +426,7 @@ async function generateImageFromZpl(zplCode, dpmm, width, height) {
                 }
             };
             const apiKey = "AIzaSyDJWpigMGz4KV8XNcXd9r9VgbA24fy2Fec";
-            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`;
+            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:generateContent?key=${apiKey}`;
             let result;
             let attempts = 0;
             const maxAttempts = 5;
@@ -510,7 +510,7 @@ async function generateImageFromZpl(zplCode, dpmm, width, height) {
             };
             
             const apiKey = "AIzaSyDJWpigMGz4KV8XNcXd9r9VgbA24fy2Fec";
-            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent?key=${apiKey}`; 
+            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:generateContent?key=${apiKey}`; 
             
             let result; 
             let attempts = 0; 


### PR DESCRIPTION
## Summary
- switch label processing to `gemini-2.0-flash-lite`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b646d52204832ab0190e2db395197a