### PR TITLE
Display per-user Tiny order summaries in Evolução das Vendas

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -62,6 +62,7 @@
     <div class="card p-4">
       <h4 class="text-sm text-gray-500 mb-2">Evolução das Vendas</h4>
       <canvas id="vendasChart" height="120"></canvas>
+      <div id="financeiroUsuarios" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mt-4"></div>
     </div>
 
     <div id="cardsContainer"></div>


### PR DESCRIPTION
## Summary
- Show daily Tiny order metrics (Valor Bruto, Valor Líquido, Pedidos) for each user inside Evolução das Vendas card
- Add helpers to compute net values and render per-user cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b826bf29ec832aa50228bf8ff55563