### PR TITLE
Exibir Top 5 SKUs no financeiro

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -54,7 +54,10 @@
 
     <div id="overviewCards" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
 
-    <div id="skusMesCard" class="card p-4 hidden"></div>
+    <div id="skusCardsContainer" class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <div id="skusMesCard" class="card p-4 hidden"></div>
+      <div id="topSkusCard" class="card p-4 hidden"></div>
+    </div>
 
     <h4 class="text-sm text-gray-500">Vendas do Dia Anterior</h4>
     <div id="vendasDiaAnterior" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>

--- a/financeiro.js
+++ b/financeiro.js
@@ -798,14 +798,19 @@ function createResumoCard(u) {
 
 function renderSkusCard(resumo) {
   const card = document.getElementById('skusMesCard');
-  if (!card) return;
+  const topCard = document.getElementById('topSkusCard');
+  if (!card || !topCard) return;
   const entries = Object.entries(resumo).sort((a, b) => b[1] - a[1]);
   if (!entries.length) {
     card.classList.add('hidden');
+    topCard.classList.add('hidden');
     card.innerHTML = '';
+    topCard.innerHTML = '';
     return;
   }
   card.classList.remove('hidden');
+  topCard.classList.remove('hidden');
+
   let html = '<h4 class="text-sm text-gray-500 mb-2">SKUs vendidos no mês</h4>';
   html += '<ul class="text-sm space-y-1">';
   entries.forEach(([sku, qtd]) => {
@@ -813,6 +818,14 @@ function renderSkusCard(resumo) {
   });
   html += '</ul>';
   card.innerHTML = html;
+
+  let topHtml = '<h4 class="text-sm text-gray-500 mb-2">Top 5 SKUs</h4>';
+  topHtml += '<ul class="text-sm space-y-1">';
+  entries.slice(0, 5).forEach(([sku, qtd]) => {
+    topHtml += `<li>${sku}: ${qtd}</li>`;
+  });
+  topHtml += '</ul>';
+  topCard.innerHTML = topHtml;
 }
 
 async function calcularFaturamentoDiaDetalhadoGestor(responsavelUid, uid, dia) {


### PR DESCRIPTION
## Summary
- split monthly SKUs card into two side-by-side cards
- show top 5 SKUs sold alongside full list in finance view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8350a1f94832a826e18bd6c3db5dc