### PR TITLE
Handle extra financial manager emails

### DIFF
--- a/acompanhamento-tiny.js
+++ b/acompanhamento-tiny.js
@@ -19,9 +19,13 @@ onAuthStateChanged(auth, async user => {
   }
   let usuarios = [{ uid: user.uid, nome: user.displayName || user.email }];
   try {
-    const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email)));
-    if (!snap.empty) {
-      const extras = await Promise.all(snap.docs.map(async d => {
+    const [snapResp, snapGest] = await Promise.all([
+      getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email))),
+      getDocs(query(collection(db, 'usuarios'), where('gestoresFinanceirosEmails', 'array-contains', user.email)))
+    ]);
+    const docs = [...snapResp.docs, ...snapGest.docs];
+    if (docs.length) {
+      const extras = await Promise.all(docs.map(async d => {
         let nome = d.data().nome;
         if (!nome) {
           try {

--- a/atualizacoes.js
+++ b/atualizacoes.js
@@ -50,12 +50,14 @@ async function carregarUsuarios() {
   if (lista) lista.innerHTML = '';
   usuariosResponsaveis = [];
   try {
-    const [snapUsuarios, snapUid] = await Promise.all([
+    const [snapUsuarios, snapUid, snapUsuariosGest, snapUidGest] = await Promise.all([
       getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', currentUser.email))),
-      getDocs(query(collection(db, 'uid'), where('responsavelFinanceiroEmail', '==', currentUser.email)))
+      getDocs(query(collection(db, 'uid'), where('responsavelFinanceiroEmail', '==', currentUser.email))),
+      getDocs(query(collection(db, 'usuarios'), where('gestoresFinanceirosEmails', 'array-contains', currentUser.email))),
+      getDocs(query(collection(db, 'uid'), where('gestoresFinanceirosEmails', 'array-contains', currentUser.email)))
     ]);
 
-    if (snapUsuarios.empty && snapUid.empty) {
+    if (snapUsuarios.empty && snapUid.empty && snapUsuariosGest.empty && snapUidGest.empty) {
       card?.classList.add('hidden');
       return;
     }
@@ -88,8 +90,8 @@ async function carregarUsuarios() {
       }
     };
 
-    for (const d of snapUsuarios.docs) await adicionarUsuario(d);
-    for (const d of snapUid.docs) await adicionarUsuario(d);
+    const docs = [...snapUsuarios.docs, ...snapUid.docs, ...snapUsuariosGest.docs, ...snapUidGest.docs];
+    for (const d of docs) await adicionarUsuario(d);
 
     carregarHistoricoFaturamento();
   } catch (err) {

--- a/desempenho.js
+++ b/desempenho.js
@@ -18,10 +18,14 @@ onAuthStateChanged(auth, async user => {
   }
   usuarios = [{ uid: user.uid, nome: user.displayName || user.email }];
   try {
-    const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email)));
-    if (!snap.empty) {
+    const [snapResp, snapGest] = await Promise.all([
+      getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email))),
+      getDocs(query(collection(db, 'usuarios'), where('gestoresFinanceirosEmails', 'array-contains', user.email)))
+    ]);
+    const docs = [...snapResp.docs, ...snapGest.docs];
+    if (docs.length) {
       usuarios = await Promise.all(
-        snap.docs.map(async d => {
+        docs.map(async d => {
           let nome = d.data().nome;
           if (!nome) {
             try {

--- a/email-expedicao.html
+++ b/email-expedicao.html
@@ -80,21 +80,29 @@
         });
       });
 
-      db.collection('usuarios').where('responsavelFinanceiroEmail', '==', user.email).onSnapshot(snap => {
+      async function atualizarFinanceiros() {
+        const [snapResp, snapGest] = await Promise.all([
+          db.collection('usuarios').where('responsavelFinanceiroEmail', '==', user.email).get(),
+          db.collection('usuarios').where('gestoresFinanceirosEmails', 'array-contains', user.email).get()
+        ]);
         financialUsersList.innerHTML = '';
-        if (snap.empty) {
+        const docs = [...snapResp.docs, ...snapGest.docs];
+        if (!docs.length) {
           financialUsersTitle.classList.add('hidden');
           return;
         }
         financialUsersTitle.classList.remove('hidden');
-        snap.forEach(doc => {
+        docs.forEach(doc => {
           const dados = doc.data();
           const li = document.createElement('li');
           const nome = dados.nome || dados.email || doc.id;
           li.textContent = `${nome} - ${dados.email || ''}`;
           financialUsersList.appendChild(li);
         });
-      });
+      }
+      atualizarFinanceiros();
+      db.collection('usuarios').where('responsavelFinanceiroEmail', '==', user.email).onSnapshot(atualizarFinanceiros);
+      db.collection('usuarios').where('gestoresFinanceirosEmails', 'array-contains', user.email).onSnapshot(atualizarFinanceiros);
     });
 
     document.getElementById('emailForm').addEventListener('submit', async e => {

--- a/financeiro.js
+++ b/financeiro.js
@@ -26,11 +26,13 @@ onAuthStateChanged(auth, async user => {
   }
   let usuarios = [{ uid: user.uid, nome: user.displayName || user.email }];
   try {
-    const [snapUsuarios, snapUid] = await Promise.all([
+    const [snapUsuarios, snapUid, snapUsuariosGest, snapUidGest] = await Promise.all([
       getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email))),
-      getDocs(query(collection(db, 'uid'), where('responsavelFinanceiroEmail', '==', user.email)))
+      getDocs(query(collection(db, 'uid'), where('responsavelFinanceiroEmail', '==', user.email))),
+      getDocs(query(collection(db, 'usuarios'), where('gestoresFinanceirosEmails', 'array-contains', user.email))),
+      getDocs(query(collection(db, 'uid'), where('gestoresFinanceirosEmails', 'array-contains', user.email)))
     ]);
-    const docs = [...snapUsuarios.docs, ...snapUid.docs];
+    const docs = [...snapUsuarios.docs, ...snapUid.docs, ...snapUsuariosGest.docs, ...snapUidGest.docs];
     if (docs.length) {
       const vistos = new Set();
       usuarios = await Promise.all(

--- a/login.js
+++ b/login.js
@@ -286,9 +286,13 @@ async function showUserArea(user) {
 
     // 3) verifica se usuário é responsável financeiro e garante acesso às sobras
     try {
-      const q = query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email));
-      const respSnap = await getDocs(q);
-      window.isFinanceiroResponsavel = !respSnap.empty;
+      const [snapResp, snapGest, snapUidResp, snapUidGest] = await Promise.all([
+        getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email))),
+        getDocs(query(collection(db, 'usuarios'), where('gestoresFinanceirosEmails', 'array-contains', user.email))),
+        getDocs(query(collection(db, 'uid'), where('responsavelFinanceiroEmail', '==', user.email))),
+        getDocs(query(collection(db, 'uid'), where('gestoresFinanceirosEmails', 'array-contains', user.email)))
+      ]);
+      window.isFinanceiroResponsavel = [snapResp, snapGest, snapUidResp, snapUidGest].some(s => !s.empty);
       ensureFinanceiroMenu();
     } catch (e) {
       console.error('Erro ao verificar responsável financeiro:', e);

--- a/pedidos-tiny.js
+++ b/pedidos-tiny.js
@@ -19,9 +19,13 @@ onAuthStateChanged(auth, async user => {
   }
   let usuarios = [{ uid: user.uid, nome: user.displayName || user.email }];
   try {
-    const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email)));
-    if (!snap.empty) {
-      const extras = await Promise.all(snap.docs.map(async d => {
+    const [snapResp, snapGest] = await Promise.all([
+      getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email))),
+      getDocs(query(collection(db, 'usuarios'), where('gestoresFinanceirosEmails', 'array-contains', user.email)))
+    ]);
+    const docs = [...snapResp.docs, ...snapGest.docs];
+    if (docs.length) {
+      const extras = await Promise.all(docs.map(async d => {
         let nome = d.data().nome;
         if (!nome) {
           try {


### PR DESCRIPTION
## Summary
- Expand financial data loading to honor `gestoresFinanceirosEmails` across usuario and uid collections
- Detect financial manager status using both primary and additional email fields
- Refresh finance-related pages and email management to include users from `gestoresFinanceirosEmails`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b77caca298832aa3ded5d4c9f2123a