### PR TITLE
Fix gestor redirect to finance page

### DIFF
--- a/login.js
+++ b/login.js
@@ -271,7 +271,11 @@ async function showUserArea(user) {
 
     if (perfil === 'gestor') {
       const path = window.location.pathname.toLowerCase();
-      if (!path.endsWith('/financeiro.html')) {
+      if (
+        path.endsWith('/index.html') ||
+        path.endsWith('/login.html') ||
+        path.endsWith('/')
+      ) {
         window.location.href = 'financeiro.html';
         return;
       }


### PR DESCRIPTION
## Summary
- adjust login redirect so gestores can open mentoria, perfil-mentorado and gestão pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8e47c8238832ab0bba9e4a1744286