### PR TITLE
Remove cards de vendas do dia anterior do financeiro

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -59,8 +59,6 @@
       <div id="topSkusCard" class="card p-4 hidden"></div>
     </div>
 
-    <h4 class="text-sm text-gray-500">Vendas do Dia Anterior</h4>
-    <div id="vendasDiaAnterior" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
 
     <div class="card p-4">
       <h4 class="text-sm text-gray-500 mb-2">Evolução das Vendas</h4>

--- a/financeiro.js
+++ b/financeiro.js
@@ -185,10 +185,7 @@ async function carregar() {
     if (texto) texto.textContent = '';
     if (resumo) resumo.textContent = '';
   }
-  await Promise.all([
-    renderVendasDiaAnterior(listaUsuarios),
-    renderPedidosTinyHoje(listaUsuarios)
-  ]);
+  await renderPedidosTinyHoje(listaUsuarios);
 }
 
 function atualizarContexto() {
@@ -874,78 +871,6 @@ function renderSkusCard(resumo) {
   });
   topHtml += '</ul>';
   topCard.innerHTML = topHtml;
-}
-
-async function calcularFaturamentoDiaDetalhadoGestor(responsavelUid, uid, dia) {
-  const lojasSnap = await getDocs(collection(db, `uid/${responsavelUid}/uid/${uid}/faturamento/${dia}/lojas`));
-  let liquido = 0;
-  let bruto = 0;
-  for (const lojaDoc of lojasSnap.docs) {
-    let dados = lojaDoc.data();
-    if (dados.encrypted) {
-      let txt;
-      const candidates = [getPassphrase(), currentUser?.email, `chave-${uid}`, uid];
-      for (const p of candidates) {
-        if (!p) continue;
-        try {
-          txt = await decryptString(dados.encrypted, p);
-          if (txt) break;
-        } catch (_) {}
-      }
-      if (txt) dados = JSON.parse(txt);
-    }
-    liquido += Number(dados.valorLiquido) || 0;
-    bruto += Number(dados.valorBruto) || 0;
-  }
-  return { liquido, bruto };
-}
-
-async function calcularVendasDiaGestor(responsavelUid, uid, dia) {
-  try {
-    const resumoDoc = await getDoc(doc(db, 'uid', responsavelUid, 'uid', uid, 'faturamento', dia));
-    if (resumoDoc.exists()) {
-      let dados = resumoDoc.data();
-      if (dados.encrypted) {
-        let txt;
-        const candidates = [getPassphrase(), currentUser?.email, `chave-${uid}`, uid];
-        for (const p of candidates) {
-          if (!p) continue;
-          try {
-            txt = await decryptString(dados.encrypted, p);
-            if (txt) break;
-          } catch (_) {}
-        }
-        if (txt) dados = JSON.parse(txt);
-      }
-      return Number(dados.vendas || dados.qtdVendas || dados.quantidade) || 0;
-    }
-  } catch (e) {
-    console.error('Erro ao calcular vendas do dia:', e);
-  }
-  return 0;
-}
-
-async function renderVendasDiaAnterior(lista) {
-  const container = document.getElementById('vendasDiaAnterior');
-  if (!container) return;
-  container.innerHTML = '';
-  const dia = new Date();
-  dia.setDate(dia.getDate() - 1);
-  const diaStr = dia.toISOString().slice(0,10);
-  const cards = [];
-  for (const u of lista) {
-    const { liquido, bruto } = await calcularFaturamentoDiaDetalhadoGestor(currentUser.uid, u.uid, diaStr);
-    const vendas = await calcularVendasDiaGestor(currentUser.uid, u.uid, diaStr);
-    const card = document.createElement('div');
-    card.className = 'card p-4';
-    card.innerHTML = `
-      <h4 class="font-bold mb-2">${u.nome}</h4>
-      <div>Bruto dia: R$ ${bruto.toLocaleString('pt-BR')}</div>
-      <div>Líquido dia: R$ ${liquido.toLocaleString('pt-BR')}</div>
-      <div>Qtd dia: ${vendas}</div>`;
-    cards.push(card);
-  }
-  cards.forEach(card => container.appendChild(card));
 }
 
 async function renderPedidosTinyHoje(lista) {


### PR DESCRIPTION
## Summary
- remove cards de vendas do dia anterior da aba financeiro
- limpa funções e chamadas relacionadas às vendas do dia anterior

## Testing
- `npm test` *(falhou: npm não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d9f4095c832aa647800d87f2466e