### PR TITLE
Busca faturamento via estrutura aninhada

### DIFF
--- a/atualizacoes.js
+++ b/atualizacoes.js
@@ -98,7 +98,10 @@ async function carregarUsuarios() {
 }
 
 async function calcularFaturamentoDiaDetalhado(uid, dia) {
-  const lojasSnap = await getDocs(collection(db, `uid/${uid}/faturamento/${dia}/lojas`));
+  let lojasSnap = await getDocs(collection(db, `uid/${currentUser.uid}/uid/${uid}/faturamento/${dia}/lojas`));
+  if (lojasSnap.empty) {
+    lojasSnap = await getDocs(collection(db, `uid/${uid}/faturamento/${dia}/lojas`));
+  }
   let liquido = 0;
   let bruto = 0;
   for (const lojaDoc of lojasSnap.docs) {
@@ -120,7 +123,10 @@ async function calcularFaturamentoDiaDetalhado(uid, dia) {
 }
 
 async function calcularVendasDia(uid, dia) {
-  const skusSnap = await getDocs(collection(db, `uid/${uid}/skusVendidos/${dia}/lista`));
+  let skusSnap = await getDocs(collection(db, `uid/${currentUser.uid}/uid/${uid}/skusVendidos/${dia}/lista`));
+  if (skusSnap.empty) {
+    skusSnap = await getDocs(collection(db, `uid/${uid}/skusVendidos/${dia}/lista`));
+  }
   let total = 0;
   skusSnap.forEach(doc => {
     const dados = doc.data();
@@ -153,12 +159,14 @@ async function carregarHistoricoFaturamento() {
   for (const u of usuariosResponsaveis) {
     let metaMensal = 0;
     try {
-      const metaDoc = await getDoc(doc(db, `uid/${u.uid}/metasFaturamento`, mesAtual));
+      let metaDoc = await getDoc(doc(db, `uid/${currentUser.uid}/uid/${u.uid}/metasFaturamento`, mesAtual));
+      if (!metaDoc.exists()) metaDoc = await getDoc(doc(db, `uid/${u.uid}/metasFaturamento`, mesAtual));
       if (metaDoc.exists()) metaMensal = Number(metaDoc.data().valor) || 0;
     } catch (_) {}
     const metaDiaria = totalDiasMes ? metaMensal / totalDiasMes : 0;
 
-    const fatSnap = await getDocs(collection(db, `uid/${u.uid}/faturamento`));
+    let fatSnap = await getDocs(collection(db, `uid/${currentUser.uid}/uid/${u.uid}/faturamento`));
+    if (fatSnap.empty) fatSnap = await getDocs(collection(db, `uid/${u.uid}/faturamento`));
     const dias = fatSnap.docs.map(d => d.id).sort().slice(-3);
 
     const col = document.createElement('div');


### PR DESCRIPTION
## Summary
- Ajusta carregamento do histórico de faturamento para buscar dados em `uid/<responsavel>/uid/<usuario>/faturamento`
- Inclui fallback para estrutura antiga de faturamento e vendas
- Garante leitura da meta mensal em estrutura aninhada

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b82bb65c5c832a83c67f147ffe4346