### PR TITLE
Move SKU sales list to dedicated tracking page

### DIFF
--- a/acompanhamento-vendas.html
+++ b/acompanhamento-vendas.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Acompanhamento de Vendas</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css?v=20240826">
+  <link rel="stylesheet" href="css/components.css">
+</head>
+<body class="bg-gray-100 text-gray-800">
+  <div id="sidebar-container"></div>
+  <div id="navbar-container"></div>
+  <div class="main-content p-4 space-y-4">
+    <div class="card p-4 flex flex-wrap items-center gap-4">
+      <div class="flex items-center gap-2">
+        <button type="button" id="usuarioIcon" class="text-blue-500 focus:outline-none">
+          <i class="fa fa-user"></i>
+        </button>
+        <div class="flex flex-col">
+          <label for="usuarioFiltro" class="text-xs font-medium">Usuário</label>
+          <select id="usuarioFiltro" class="border rounded p-2 text-sm"></select>
+        </div>
+      </div>
+      <div class="flex items-center gap-2">
+        <button type="button" id="mesIcon" class="text-blue-500 focus:outline-none">
+          <i class="fa fa-calendar"></i>
+        </button>
+        <div class="flex flex-col">
+          <label for="mesFiltro" class="text-xs font-medium">Mês</label>
+          <input type="month" id="mesFiltro" class="border rounded p-2 text-sm" />
+        </div>
+      </div>
+    </div>
+    <div id="skusCardsContainer" class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <div id="skusMesCard" class="card p-4 hidden"></div>
+      <div id="topSkusCard" class="card p-4 hidden"></div>
+    </div>
+  </div>
+  <script type="module" src="firebase-config.js"></script>
+  <script type="module" src="acompanhamento-vendas.js"></script>
+  <script>window.CUSTOM_SIDEBAR_PATH = '/VendedorPro/partials/sidebar.html';</script>
+  <script src="shared.js"></script>
+</body>
+</html>

