### PR TITLE
feat: sync faturamento with finance responsible

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -3179,6 +3179,81 @@ function atualizarTipoFiltroGestor() {
   else mesEl?.classList.remove('hidden');
 }
 
+async function atualizarResponsavelFinanceiro() {
+  const botao = document.getElementById('btnAtualizarRespFin');
+  if (botao) toggleLoading(botao, 'Atualizar Responsável');
+  try {
+    const usuarioDoc = await db.collection('usuarios').doc(usuarioLogado.uid).get();
+    const dadosUsuario = usuarioDoc.data() || {};
+    const respEmail = dadosUsuario.responsavelFinanceiroEmail;
+    if (!respEmail) {
+      alert('Nenhum responsável financeiro configurado.');
+      return;
+    }
+    const respSnap = await db.collection('usuarios').where('email', '==', respEmail).limit(1).get();
+    if (respSnap.empty) {
+      alert('Responsável financeiro não encontrado.');
+      return;
+    }
+    const responsavelUid = respSnap.docs[0].id;
+    const baseResp = db.collection('uid').doc(responsavelUid).collection('uid').doc(usuarioLogado.uid);
+    const pass = getPassphrase() || usuarioLogado.uid;
+    const filtroMes = document.getElementById('filtroMesAcompanhamento')?.value;
+    const { decryptString, encryptString } = await import('./crypto.js');
+    const snap = await db.collection('uid').doc(usuarioLogado.uid).collection('faturamento').get();
+    for (const doc of snap.docs) {
+      const dia = doc.id;
+      if (filtroMes) {
+        const [anoFiltro, mesFiltro] = filtroMes.split('-');
+        const [ano, mes] = dia.split('-');
+        if (ano !== anoFiltro || mes !== mesFiltro) continue;
+      }
+      let resumo = doc.data();
+      if (resumo.encrypted) {
+        try {
+          resumo = JSON.parse(await decryptString(resumo.encrypted, pass));
+        } catch (e) {
+          console.error('Erro ao descriptografar faturamento', e);
+          continue;
+        }
+      }
+      const resumoResp = await baseResp.collection('faturamento').doc(dia).get();
+      if (!resumoResp.exists) {
+        const encResumo = await encryptString(JSON.stringify(resumo), respEmail);
+        await baseResp.collection('faturamento').doc(dia).set({ encrypted: encResumo, uid: usuarioLogado.uid }, { merge: true });
+      }
+      const lojasSnap = await db.collection(`uid/${usuarioLogado.uid}/faturamento/${dia}/lojas`).get();
+      for (const lojaDoc of lojasSnap.docs) {
+        const loja = lojaDoc.id;
+        const destinoDoc = await baseResp.collection('faturamento').doc(dia).collection('lojas').doc(loja).get();
+        if (destinoDoc.exists) continue;
+        let dadosLoja = lojaDoc.data();
+        if (dadosLoja.encrypted) {
+          try {
+            dadosLoja = JSON.parse(await decryptString(dadosLoja.encrypted, pass));
+          } catch (e) {
+            console.error('Erro ao descriptografar faturamento', e);
+            continue;
+          }
+        }
+        const encLoja = await encryptString(JSON.stringify(dadosLoja), respEmail);
+        await baseResp
+          .collection('faturamento')
+          .doc(dia)
+          .collection('lojas')
+          .doc(loja)
+          .set({ encrypted: encLoja, uid: usuarioLogado.uid });
+      }
+    }
+    alert('Dados enviados ao responsável financeiro.');
+  } catch (e) {
+    console.error('Erro ao atualizar responsável financeiro', e);
+    alert('Erro ao atualizar responsável financeiro.');
+  } finally {
+    if (botao) toggleLoading(botao, 'Atualizar Responsável');
+  }
+}
+
 window.carregarRegistrosFaturamento = carregarRegistrosFaturamento;
 window.carregarControleVendas = carregarControleVendas;
 window.carregarSobras = carregarSobras;
@@ -3192,6 +3267,7 @@ window.exportarAcompanhamentoExcel = exportarAcompanhamentoExcel;
 window.exportarAcompanhamentoPDF = exportarAcompanhamentoPDF;
 window.printAcompanhamento = printAcompanhamento;
   window.salvarMetasAcompanhamento = salvarMetasAcompanhamento;
+window.atualizarResponsavelFinanceiro = atualizarResponsavelFinanceiro;
 window.exportarVendasMes = exportarVendasMes;
 window.mostrarDetalhesVendas = mostrarDetalhesVendas;
 window.mostrarDetalhesSobra = mostrarDetalhesSobra;

--- a/sobras-tabs/acompanhamento.html
+++ b/sobras-tabs/acompanhamento.html
@@ -48,6 +48,9 @@
     <button onclick="printAcompanhamento()" class="flex items-center gap-2 px-4 py-2 bg-gray-500 hover:bg-gray-600 text-white font-semibold rounded-lg shadow transition duration-150">
       <i class="fas fa-print"></i> Imprimir
     </button>
+    <button id="btnAtualizarRespFin" onclick="atualizarResponsavelFinanceiro()" class="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg shadow transition duration-150">
+      <i class="fas fa-user-check"></i> Atualizar Responsável
+    </button>
   </div>
 
   <!-- INÍCIO DA ÁREA DE IMPRESSÃO -->


### PR DESCRIPTION
## Summary
- add "Atualizar Responsável" button to acompanhamento de faturamento
- implement logic to decrypt faturamento and copy to financial responsible's collection if missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b81ce049ec832a9730cad323aa594c