### PR TITLE
feat: sync sales with finance manager

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -3247,16 +3247,51 @@ async function atualizarResponsavelFinanceiro(btn) {
             console.error('Erro ao descriptografar faturamento', e);
             continue;
           }
-        }
-        const encLoja = await encryptString(JSON.stringify(dadosLoja), respEmail);
-        await baseResp
-          .collection('faturamento')
-          .doc(dia)
-          .collection('lojas')
-          .doc(loja)
-          .set({ encrypted: encLoja, uid: usuarioLogado.uid });
+      }
+      const encLoja = await encryptString(JSON.stringify(dadosLoja), respEmail);
+      await baseResp
+        .collection('faturamento')
+        .doc(dia)
+        .collection('lojas')
+        .doc(loja)
+        .set({ encrypted: encLoja, uid: usuarioLogado.uid });
       }
     }
+
+    // Copiar SKUs vendidos para o responsável financeiro
+    const skusSnap = await db.collection('uid').doc(usuarioLogado.uid).collection('skusVendidos').get();
+    for (const doc of skusSnap.docs) {
+      const dia = doc.id;
+      if (filtroMes) {
+        const [anoFiltro, mesFiltro] = filtroMes.split('-');
+        const [ano, mes] = dia.split('-');
+        if (ano !== anoFiltro || mes !== mesFiltro) continue;
+      }
+      const listaSnap = await db.collection(`uid/${usuarioLogado.uid}/skusVendidos/${dia}/lista`).get();
+      if (listaSnap.empty) continue;
+      await baseResp.collection('skusVendidos').doc(dia).set({ data: dia, uid: usuarioLogado.uid }, { merge: true });
+      for (const skuDoc of listaSnap.docs) {
+        const dadosSku = skuDoc.data();
+        const payload = {
+          sku: dadosSku.sku || skuDoc.id,
+          total: dadosSku.total || 0,
+          valorLiquido: dadosSku.valorLiquido || 0,
+          data: dia,
+          loja: dadosSku.loja || null,
+          uid: usuarioLogado.uid
+        };
+        const dadoSalvar = respEmail
+          ? { encrypted: await encryptString(JSON.stringify(payload), respEmail), uid: usuarioLogado.uid }
+          : payload;
+        await baseResp
+          .collection('skusVendidos')
+          .doc(dia)
+          .collection('lista')
+          .doc(skuDoc.id)
+          .set(dadoSalvar);
+      }
+    }
+
     alert('Dados enviados ao responsável financeiro.');
   } catch (e) {
     console.error('Erro ao atualizar responsável financeiro', e);

--- a/sobras-tabs/controleVendas.html
+++ b/sobras-tabs/controleVendas.html
@@ -13,9 +13,14 @@
             <input type="month" id="filtroMesVendas" class="border border-gray-300 rounded px-2 py-2"
               onchange="carregarControleVendas()" />
           </div>
-          <button onclick="exportarVendasMes()" class="flex items-center gap-2 px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded">
+          <div class="flex items-center gap-2">
+            <button onclick="exportarVendasMes()" class="flex items-center gap-2 px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded">
             <i class="fas fa-file-excel"></i> Exportar Mês
           </button>
+          <button id="btnAtualizarRespFinVendas" onclick="atualizarResponsavelFinanceiro(this)" class="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded">
+            <i class="fas fa-user-check"></i> Atualizar Responsável
+          </button>
+          </div>
         </div>
         <div id="cardsProjecao" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 p-4"></div>
         <div id="resumoMensalVendas" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 p-4"></div>


### PR DESCRIPTION
## Summary
- add finance manager sync button to sales control tab
- replicate sold SKUs to finance manager structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b82c96bcb8832abb6c9717a3afb931