--- a/acompanhamento-vendas.js
+++ b/acompanhamento-vendas.js
@@ -1,0 +1,159 @@
+import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { getFirestore, collection, getDocs, query, where, orderBy, startAt, endAt, doc, getDoc } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { firebaseConfig, getPassphrase } from './firebase-config.js';
+import { loadSecureDoc } from './secure-firestore.js';
+
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+const db = getFirestore(app);
+const auth = getAuth(app);
+
+let usuariosCache = [];
+
+onAuthStateChanged(auth, async user => {
+  if (!user) {
+    window.location.href = 'index.html?login=1';
+    return;
+  }
+  let usuarios = [{ uid: user.uid, nome: user.displayName || user.email }];
+  try {
+    const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email)));
+    if (!snap.empty) {
+      const extras = await Promise.all(snap.docs.map(async d => {
+        let nome = d.data().nome;
+        if (!nome) {
+          try {
+            const perfil = await getDoc(doc(db, 'perfilMentorado', d.id));
+            if (perfil.exists()) nome = perfil.data().nome;
+          } catch (_) {}
+        }
+        return { uid: d.id, nome: nome || d.data().email || d.id };
+      }));
+      usuarios = usuarios.concat(extras);
+    }
+  } catch (err) {
+    console.error('Erro ao verificar acesso financeiro:', err);
+  }
+  usuariosCache = usuarios;
+  setupFiltros(usuarios);
+  await carregar();
+});
+
+function setupFiltros(usuarios) {
+  const userSel = document.getElementById('usuarioFiltro');
+  const mesSel = document.getElementById('mesFiltro');
+  if (!userSel || !mesSel) return;
+  userSel.innerHTML = '<option value="todos">Todos</option>';
+  usuarios.forEach(u => {
+    const opt = document.createElement('option');
+    opt.value = u.uid;
+    opt.textContent = u.nome;
+    userSel.appendChild(opt);
+  });
+  userSel.value = 'todos';
+  mesSel.value = formatMes(new Date());
+  userSel.addEventListener('change', carregar);
+  mesSel.addEventListener('change', carregar);
+}
+
+async function carregar() {
+  const mes = document.getElementById('mesFiltro')?.value;
+  const uid = document.getElementById('usuarioFiltro')?.value || 'todos';
+  const listaUsuarios = uid === 'todos' ? usuariosCache : usuariosCache.filter(u => u.uid === uid);
+  await carregarSkus(listaUsuarios, mes);
+}
+
+async function carregarSkus(usuarios, mes) {
+  const resumoGeral = {};
+  const mesData = mes ? parseMes(mes) : null;
+  for (const usuario of usuarios) {
+    const pass = getPassphrase() || `chave-${usuario.uid}`;
+    const baseCol = collection(db, `usuarios/${usuario.uid}/pedidostiny`);
+    let q = baseCol;
+    if (mesData) {
+      const inicio = new Date(mesData.getFullYear(), mesData.getMonth(), 1).toISOString().split('T')[0];
+      const fim = new Date(mesData.getFullYear(), mesData.getMonth() + 1, 0).toISOString().split('T')[0];
+      q = query(baseCol, orderBy('data'), startAt(inicio), endAt(fim));
+    }
+    const snap = await getDocs(q);
+    const promessas = snap.docs.map(async docSnap => {
+      let pedido = await loadSecureDoc(db, `usuarios/${usuario.uid}/pedidostiny`, docSnap.id, pass);
+      if (!pedido) {
+        const raw = docSnap.data();
+        if (raw && !raw.encrypted && !raw.encryptedData) pedido = raw;
+      }
+      if (!pedido) return {};
+      const dataStr = pedido.data || pedido.dataPedido || pedido.date || '';
+      const data = parseDate(dataStr);
+      if (mesData && !sameMonth(data, mesData)) return {};
+      const itens = Array.isArray(pedido.itens) && pedido.itens.length ? pedido.itens : [pedido];
+      const resumoLocal = {};
+      itens.forEach(item => {
+        const sku = item.sku || pedido.sku || 'sem-sku';
+        const qtd = Number(item.quantidade || item.qtd || item.quantity || item.total || 1) || 1;
+        resumoLocal[sku] = (resumoLocal[sku] || 0) + qtd;
+      });
+      return resumoLocal;
+    });
+    const resultados = await Promise.all(promessas);
+    resultados.forEach(res => {
+      Object.entries(res).forEach(([sku, qtd]) => {
+        resumoGeral[sku] = (resumoGeral[sku] || 0) + qtd;
+      });
+    });
+  }
+  renderSkusCard(resumoGeral);
+}
+
+function renderSkusCard(resumo) {
+  const card = document.getElementById('skusMesCard');
+  const topCard = document.getElementById('topSkusCard');
+  if (!card || !topCard) return;
+  const entries = Object.entries(resumo).sort((a, b) => b[1] - a[1]);
+  card.innerHTML = '';
+  topCard.innerHTML = '';
+  if (!entries.length) {
+    card.classList.add('hidden');
+    topCard.classList.add('hidden');
+    return;
+  }
+  card.classList.remove('hidden');
+  topCard.classList.remove('hidden');
+  let html = '<h4 class="text-sm text-gray-500 mb-2">SKUs vendidos no mês</h4><ul class="text-sm space-y-1">';
+  entries.forEach(([sku, qtd]) => { html += `<li>${sku}: ${qtd}</li>`; });
+  html += '</ul>';
+  card.innerHTML = html;
+  let topHtml = '<h4 class="text-sm text-gray-500 mb-2">Top 5 SKUs</h4><ul class="text-sm space-y-1">';
+  entries.slice(0,5).forEach(([sku, qtd]) => { topHtml += `<li>${sku}: ${qtd}</li>`; });
+  topHtml += '</ul>';
+  topCard.innerHTML = topHtml;
+}
+
+function parseDate(str) {
+  if (!str) return new Date('');
+  const parts = str.split(/[\/\-]/);
+  if (parts.length === 3) {
+    if (str.includes('-') && parts[0].length === 4) {
+      return new Date(str);
+    }
+    const [d, m, y] = parts;
+    return new Date(Number(y), Number(m) - 1, Number(d));
+  }
+  return new Date(str);
+}
+
+function parseMes(str) {
+  const [ano, mes] = (str || '').split('-').map(Number);
+  if (!ano || !mes) return new Date('');
+  return new Date(ano, mes - 1, 1);
+}
+
+function formatMes(date) {
+  const ano = date.getFullYear();
+  const mes = String(date.getMonth() + 1).padStart(2, '0');
+  return `${ano}-${mes}`;
+}
+
+function sameMonth(a, b) {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
+}

--- a/financeiro.html
+++ b/financeiro.html
@@ -53,12 +53,6 @@
     </div>
 
     <div id="overviewCards" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
-
-    <div id="skusCardsContainer" class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-      <div id="skusMesCard" class="card p-4 hidden"></div>
-      <div id="topSkusCard" class="card p-4 hidden"></div>
-    </div>
-
     <h4 class="text-sm text-gray-500">Vendas do Dia Anterior</h4>
     <div id="vendasDiaAnterior" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
 

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -87,6 +87,14 @@
         <span class="link-text">Acompanhamento Tiny</span>
       </a>
     </li>
+      <li>
+        <a href="/VendedorPro/acompanhamento-vendas.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-acompanhamento-vendas" data-perfil="gestor,mentor,gestor financeiro">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v6.75A1.125 1.125 0 0 1 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 9.75 19.875V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 16.5 19.875V4.125Z" />
+          </svg>
+          <span class="link-text">Acompanhamento Vendas</span>
+        </a>
+        </li>
 
     <li>
       <a href="/VendedorPro/mentoria.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-mentoria" data-perfil="gestor,mentor">


### PR DESCRIPTION
## Summary
- add `acompanhamento-vendas` page to display monthly and top SKU sales
- remove SKU listing code from finance page
- link sales tracking page in sidebar navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8d9933f10832a83fb09f928d65e56