### PR TITLE
Fix faturamento history decryption on updates page

### DIFF
--- a/atualizacoes.js
+++ b/atualizacoes.js
@@ -97,8 +97,11 @@ async function carregarUsuarios() {
   }
 }
 
-async function calcularFaturamentoDiaDetalhado(responsavelUid, uid, dia) {
-  const lojasSnap = await getDocs(collection(db, 'uid', responsavelUid, 'uid', uid, 'faturamento', dia, 'lojas'));
+async function calcularFaturamentoDiaDetalhado(uid, dia) {
+  // Busca registros de faturamento do dia para o usuário informado
+  // A estrutura dos dados segue o padrão `uid/{uid}/faturamento/{dia}/lojas`
+  // semelhante ao utilizado em outros módulos (ex: financeiro.js).
+  const lojasSnap = await getDocs(collection(db, 'uid', uid, 'faturamento', dia, 'lojas'));
   let liquido = 0;
   let bruto = 0;
   for (const lojaDoc of lojasSnap.docs) {
@@ -119,8 +122,10 @@ async function calcularFaturamentoDiaDetalhado(responsavelUid, uid, dia) {
   return { liquido, bruto };
 }
 
-async function calcularVendasDia(responsavelUid, uid, dia) {
-  const skusSnap = await getDocs(collection(db, 'uid', responsavelUid, 'uid', uid, 'skusVendidos', dia, 'lista'));
+async function calcularVendasDia(uid, dia) {
+  // Busca a quantidade de SKUs vendidos no dia para o usuário
+  // seguindo o padrão `uid/{uid}/skusVendidos/{dia}/lista`.
+  const skusSnap = await getDocs(collection(db, 'uid', uid, 'skusVendidos', dia, 'lista'));
   let total = 0;
   skusSnap.forEach(doc => {
     const dados = doc.data();
@@ -153,12 +158,14 @@ async function carregarHistoricoFaturamento() {
   for (const u of usuariosResponsaveis) {
     let metaMensal = 0;
     try {
-      const metaDoc = await getDoc(doc(db, 'uid', currentUser.uid, 'uid', u.uid, 'metasFaturamento', mesAtual));
+      // Metas de faturamento ficam armazenadas em `uid/{uid}/metasFaturamento/{mes}`
+      const metaDoc = await getDoc(doc(db, 'uid', u.uid, 'metasFaturamento', mesAtual));
       if (metaDoc.exists()) metaMensal = Number(metaDoc.data().valor) || 0;
     } catch (_) {}
     const metaDiaria = totalDiasMes ? metaMensal / totalDiasMes : 0;
 
-    const fatSnap = await getDocs(collection(db, 'uid', currentUser.uid, 'uid', u.uid, 'faturamento'));
+    // Recupera os registros de faturamento do usuário
+    const fatSnap = await getDocs(collection(db, 'uid', u.uid, 'faturamento'));
     const dias = fatSnap.docs.map(d => d.id).sort().slice(-3);
 
     const col = document.createElement('div');
@@ -170,8 +177,8 @@ async function carregarHistoricoFaturamento() {
     col.appendChild(header);
 
     for (const dia of dias) {
-      const { liquido, bruto } = await calcularFaturamentoDiaDetalhado(currentUser.uid, u.uid, dia);
-      const vendas = await calcularVendasDia(currentUser.uid, u.uid, dia);
+      const { liquido, bruto } = await calcularFaturamentoDiaDetalhado(u.uid, dia);
+      const vendas = await calcularVendasDia(u.uid, dia);
       const diff = metaDiaria - liquido;
       const atingido = diff <= 0;
       const day = document.createElement('div');


### PR DESCRIPTION
## Summary
- Correct faturamento and sales history retrieval to use uid-level paths
- Ensure metas and faturamento are loaded from same uid-level collections so decryption works

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b82e9a860c832a8b9d33390eb850bf