### PR TITLE
fix: correct date parsing for Tiny tracking

### DIFF
--- a/acompanhamento-tiny.js
+++ b/acompanhamento-tiny.js
@@ -108,13 +108,19 @@ function preencherFiltroLoja(pedidos) {
 
 function parseDate(str) {
   if (!str) return new Date('');
+  if (str.includes('T') || str.includes(' ')) {
+    const d = new Date(str);
+    if (!isNaN(d)) return d;
+  }
   const parts = str.split(/[\/\-]/);
   if (parts.length === 3) {
+    let y, m, d;
     if (str.includes('-') && parts[0].length === 4) {
-      return new Date(str);
+      [y, m, d] = parts;
+    } else {
+      [d, m, y] = parts;
     }
-    const [d, m, y] = parts;
-    return new Date(`${y}-${m}-${d}`);
+    return new Date(Number(y), Number(m) - 1, Number(d));
   }
   return new Date(str);
 }


### PR DESCRIPTION
## Summary
- handle more date formats without timezone shifts in Tiny dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b96ceb40b0832a92dae45f4cb4783d