### PR TITLE
refactor: remove duplicate styles

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -22,14 +22,6 @@
 .btn-primary:active { background-color: #3730a3; }
 .btn-primary:disabled { opacity: .5; }
 
-.section-title {
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: #0f172a;
-}
-@media (min-width:768px) {
-  .section-title { font-size: 1.25rem; }
-}
 
 .dropdown {
   position: relative;

--- a/dashboard-geral.js
+++ b/dashboard-geral.js
@@ -245,7 +245,7 @@ function renderKpis(bruto, liquido, unidades, ticket, meta, diasAcima, diasAbaix
   const kpis = document.getElementById('kpis');
   if (!kpis) return;
   const card = (titulo, valor, subt = '') => `
-    <div class="card">
+    <div class="dashboard-card">
       <div class="text-slate-600 text-sm font-medium tracking-wide uppercase">${titulo}</div>
       <div class="mt-2 flex items-end gap-2">
         <div class="text-2xl md:text-3xl font-semibold text-slate-900">${valor}</div>
@@ -872,9 +872,9 @@ async function exportarFechamentoMes() {
       const pess = base * 0.85;
       const otm = base * 1.15;
       cardsPrev.innerHTML = `
-        <div class="card" style="background:#fee2e2;color:#991b1b;"><div>Pessimista</div><strong>${pess.toFixed(0)}</strong></div>
-        <div class="card" style="background:#dbeafe;color:#1e3a8a;"><div>Base</div><strong>${base.toFixed(0)}</strong></div>
-        <div class="card" style="background:#d1fae5;color:#065f46;"><div>Otimista</div><strong>${otm.toFixed(0)}</strong></div>
+        <div class="dashboard-card" style="background:#fee2e2;color:#991b1b;"><div>Pessimista</div><strong>${pess.toFixed(0)}</strong></div>
+        <div class="dashboard-card" style="background:#dbeafe;color:#1e3a8a;"><div>Base</div><strong>${base.toFixed(0)}</strong></div>
+        <div class="dashboard-card" style="background:#d1fae5;color:#065f46;"><div>Otimista</div><strong>${otm.toFixed(0)}</strong></div>
       `;
     }
     renderPrevisaoChart(container.querySelector('#previsaoChart'), prev.dados);
@@ -947,7 +947,7 @@ function gerarHTMLFechamento() {
           color: var(--primary-color);
         }
         .header .responsavel { text-align: right; font-size: 12px; }
-        .section-title {
+        .dashboard-section-title {
           font-size: 18px;
           font-weight: 600;
           color: var(--primary-color);
@@ -962,7 +962,7 @@ function gerarHTMLFechamento() {
           gap: 15px;
           margin-bottom: 20px;
         }
-        .card {
+        .dashboard-card {
           background-color: var(--card-bg);
           border: 1px solid #e5e7eb;
           border-radius: 12px;
@@ -970,13 +970,13 @@ function gerarHTMLFechamento() {
           text-align: center;
           box-shadow: 0 2px 4px rgba(0,0,0,0.05);
         }
-        .card .icon {
+        .dashboard-card .icon {
           font-size: 28px;
           margin-bottom: 8px;
           color: var(--secondary-color);
         }
-        .card .label { font-size: 12px; color: #6b7280; margin-top: 4px; }
-        .card .value {
+        .dashboard-card .label { font-size: 12px; color: #6b7280; margin-top: 4px; }
+        .dashboard-card .value {
           font-size: 24px;
           font-weight: 600;
           color: var(--text-color);
@@ -1036,26 +1036,26 @@ function gerarHTMLFechamento() {
           <div class="title">Fechamento de ${mesTitle}</div>
           <div class="responsavel">${d.responsavel ? `Responsável: ${d.responsavel}` : ''}</div>
         </div>
-        <h2 class="section-title">1. Resumo Executivo</h2>
+        <h2 class="dashboard-section-title">1. Resumo Executivo</h2>
         <p>Desempenho financeiro consolidado do período com comparação à meta estabelecida.</p>
-        <h3 class="section-title">Indicadores Chave do Mês</h3>
+        <h3 class="dashboard-section-title">Indicadores Chave do Mês</h3>
         <div class="cards">
-          <div class="card">
+          <div class="dashboard-card">
             <div class="icon"><i class='bx bx-money'></i></div>
             <div class="label">Faturamento Bruto</div>
             <div class="value">R$ ${d.totalBruto.toLocaleString('pt-BR',{minimumFractionDigits:2,maximumFractionDigits:2})}</div>
           </div>
-          <div class="card">
+          <div class="dashboard-card">
             <div class="icon"><i class='bx bx-wallet'></i></div>
             <div class="label">Faturamento Líquido</div>
             <div class="value">R$ ${d.totalLiquido.toLocaleString('pt-BR',{minimumFractionDigits:2,maximumFractionDigits:2})} <i class='bx ${iconLiquido} ${classeLiquido}'></i></div>
           </div>
-          <div class="card">
+          <div class="dashboard-card">
             <div class="icon"><i class='bx bx-package'></i></div>
             <div class="label">Pedidos Totais</div>
             <div class="value">${d.totalUnidades}</div>
           </div>
-          <div class="card">
+          <div class="dashboard-card">
             <div class="icon"><i class='bx bx-stats'></i></div>
             <div class="label">Ticket Médio</div>
             <div class="value">R$ ${d.ticketMedio.toLocaleString('pt-BR',{minimumFractionDigits:2,maximumFractionDigits:2})}</div>
@@ -1070,28 +1070,28 @@ function gerarHTMLFechamento() {
           <span>${d.diasAcima} dias acima da meta</span>
           <span>${d.diasAbaixo} dias abaixo da meta</span>
         </div>
-        <h3 class="section-title">Desempenho Faturamento</h3>
+        <h3 class="dashboard-section-title">Desempenho Faturamento</h3>
         <div class="chart-container"><canvas id="diarioChart"></canvas></div>
         <div class="chart-container"><canvas id="tendenciaChart"></canvas></div>
       </div>
       <div class="page">
-        <h2 class="section-title">2. Análise Detalhada</h2>
-        <h3 class="section-title">Desempenho por Produto (SKU)</h3>
+        <h2 class="dashboard-section-title">2. Análise Detalhada</h2>
+        <h3 class="dashboard-section-title">Desempenho por Produto (SKU)</h3>
         <div class="chart-container"><canvas id="topSkusMargemChart"></canvas></div>
         <div class="tables-container">
           <div class="table-box">
-            <h4 class="section-title" style="font-size:14px;">Top 5 SKUs do mês</h4>
+            <h4 class="dashboard-section-title" style="font-size:14px;">Top 5 SKUs do mês</h4>
             <ol id="topSkusList" class="list-items"></ol>
           </div>
           <div class="table-box">
-            <h4 class="section-title" style="font-size:14px;">Top 5 mais rentáveis</h4>
+            <h4 class="dashboard-section-title" style="font-size:14px;">Top 5 mais rentáveis</h4>
             <ol id="topRentaveis" class="list-items"></ol>
           </div>
         </div>
       </div>
       <div class="page">
-        <h2 class="section-title">3. Projeções e Previsões</h2>
-        <h3 class="section-title">Projeção de Vendas</h3>
+        <h2 class="dashboard-section-title">3. Projeções e Previsões</h2>
+        <h3 class="dashboard-section-title">Projeção de Vendas</h3>
         <div class="chart-container"><canvas id="previsaoChart"></canvas></div>
         <div id="topSkusPrevisao"></div>
       </div>

--- a/equipes.html
+++ b/equipes.html
@@ -278,22 +278,6 @@
             margin-left: 0;
         }
 
-        /* Team Section */
-        .section-title {
-            font-size: 20px;
-            font-weight: 600;
-            margin: 32px 0 24px;
-            padding-bottom: 12px;
-            border-bottom: 1px solid var(--border);
-        }
-        .section-title-with-btn {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            padding-bottom: 12px;
-            border-bottom: 1px solid var(--border);
-        }
-        
         .members-grid {
             display: grid;
             grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));

--- a/gestao-contas.html
+++ b/gestao-contas.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="css/components.css">
   <style>
     body{font-family:system-ui,Segoe UI,Roboto,Arial;margin:24px;max-width:920px}
-    .card{border:1px solid var(--border);border-radius:14px;padding:16px;margin:12px 0}
+    .account-card{margin:12px 0}
     .row{display:flex;gap:12px;flex-wrap:wrap}
     label{font-weight:600}
     input,button,select{padding:10px;border:1px solid #d1d5db;border-radius:10px}
@@ -33,7 +33,7 @@
     <h1>Leitor de Boletos</h1>
     <p class="muted">Aponte a câmera para o código de barras OU cole a linha digitável abaixo.</p>
 
-    <div class="card">
+    <div class="card account-card">
       <div class="row">
         <button id="btnStart">Iniciar câmera</button>
         <button id="btnStop" disabled>Parar</button>
@@ -43,7 +43,7 @@
       <div class="muted">Formato suportado: ITF/Code128 (a maioria dos boletos). Iluminação ajuda muito.</div>
     </div>
 
-    <div class="card">
+    <div class="card account-card">
       <label for="linha">Linha digitável (47/48 dígitos)</label>
       <div class="row">
         <input id="linha" placeholder="Ex.: 34191.79001 01043.510047 91020.150008 9 12345678901234" style="flex:1" />
@@ -52,13 +52,13 @@
       <div id="status"></div>
     </div>
 
-    <div class="card">
+    <div class="card account-card">
       <h3>Resultado</h3>
       <div id="resultado" class="grid"></div>
     </div>
 
     <h2>Financeiro - Fechamentos</h2>
-    <div class="card">
+    <div class="card account-card">
       <input type="file" id="inputPdfFechamento" accept="application/pdf" multiple />
       <div class="row" style="margin-top:8px">
         <button id="btnProcessarPdf">Processar PDF</button>

--- a/pdf-x-excel.html
+++ b/pdf-x-excel.html
@@ -17,7 +17,7 @@
     :root{--bg:#0b1020;--card:#111834;--muted:#9fb1ff;--ink:#e9edff;--accent:#6ea8ff}
     *{box-sizing:border-box} body{font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;background:linear-gradient(180deg,#0b1020,#0d1430 30%,#0b1020 100%);color:var(--ink);min-height:100vh;margin:0}
     .wrap{max-width:1100px;margin:32px auto;padding:0 16px}
-    .card{background:rgba(17,24,52,.7);backdrop-filter: blur(8px);border:1px solid rgba(255,255,255,.06);border-radius:20px;box-shadow:0 10px 40px rgba(0,0,0,.35)}
+    .glass-card{background:rgba(17,24,52,.7);backdrop-filter: blur(8px);border:1px solid rgba(255,255,255,.06);border-radius:20px;box-shadow:0 10px 40px rgba(0,0,0,.35)}
     .pad{padding:20px}
     h1{font-size:28px;margin:0 0 8px} .sub{color:#bcd0ff;margin:0 0 16px}
     .row{display:flex;gap:14px;flex-wrap:wrap}
@@ -46,7 +46,7 @@
   <div id="navbar-container"></div>
   <div class="main-content">
   <div class="wrap">
-    <div class="card pad">
+    <div class="card glass-card pad">
       <h1>PDF → Excel (layout fiel) — v1</h1>
       <p class="sub">Lê PDFs <span class="pill">Rech Orçamento (SIGER)</span> e <span class="pill">TOTVS Posicao dos Clientes</span> e exporta Excel com layout, cabeçalho, bordas, mesclagens e formatos.
       </p>
@@ -62,11 +62,11 @@
     </div>
 
     <div class="grid" style="margin-top:16px">
-      <div class="card pad">
+      <div class="card glass-card pad">
         <h3 style="margin:0 0 10px">Prévia interpretada</h3>
         <div id="preview" class="mono" style="font-size:12px"></div>
       </div>
-      <div class="card pad">
+      <div class="card glass-card pad">
         <h3 style="margin:0 0 10px">Tabela (amostra)</h3>
         <div style="overflow:auto;max-height:480px">
           <table id="tbl" class="table"></table>
@@ -74,7 +74,7 @@
       </div>
     </div>
 
-    <div class="card pad" style="margin-top:16px">
+    <div class="card glass-card pad" style="margin-top:16px">
       <div class="hstack">
         <div class="kbd">Dica</div>
         <div class="muted">Este protótipo está calibrado para os exemplos enviados. Se o seu layout variar, ajuste as regras de parsing dentro do código (seções <span class="mono">parseRechOrcamento</span> e <span class="mono">parseTotvsPosicaoClientes</span>).</div>
@@ -82,7 +82,7 @@
       <div id="log" class="log" style="margin-top:10px"></div>
     </div>
 
-    <div class="card pad tests" style="margin-top:16px">
+    <div class="card glass-card pad tests" style="margin-top:16px">
       <strong>Testes automatizados</strong>
       <div>Use o botão <em>🧪 Rodar testes</em> para validar o detector/parsers localmente. Resultados aparecem no log.</div>
     </div>


### PR DESCRIPTION
## Summary
- remove leftover section-title and card style duplicates
- add specific dashboard, account, and glass card classes
- clean unused styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b978fc143c832aa3697e2677f0f8ae