### PR TITLE
Limit finance top sellers to 10 entries

### DIFF
--- a/financeiro.js
+++ b/financeiro.js
@@ -981,9 +981,12 @@ async function renderPedidosTinyHoje(lista) {
       <div>Valor Bruto: ${formatCurrency(bruto)}</div>
       <div>Valor Líquido: ${formatCurrency(liquido)}</div>
       <div>Pedidos: ${pedidos}</div>`;
-    cards.push(card);
+    cards.push({ card, bruto });
   }
-  cards.forEach(c => container.appendChild(c));
+  cards
+    .sort((a, b) => b.bruto - a.bruto)
+    .slice(0, 10)
+    .forEach(c => container.appendChild(c.card));
 }
 
 function renderTabelaSaques() {


### PR DESCRIPTION
## Summary
- Restrict finance sales evolution card to display only top 10 sellers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b89205c27c832a9c4d4912357934d6