### PR TITLE
Fix total faturado card aggregation

### DIFF
--- a/financeiro.js
+++ b/financeiro.js
@@ -374,12 +374,13 @@ async function carregarFaturamentoMeta(usuarios, mes) {
     let total = 0;
     let totalBruto = 0;
     const diario = {};
-    const snap = await getDocs(collection(db, `uid/${usuario.uid}/faturamento`));
+    const basePath = `uid/${currentUser.uid}/uid/${usuario.uid}/faturamento`;
+    const snap = await getDocs(collection(db, basePath));
     const dias = await Promise.all(
       snap.docs
         .filter(docSnap => !mes || docSnap.id.includes(mes))
         .map(async docSnap => {
-          const lojasSnap = await getDocs(collection(db, `uid/${usuario.uid}/faturamento/${docSnap.id}/lojas`));
+          const lojasSnap = await getDocs(collection(db, `${basePath}/${docSnap.id}/lojas`));
           let totalDia = 0;
           let totalDiaBruto = 0;
           await Promise.all(lojasSnap.docs.map(async lojaDoc => {


### PR DESCRIPTION
## Summary
- Sum gross revenue for all managed users using gestor's faturamento collection to populate the Total Faturado card

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b835a87870832ab542f2943949d404