### PR TITLE
fix: include all finance users in faturamento view

### DIFF
--- a/atualizacoes.js
+++ b/atualizacoes.js
@@ -50,7 +50,14 @@ async function carregarUsuarios() {
   if (lista) lista.innerHTML = '';
   usuariosResponsaveis = [];
   try {
-    const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', currentUser.email)));
+    const email = currentUser.email || '';
+    const variations = [...new Set([email, email.toLowerCase(), email.toUpperCase()])];
+    const snap = await getDocs(
+      query(
+        collection(db, 'usuarios'),
+        where('responsavelFinanceiroEmail', 'in', variations)
+      )
+    );
     if (snap.empty) {
       card?.classList.add('hidden');
       return;

--- a/financeiro.js
+++ b/financeiro.js
@@ -26,7 +26,14 @@ onAuthStateChanged(auth, async user => {
   }
   let usuarios = [{ uid: user.uid, nome: user.displayName || user.email }];
   try {
-    const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email)));
+    const email = user.email || '';
+    const variations = [...new Set([email, email.toLowerCase(), email.toUpperCase()])];
+    const snap = await getDocs(
+      query(
+        collection(db, 'usuarios'),
+        where('responsavelFinanceiroEmail', 'in', variations)
+      )
+    );
     if (!snap.empty) {
       usuarios = await Promise.all(
         snap.docs.map(async d => {


### PR DESCRIPTION
## Summary
- ensure finance dashboards lookup responsible users case-insensitively

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7723c8ce4832a84c54476debfd0a2