### PR TITLE
Remove previous day sales cards from finance tab

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -53,8 +53,6 @@
     </div>
 
     <div id="overviewCards" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
-    <h4 class="text-sm text-gray-500">Vendas do Dia Anterior</h4>
-    <div id="vendasDiaAnterior" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
 
     <div class="card p-4">
       <h4 class="text-sm text-gray-500 mb-2">Evolução das Vendas</h4>


### PR DESCRIPTION
## Summary
- Remove "Vendas do Dia Anterior" section from finance page
- Drop functions and calls that rendered previous day sales cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8db4c3f00832a9fe4d9d5dd8e6109