### PR TITLE
Fix missing billing records for finance manager

### DIFF
--- a/financeiro.js
+++ b/financeiro.js
@@ -26,10 +26,19 @@ onAuthStateChanged(auth, async user => {
   }
   let usuarios = [{ uid: user.uid, nome: user.displayName || user.email }];
   try {
-    const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email)));
-    if (!snap.empty) {
+    const [snapUsuarios, snapUid] = await Promise.all([
+      getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email))),
+      getDocs(query(collection(db, 'uid'), where('responsavelFinanceiroEmail', '==', user.email)))
+    ]);
+    const docs = [...snapUsuarios.docs, ...snapUid.docs];
+    if (docs.length) {
+      const vistos = new Set();
       usuarios = await Promise.all(
-        snap.docs.map(async d => {
+        docs.filter(d => {
+          if (vistos.has(d.id)) return false;
+          vistos.add(d.id);
+          return true;
+        }).map(async d => {
           let nome = d.data().nome;
           if (!nome) {
             try {


### PR DESCRIPTION
## Summary
- include users assigned by `responsavelFinanceiroEmail` in both `usuarios` and `uid` collections when loading billing data
- expand finance page query to merge users from both collections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7723c8ce4832a84c54476debfd0a2