### PR TITLE
Update Gemini API key for ZPL import

### DIFF
--- a/zpl-import.html
+++ b/zpl-import.html
@@ -425,7 +425,7 @@ async function generateImageFromZpl(zplCode, dpmm, width, height) {
                     }
                 }
             };
-            const apiKey = "AIzaSyDJWpigMGz4KV8XNcXd9r9VgbA24fy2Fec";
+            const apiKey = "AIzaSyBm0JQ2vVEFGDfKWIQVcBmQ7CVaH6D3BTk";
             const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:generateContent?key=${apiKey}`;
             let result;
             let attempts = 0;
@@ -509,7 +509,7 @@ async function generateImageFromZpl(zplCode, dpmm, width, height) {
                 }
             };
             
-            const apiKey = "AIzaSyDJWpigMGz4KV8XNcXd9r9VgbA24fy2Fec";
+            const apiKey = "AIzaSyBm0JQ2vVEFGDfKWIQVcBmQ7CVaH6D3BTk";
             const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:generateContent?key=${apiKey}`; 
             
             let result; 


### PR DESCRIPTION
## Summary
- replace hardcoded Gemini API key in ZPL import module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6ccd82ac0832a8279e17b3f74f7ca