### PR TITLE
Open mentor details in new tab

### DIFF
--- a/mentoria.js
+++ b/mentoria.js
@@ -54,7 +54,7 @@ function carregarUsuariosFinanceiros(user) {
       `;
       card.addEventListener('click', e => {
         if (e.target.tagName === 'A') return;
-        mostrarDetalhes(docSnap.id, dados, perfilData);
+        window.open(`perfil-mentorado.html?uid=${docSnap.id}`, '_blank');
       });
       container.appendChild(card);
     }


### PR DESCRIPTION
## Summary
- allow opening mentee details in a new browser tab from the Mentoria card

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b96db279c4832a8ad94de4df22c952