### PR TITLE
fix: handle invalid dates in tiny tracking filter

### DIFF
--- a/acompanhamento-tiny.js
+++ b/acompanhamento-tiny.js
@@ -216,7 +216,7 @@ export function aplicarFiltros() {
     } else if (tipo === 'personalizado' && inicio && fim) {
       const i = parseDate(inicio);
       const f = parseDate(fim);
-      if (data < i || data > f) return false;
+      if (isNaN(data) || data < i || data > f) return false;
     }
 
     const lojaPedido = (p.loja || p.store || '').toLowerCase();


### PR DESCRIPTION
## Summary
- ensure Tiny tracking filters skip orders with invalid dates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b96aec6dec832a9d291d1dbb451769