### PR TITLE
fix: decrypt billing history on updates page

### DIFF
--- a/atualizacoes.js
+++ b/atualizacoes.js
@@ -104,12 +104,14 @@ async function calcularFaturamentoDiaDetalhado(responsavelUid, uid, dia) {
   for (const lojaDoc of lojasSnap.docs) {
     let dados = lojaDoc.data();
     if (dados.encrypted) {
-      const pass = getPassphrase() || `chave-${uid}`;
       let txt;
-      try {
-        txt = await decryptString(dados.encrypted, pass);
-      } catch (e) {
-        try { txt = await decryptString(dados.encrypted, uid); } catch (_) {}
+      const candidates = [getPassphrase(), currentUser?.email, `chave-${uid}`, uid];
+      for (const p of candidates) {
+        if (!p) continue;
+        try {
+          txt = await decryptString(dados.encrypted, p);
+          if (txt) break;
+        } catch (_) {}
       }
       if (txt) dados = JSON.parse(txt);
     }


### PR DESCRIPTION
## Summary
- ensure billing history records decrypt correctly on the updates page by trying multiple passphrase options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b82e9a860c832a8b9d33390eb850bf