### PR TITLE
Support multiple expedition and financial managers

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -364,25 +364,26 @@ const API_URL = 'https://us-central1-matheus-35023.cloudfunctions.net/proxyDeepS
         const dadosUsuario = usuarioDoc.data() || {};
         const autorNome = dadosUsuario.nome || firebase.auth().currentUser?.email || '';
         const autorEmail = firebase.auth().currentUser?.email || '';
-        const respEmail = dadosUsuario.responsavelFinanceiroEmail;
-        if (!respEmail) return;
-        const respSnap = await db.collection('usuarios').where('email', '==', respEmail).limit(1).get();
-        if (respSnap.empty) return;
-        const respDoc = respSnap.docs[0];
-        const respData = respDoc.data() || {};
-        const responsavelUid = respData.uid || respDoc.id;
-        const descricao = `Faturamento de ${dataRef} da loja ${loja} atualizado. Bruto: R$ ${bruto.toFixed(2)}, Líquido: R$ ${liquido.toFixed(2)}, Vendas: ${qtdVendas}`;
-        await db.collection('financeiroAtualizacoes').add({
-          descricao,
-          autorUid: usuarioLogado.uid,
-          autorNome,
-          autorEmail,
-          dataFaturamento: dataRef,
-          destinatarios: [responsavelUid, usuarioLogado.uid],
-          createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-          anexos: [],
-          tipo: 'faturamento'
-        });
+        const respEmails = dadosUsuario.gestoresFinanceirosEmails || (dadosUsuario.responsavelFinanceiroEmail ? [dadosUsuario.responsavelFinanceiroEmail] : []);
+        for (const respEmail of respEmails) {
+          const respSnap = await db.collection('usuarios').where('email', '==', respEmail).limit(1).get();
+          if (respSnap.empty) continue;
+          const respDoc = respSnap.docs[0];
+          const respData = respDoc.data() || {};
+          const responsavelUid = respData.uid || respDoc.id;
+          const descricao = `Faturamento de ${dataRef} da loja ${loja} atualizado. Bruto: R$ ${bruto.toFixed(2)}, Líquido: R$ ${liquido.toFixed(2)}, Vendas: ${qtdVendas}`;
+          await db.collection('financeiroAtualizacoes').add({
+            descricao,
+            autorUid: usuarioLogado.uid,
+            autorNome,
+            autorEmail,
+            dataFaturamento: dataRef,
+            destinatarios: [responsavelUid, usuarioLogado.uid],
+            createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+            anexos: [],
+            tipo: 'faturamento'
+          });
+        }
       } catch (e) {
         console.error('Erro ao notificar responsável financeiro:', e);
       }
