### PR TITLE
refactor: centralize global font styles

### DIFF
--- a/atualizacoes-dia.html
+++ b/atualizacoes-dia.html
@@ -6,11 +6,11 @@
   <title>Atualizações do Dia</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="css/styles.css?v=20240826" />
   <link rel="stylesheet" href="css/components.css" />
 </head>
-<body class="bg-gray-100" style="font-family: 'Poppins', sans-serif;">
+<body class="bg-gray-100">
   <button class="mobile-menu-btn" onclick="toggleSidebar()" aria-label="Abrir menu" aria-expanded="false">☰</button>
   <div id="sidebar-container"></div>
   <div id="navbar-container"></div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -32,7 +32,7 @@
   
 
 body {
-  font-family: 'Poppins', sans-serif;
+  font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
 }
 
 #sidebar-container {

--- a/dashboard-geral.js
+++ b/dashboard-geral.js
@@ -908,9 +908,9 @@ function gerarHTMLFechamento() {
   const classeLiquido = variacaoLiquido >= 0 ? 'trend-up' : 'trend-down';
 
   return `
-    <div style="font-family:'Poppins',sans-serif;width:100%;max-width:190mm;color:#111827;">
+    <div style="font-family:'Inter',sans-serif;width:100%;max-width:190mm;color:#111827;">
       <style>
-        @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
         @import url('https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css');
         :root {
           --primary-color: #4C1D95;

--- a/equipes.html
+++ b/equipes.html
@@ -15,7 +15,6 @@
             margin: 0;
             padding: 0;
             box-sizing: border-box;
-            font-family: 'Inter', sans-serif;
         }
 
         :root {

--- a/etiquetas-ocr.html
+++ b/etiquetas-ocr.html
@@ -18,9 +18,6 @@
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/tesseract.js@4.0.2/dist/tesseract.min.js"></script>
   <style>
-    body {
-      font-family: 'Inter', sans-serif;
-    }
     /* Barra de progresso customizada */
     .progress-bar-bg {
       background: linear-gradient(90deg, #cfd9df 0%, #e2ebf0 100%);

--- a/expedicao-historico.html
+++ b/expedicao-historico.html
@@ -6,14 +6,14 @@
   <title>Histórico Expedição</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/styles.css?v=20240826">
   <link rel="stylesheet" href="css/components.css">
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
 </head>
-<body class="bg-gray-100" style="font-family: 'Poppins', sans-serif;">
+<body class="bg-gray-100">
   <div id="sidebar-container"></div>
   <div id="navbar-container"></div>
   <div class="main-content p-4">

--- a/expedicao.html
+++ b/expedicao.html
@@ -6,7 +6,7 @@
     <title>Expedição</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/styles.css?v=20240826">
     <link rel="stylesheet" href="css/components.css">
     <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
@@ -17,7 +17,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/tesseract.js@4.0.2/dist/tesseract.min.js"></script>
   </head>
-  <body class="bg-gray-100" style="font-family: 'Poppins', sans-serif;">
+  <body class="bg-gray-100">
   <div id="sidebar-container"></div>
   <div id="navbar-container"></div>
   <div id="gestorUsersCard" class="hidden fixed top-24 right-4 w-72 bg-white rounded shadow-lg p-4">

--- a/gestao-contas.html
+++ b/gestao-contas.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="css/styles.css?v=20240826">
   <link rel="stylesheet" href="css/components.css">
   <style>
-    body{font-family:system-ui,Segoe UI,Roboto,Arial;margin:24px;max-width:920px}
+    body{margin:24px;max-width:920px}
     .card{border:1px solid var(--border);border-radius:14px;padding:16px;margin:12px 0}
     .row{display:flex;gap:12px;flex-wrap:wrap}
     label{font-weight:600}

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>VendedorPro - Sistema Premium</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/styles.css?v=20240826">
   <link rel="stylesheet" href="css/components.css">
   <link rel="stylesheet" href="https://unpkg.com/intro.js/minified/introjs.min.css">

--- a/manual.html
+++ b/manual.html
@@ -12,7 +12,6 @@
   <style>
     :root { --brand:#f97316; }
     html { scroll-behavior: smooth; }
-    body { font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
     /* Caixa de destaque */
     .callout { @apply rounded-xl p-4 border; }
     .callout-tip { background: #f0fdf4; border-color:#86efac; }

--- a/mentoria.html
+++ b/mentoria.html
@@ -18,7 +18,6 @@
   <!-- Layout padrão para TODAS as páginas -->
   <style>
     :root { --sbw: 256px; } /* largura do sidebar */
-    body { font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
     @media (min-width:1024px){ .main-content { margin-left: var(--sbw); } } /* empurra o conteúdo no desktop */
     .mobile-menu-btn{ position:fixed; left:12px; top:12px; z-index:50; }
   </style>

--- a/pdf-x-excel.html
+++ b/pdf-x-excel.html
@@ -15,7 +15,7 @@
   <script src="https://cdn.jsdelivr.net/npm/file-saver@2.0.5/dist/FileSaver.min.js"></script>
   <style>
     :root{--bg:#0b1020;--card:#111834;--muted:#9fb1ff;--ink:#e9edff;--accent:#6ea8ff}
-    *{box-sizing:border-box} body{font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;background:linear-gradient(180deg,#0b1020,#0d1430 30%,#0b1020 100%);color:var(--ink);min-height:100vh;margin:0}
+    *{box-sizing:border-box} body{background:linear-gradient(180deg,#0b1020,#0d1430 30%,#0b1020 100%);color:var(--ink);min-height:100vh;margin:0}
     .wrap{max-width:1100px;margin:32px auto;padding:0 16px}
     .card{background:rgba(17,24,52,.7);backdrop-filter: blur(8px);border:1px solid rgba(255,255,255,.06);border-radius:20px;box-shadow:0 10px 40px rgba(0,0,0,.35)}
     .pad{padding:20px}

--- a/shopee-sync-extension/popup.html
+++ b/shopee-sync-extension/popup.html
@@ -4,8 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Shopee Sync</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
-    body { font-family: Arial, sans-serif; width: 300px; padding: 10px; }
+    body { font-family: 'Inter', sans-serif; width: 300px; padding: 10px; }
     input { width: 100%; margin-bottom: 5px; }
     button { width: 100%; margin-top: 5px; }
   </style>

--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -7,6 +7,7 @@
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="css/styles.css?v=20240826">
     <link rel="stylesheet" href="css/components.css">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <!-- A biblioteca pdf-lib é carregada aqui -->
     <script src="https://unpkg.com/pdf-lib@1.4.0"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
@@ -14,13 +15,6 @@
     <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-storage-compat.js"></script>
     <script type="module" src="firebase-config.js"></script>
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@600;800&display=swap'); 
-        body { 
-            font-family: 'Inter', sans-serif; 
-            background-color: #f0f4f8; 
-        } 
-    </style> 
     <script src="https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.min.js"></script>
 </head> 
 <body class="bg-gray-50">

--- a/zpl-import.html
+++ b/zpl-import.html
@@ -7,6 +7,7 @@
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="css/styles.css?v=20240826">
     <link rel="stylesheet" href="css/components.css">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <!-- A biblioteca pdf-lib é carregada aqui -->
     <script src="https://unpkg.com/pdf-lib@1.4.0"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
@@ -14,13 +15,6 @@
     <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-storage-compat.js"></script>
     <script type="module" src="firebase-config.js"></script>
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@600;800&display=swap'); 
-        body { 
-            font-family: 'Inter', sans-serif; 
-            background-color: #f0f4f8; 
-        } 
-    </style> 
 </head> 
 <body class="bg-gray-50">
   <div id="sidebar-container"></div>


### PR DESCRIPTION
## Summary
- centralize font styling in global stylesheet
- drop inline font declarations across various pages

## Testing
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68b978fc143c832aa3697e2677f0f8ae