### PR TITLE
fix: ajusta layout do dashboard geral

### DIFF
--- a/dashboard-geral.html
+++ b/dashboard-geral.html
@@ -13,18 +13,18 @@
 <body class="bg-slate-50 text-slate-700">
   <div id="sidebar-container"></div>
   <div id="navbar-container"></div>
-
-  <header class="sticky top-0 bg-white/80 backdrop-blur border-b border-slate-200">
-    <div class="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
-      <h1 class="text-lg md:text-xl font-semibold text-slate-900">Dashboard Geral</h1>
-      <div class="flex flex-wrap items-center gap-3">
-        <input type="month" id="filtroMes" class="h-10 rounded-xl border-slate-300 text-sm text-slate-700 focus:ring-2 focus:ring-indigo-500" />
-        <button id="imprimirFechamentoBtn" class="btn-primary h-10 flex-shrink-0">Imprimir Fechamento</button>
+  <div class="main-content">
+    <header class="sticky top-0 bg-white/80 backdrop-blur border-b border-slate-200">
+      <div class="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
+        <h1 class="text-lg md:text-xl font-semibold text-slate-900">Dashboard Geral</h1>
+        <div class="flex flex-wrap items-center gap-3">
+          <input type="month" id="filtroMes" class="h-10 rounded-xl border-slate-300 text-sm text-slate-700 focus:ring-2 focus:ring-indigo-500" />
+          <button id="imprimirFechamentoBtn" class="btn-primary h-10 flex-shrink-0">Imprimir Fechamento</button>
+        </div>
       </div>
-    </div>
-  </header>
+    </header>
 
-  <main id="dashboard-completo" class="max-w-7xl mx-auto px-4 py-6 space-y-6">
+    <main id="dashboard-completo" class="max-w-7xl mx-auto px-4 py-6 space-y-6">
     <div class="flex flex-wrap gap-3">
       <button class="tab-btn rounded-xl border border-slate-300 bg-slate-900 text-white px-4 py-2" data-tab="overview">Visão Geral</button>
       <button class="tab-btn rounded-xl border border-slate-300 bg-white text-slate-700 px-4 py-2" data-tab="meta">Comparativo com a Meta</button>
@@ -142,7 +142,8 @@
       <div id="analise-ia-output" class="mt-4"></div>
       <!-- END: Botão de Análise de IA -->
     </div>
-  </main>
+    </main>
+  </div>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="dashboard-geral.js"></script>


### PR DESCRIPTION
## Summary
- adiciona contêiner `.main-content` no dashboard geral para que o sidebar não sobreponha o conteúdo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b97caf05e8832aae3e5d49df5a77c5