@@ -1466,7 +1467,8 @@ document.getElementById("dadosSobrasIA").value = sobras.map(s => {
           const rows = XLSX.utils.sheet_to_json(sheet);
           const usuarioDoc = await db.collection('usuarios').doc(usuarioLogado.uid).get();
           const dadosUsuario = usuarioDoc.data() || {};
-          const respEmail = dadosUsuario.responsavelFinanceiroEmail || null;
+          const finEmails = dadosUsuario.gestoresFinanceirosEmails || [];
+          const respEmail = finEmails[0] || dadosUsuario.responsavelFinanceiroEmail || null;
           let baseResp = null;
           if (respEmail) {
             const respSnap = await db.collection('usuarios').where('email', '==', respEmail).limit(1).get();
@@ -2120,8 +2122,13 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
         };
         const snap = await db.collection('uid').doc(usuarioLogado.uid).collection('pedidosErrados').get();
         addPedidos(snap, usuarioLogado.email || usuarioLogado.uid);
-        const respSnap = await db.collection('usuarios').where('responsavelFinanceiroEmail', '==', usuarioLogado.email).get();
-        for (const docSnap of respSnap.docs) {
+        const respSnap1 = await db.collection('usuarios').where('responsavelFinanceiroEmail', '==', usuarioLogado.email).get();
+        const respSnap2 = await db.collection('usuarios').where('gestoresFinanceirosEmails', 'array-contains', usuarioLogado.email).get();
+        const processados = new Set();
+        const todos = [...respSnap1.docs, ...respSnap2.docs];
+        for (const docSnap of todos) {
+          if (processados.has(docSnap.id)) continue;
+          processados.add(docSnap.id);
           const nome = docSnap.data().nome || docSnap.data().email || docSnap.id;
           const errSnap = await db.collection('uid').doc(docSnap.id).collection('pedidosErrados').get();
           addPedidos(errSnap, nome);
@@ -3080,11 +3087,11 @@ function filtrarPorSKU() {
 
 async function verificarGestorFinanceiro() {
   try {
-    const snap = await db.collection('usuarios')
-      .where('responsavelFinanceiroEmail', '==', usuarioLogado.email)
-      .limit(1)
-      .get();
-    if (!snap.empty) {
+    const [snap1, snap2] = await Promise.all([
+      db.collection('usuarios').where('responsavelFinanceiroEmail', '==', usuarioLogado.email).limit(1).get(),
+      db.collection('usuarios').where('gestoresFinanceirosEmails', 'array-contains', usuarioLogado.email).limit(1).get()
+    ]);
+    if (!snap1.empty || !snap2.empty) {
       const btn = document.getElementById('btnAcompanhamentoGestor');
       if (btn) btn.classList.remove('hidden');
     }
@@ -3098,11 +3105,12 @@ async function carregarAcompanhamentoGestor() {
   if (pedidosBody) pedidosBody.innerHTML = '';
 
   try {
-    const usuariosSnap = await db.collection('usuarios')
-      .where('responsavelFinanceiroEmail', '==', usuarioLogado.email)
-      .get();
+    const snap1 = await db.collection('usuarios').where('responsavelFinanceiroEmail', '==', usuarioLogado.email).get();
+    const snap2 = await db.collection('usuarios').where('gestoresFinanceirosEmails', 'array-contains', usuarioLogado.email).get();
+    const processados = new Set();
     const usuarios = [];
-    usuariosSnap.forEach(doc => usuarios.push({ uid: doc.id, ...doc.data() }));
+    snap1.forEach(doc => { if (!processados.has(doc.id)) { processados.add(doc.id); usuarios.push({ uid: doc.id, ...doc.data() }); } });
+    snap2.forEach(doc => { if (!processados.has(doc.id)) { processados.add(doc.id); usuarios.push({ uid: doc.id, ...doc.data() }); } });
 
     const selectUsuario = document.getElementById('filtroUsuarioGestor');
     if (selectUsuario && selectUsuario.options.length <= 1) {
@@ -3189,7 +3197,8 @@ async function atualizarResponsavelFinanceiro(btn) {
   try {
     const usuarioDoc = await db.collection('usuarios').doc(usuarioLogado.uid).get();
     const dadosUsuario = usuarioDoc.data() || {};
-    const respEmail = (dadosUsuario.responsavelFinanceiroEmail || '').trim();
+    const finEmails = dadosUsuario.gestoresFinanceirosEmails || [];
+    const respEmail = (finEmails[0] || dadosUsuario.responsavelFinanceiroEmail || '').trim();
     if (!respEmail) {
       alert('Nenhum responsável financeiro configurado.');
       return;

--- a/acompanhamento-tiny.js
+++ b/acompanhamento-tiny.js
@@ -19,9 +19,18 @@ onAuthStateChanged(auth, async user => {
   }
   let usuarios = [{ uid: user.uid, nome: user.displayName || user.email }];
   try {
-    const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email)));
-    if (!snap.empty) {
-      const extras = await Promise.all(snap.docs.map(async d => {
+    const [snap1, snap2] = await Promise.all([
+      getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email))),
+      getDocs(query(collection(db, 'usuarios'), where('gestoresFinanceirosEmails', 'array-contains', user.email)))
+    ]);
+    const docs = [...snap1.docs, ...snap2.docs];
+    if (docs.length) {
+      const vistos = new Set();
+      const extras = await Promise.all(docs.filter(d => {
+        if (vistos.has(d.id)) return false;
+        vistos.add(d.id);
+        return true;
+      }).map(async d => {
         let nome = d.data().nome;
         if (!nome) {
           try {

--- a/acompanhamento-vendas.js
+++ b/acompanhamento-vendas.js
@@ -17,9 +17,18 @@ onAuthStateChanged(auth, async user => {
   }
   let usuarios = [{ uid: user.uid, nome: user.displayName || user.email }];
   try {
-    const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email)));
-    if (!snap.empty) {
-      const extras = await Promise.all(snap.docs.map(async d => {
+    const [snap1, snap2] = await Promise.all([
+      getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email))),
+      getDocs(query(collection(db, 'usuarios'), where('gestoresFinanceirosEmails', 'array-contains', user.email)))
+    ]);
+    const docs = [...snap1.docs, ...snap2.docs];
+    if (docs.length) {
+      const vistos = new Set();
+      const extras = await Promise.all(docs.filter(d => {
+        if (vistos.has(d.id)) return false;
+        vistos.add(d.id);
+        return true;
+      }).map(async d => {
         let nome = d.data().nome;
         if (!nome) {
           try {

--- a/atualizacoes.js
+++ b/atualizacoes.js
@@ -50,12 +50,14 @@ async function carregarUsuarios() {
   if (lista) lista.innerHTML = '';
   usuariosResponsaveis = [];
   try {
-    const [snapUsuarios, snapUid] = await Promise.all([
+    const [snapUsuarios, snapUid, snapUsuarios2, snapUid2] = await Promise.all([
       getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', currentUser.email))),
-      getDocs(query(collection(db, 'uid'), where('responsavelFinanceiroEmail', '==', currentUser.email)))
+      getDocs(query(collection(db, 'uid'), where('responsavelFinanceiroEmail', '==', currentUser.email))),
+      getDocs(query(collection(db, 'usuarios'), where('gestoresFinanceirosEmails', 'array-contains', currentUser.email))),
+      getDocs(query(collection(db, 'uid'), where('gestoresFinanceirosEmails', 'array-contains', currentUser.email)))
     ]);
 
-    if (snapUsuarios.empty && snapUid.empty) {
+    if (snapUsuarios.empty && snapUid.empty && snapUsuarios2.empty && snapUid2.empty) {
       card?.classList.add('hidden');
       return;
     }
@@ -90,6 +92,8 @@ async function carregarUsuarios() {
 
     for (const d of snapUsuarios.docs) await adicionarUsuario(d);
     for (const d of snapUid.docs) await adicionarUsuario(d);
+    for (const d of snapUsuarios2.docs) await adicionarUsuario(d);
+    for (const d of snapUid2.docs) await adicionarUsuario(d);
 
     carregarHistoricoFaturamento();
   } catch (err) {

--- a/email-expedicao.html
+++ b/email-expedicao.html
@@ -18,7 +18,7 @@
     <h1 class="text-2xl font-bold mb-4">E-mails do Responsável pela Expedição</h1>
     <form id="emailForm" class="space-y-4 max-w-lg">
       <input type="text" id="emailExpedicao" placeholder="email@empresa.com, outro@empresa.com" class="w-full p-2 border rounded">
-      <input type="email" id="emailFinanceiro" placeholder="financeiro@empresa.com" class="w-full p-2 border rounded">
+      <input type="text" id="emailFinanceiro" placeholder="financeiro@empresa.com, outro@empresa.com" class="w-full p-2 border rounded">
       <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Salvar</button>
     </form>
     <p id="status" class="mt-4 text-green-600 hidden"></p>
@@ -65,7 +65,8 @@
         const data = doc.data() || {};
         const emails = data.gestoresExpedicaoEmails || data.responsavelExpedicaoEmail || '';
         input.value = Array.isArray(emails) ? emails.join(', ') : emails;
-        financeInput.value = data.responsavelFinanceiroEmail || '';
+        const finEmails = data.gestoresFinanceirosEmails || data.responsavelFinanceiroEmail || '';
+        financeInput.value = Array.isArray(finEmails) ? finEmails.join(', ') : finEmails;
       } catch (e) {
         console.error('Erro ao carregar e-mail:', e);
       }
@@ -80,20 +81,34 @@
         });
       });
 
-      db.collection('usuarios').where('responsavelFinanceiroEmail', '==', user.email).onSnapshot(snap => {
+      const renderFinanceUsers = usuarios => {
         financialUsersList.innerHTML = '';
-        if (snap.empty) {
+        if (!usuarios.length) {
           financialUsersTitle.classList.add('hidden');
           return;
         }
         financialUsersTitle.classList.remove('hidden');
-        snap.forEach(doc => {
-          const dados = doc.data();
+        usuarios.forEach(dados => {
           const li = document.createElement('li');
-          const nome = dados.nome || dados.email || doc.id;
+          const nome = dados.nome || dados.email || dados.id;
           li.textContent = `${nome} - ${dados.email || ''}`;
           financialUsersList.appendChild(li);
         });
+      };
+
+      let finDocs1 = [], finDocs2 = [];
+      const mergeAndRender = () => {
+        const map = new Map();
+        [...finDocs1, ...finDocs2].forEach(d => map.set(d.id, d));
+        renderFinanceUsers(Array.from(map.values()));
+      };
+      db.collection('usuarios').where('responsavelFinanceiroEmail', '==', user.email).onSnapshot(snap => {
+        finDocs1 = snap.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+        mergeAndRender();
+      });
+      db.collection('usuarios').where('gestoresFinanceirosEmails', 'array-contains', user.email).onSnapshot(snap => {
+        finDocs2 = snap.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+        mergeAndRender();
       });
     });
 
@@ -102,17 +117,20 @@
       statusEl.classList.add('hidden');
       const emailsRaw = input.value.trim();
       const emails = emailsRaw.split(',').map(e => e.trim()).filter(e => e);
-      const emailFinanceiro = financeInput.value.trim();
+      const financeRaw = financeInput.value.trim();
+      const finEmails = financeRaw.split(',').map(e => e.trim()).filter(e => e);
       try {
         await db.collection('uid').doc(currentUser.uid).set({
           responsavelExpedicaoEmail: emails[0] || null,
           gestoresExpedicaoEmails: emails,
-          responsavelFinanceiroEmail: emailFinanceiro || null,
+          responsavelFinanceiroEmail: finEmails[0] || null,
+          gestoresFinanceirosEmails: finEmails,
           uid: currentUser.uid,
           email: currentUser.email
         }, { merge: true });
         await db.collection('usuarios').doc(currentUser.uid).set({
-          responsavelFinanceiroEmail: emailFinanceiro || null,
+          responsavelFinanceiroEmail: finEmails[0] || null,
+          gestoresFinanceirosEmails: finEmails,
           gestoresExpedicaoEmails: emails,
           email: currentUser.email
         }, { merge: true });

--- a/financeiro.js
+++ b/financeiro.js
@@ -27,11 +27,13 @@ onAuthStateChanged(auth, async user => {
   currentUser = user;
   let usuarios = [{ uid: user.uid, nome: user.displayName || user.email }];
   try {
-    const [snapUsuarios, snapUid] = await Promise.all([
+    const [snapUsuarios, snapUid, snapUsuarios2, snapUid2] = await Promise.all([
       getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email))),
-      getDocs(query(collection(db, 'uid'), where('responsavelFinanceiroEmail', '==', user.email)))
+      getDocs(query(collection(db, 'uid'), where('responsavelFinanceiroEmail', '==', user.email))),
+      getDocs(query(collection(db, 'usuarios'), where('gestoresFinanceirosEmails', 'array-contains', user.email))),
+      getDocs(query(collection(db, 'uid'), where('gestoresFinanceirosEmails', 'array-contains', user.email)))
     ]);
-    const docs = [...snapUsuarios.docs, ...snapUid.docs];
+    const docs = [...snapUsuarios.docs, ...snapUid.docs, ...snapUsuarios2.docs, ...snapUid2.docs];
     if (docs.length) {
       const vistos = new Set();
       usuarios = await Promise.all(

--- a/mentoria.js
+++ b/mentoria.js
@@ -11,14 +11,16 @@ const auth = getAuth(app);
 function carregarUsuariosFinanceiros(user) {
   const container = document.getElementById('mentoradosList');
   const mesAtual = new Date().toISOString().slice(0, 7);
-  const q = query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email));
-  onSnapshot(q, async snap => {
+  const q1 = query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email));
+  const q2 = query(collection(db, 'usuarios'), where('gestoresFinanceirosEmails', 'array-contains', user.email));
+  const mergeSnaps = async snap => {
     container.innerHTML = '';
-    if (snap.empty) {
+    const docs = [...snap.docs];
+    if (!docs.length) {
       container.innerHTML = '<p class="text-sm text-gray-500 col-span-full">Nenhum usuário encontrado.</p>';
       return;
     }
-    for (const docSnap of snap.docs) {
+    for (const docSnap of docs) {
       const dados = docSnap.data();
       const email = dados.email || '';
       let perfilData = {};
@@ -58,7 +60,9 @@ function carregarUsuariosFinanceiros(user) {
       });
       container.appendChild(card);
     }
-  });
+  };
+  onSnapshot(q1, mergeSnaps);
+  onSnapshot(q2, mergeSnaps);
 }
 
 async function calcularResumo(uid) {

--- a/painel-usuarios.html
+++ b/painel-usuarios.html
@@ -26,6 +26,7 @@
           <input type="text" id="nome" placeholder="Nome do Usuário" class="w-full p-2 border rounded">
           <input type="email" id="email" placeholder="E-mail do Usuário" class="w-full p-2 border rounded">
           <input type="text" id="emailExpedicao" placeholder="E-mails Responsável Expedição (separados por vírgula)" class="w-full p-2 border rounded">
+          <input type="text" id="emailFinanceiro" placeholder="E-mails Responsável Financeiro (separados por vírgula)" class="w-full p-2 border rounded">
       <select id="perfil" class="w-full p-2 border rounded">
         <option value="Cliente">Cliente</option>
         <option value="ADM">ADM</option>
@@ -81,8 +82,10 @@ if (!firebase.apps.length) {
       const uid = document.getElementById("uid").value.trim();
       const nome = document.getElementById("nome").value.trim();
       const email = document.getElementById("email").value.trim();
- const emailExpedicaoRaw = document.getElementById("emailExpedicao").value.trim();
+      const emailExpedicaoRaw = document.getElementById("emailExpedicao").value.trim();
       const gestoresEmails = emailExpedicaoRaw.split(',').map(e => e.trim()).filter(e => e);
+      const emailFinanceiroRaw = document.getElementById("emailFinanceiro").value.trim();
+      const gestoresFinEmails = emailFinanceiroRaw.split(',').map(e => e.trim()).filter(e => e);
       const perfil = document.getElementById("perfil").value;
 
       if (uid && nome && email) {
@@ -91,11 +94,18 @@ const { encryptString } = await import('./crypto.js');
         await db.collection('uid').doc(uid).set({
           uid,
           email,
- responsavelExpedicaoEmail: gestoresEmails[0] || null,
+          responsavelExpedicaoEmail: gestoresEmails[0] || null,
           gestoresExpedicaoEmails: gestoresEmails,
+          responsavelFinanceiroEmail: gestoresFinEmails[0] || null,
+          gestoresFinanceirosEmails: gestoresFinEmails,
           encrypted: await encryptString(JSON.stringify({ nome, perfil }), pass)
         });
-        await db.collection('usuarios').doc(uid).set({ perfil, email }, { merge: true });
+        await db.collection('usuarios').doc(uid).set({
+          perfil,
+          email,
+          responsavelFinanceiroEmail: gestoresFinEmails[0] || null,
+          gestoresFinanceirosEmails: gestoresFinEmails
+        }, { merge: true });
         alert("Usuário salvo com sucesso!");
         carregarUsuarios();
       }
@@ -111,12 +121,14 @@ const { encryptString } = await import('./crypto.js');
         const pass = getPassphrase() || `chave-${doc.id}`;
         const data = JSON.parse(await decryptString(enc, pass));
         const info = doc.data();
-const respArr = info.gestoresExpedicaoEmails || [];
+        const respArr = info.gestoresExpedicaoEmails || [];
         const resp = respArr.length ? respArr.join(', ') : (info.responsavelExpedicaoEmail || 'N/A');
-         const email = info.email || 'N/A';
+        const finArr = info.gestoresFinanceirosEmails || [];
+        const fin = finArr.length ? finArr.join(', ') : (info.responsavelFinanceiroEmail || 'N/A');
+        const email = info.email || 'N/A';
         const item = document.createElement("li");
         item.className = "p-2 bg-gray-50 border rounded";
-        item.innerText = `UID: ${doc.id} | Email: ${email} | Resp Exp: ${resp} | Nome: ${data.nome} | Perfil: ${data.perfil}`;
+        item.innerText = `UID: ${doc.id} | Email: ${email} | Resp Exp: ${resp} | Resp Fin: ${fin} | Nome: ${data.nome} | Perfil: ${data.perfil}`;
         lista.appendChild(item);
     }
     }

--- a/pedidos-tiny.js
+++ b/pedidos-tiny.js
@@ -19,9 +19,18 @@ onAuthStateChanged(auth, async user => {
   }
   let usuarios = [{ uid: user.uid, nome: user.displayName || user.email }];
   try {
-    const snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email)));
-    if (!snap.empty) {
-      const extras = await Promise.all(snap.docs.map(async d => {
+    const [snap1, snap2] = await Promise.all([
+      getDocs(query(collection(db, 'usuarios'), where('responsavelFinanceiroEmail', '==', user.email))),
+      getDocs(query(collection(db, 'usuarios'), where('gestoresFinanceirosEmails', 'array-contains', user.email)))
+    ]);
+    const docs = [...snap1.docs, ...snap2.docs];
+    if (docs.length) {
+      const vistos = new Set();
+      const extras = await Promise.all(docs.filter(d => {
+        if (vistos.has(d.id)) return false;
+        vistos.add(d.id);
+        return true;
+      }).map(async d => {
         let nome = d.data().nome;
         if (!nome) {
           try {


### PR DESCRIPTION
## Summary
- Allow admins to set multiple expedition and financial responsible emails
- Deliver financial updates to all registered responsibles
- Detect finance privileges across modules using email arrays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8ed517c28832aba566dda3c550cc7