### PR TITLE
feat: paginate Tiny tracking with combined filters

### DIFF
--- a/acompanhamento-tiny.html
+++ b/acompanhamento-tiny.html
@@ -79,6 +79,7 @@
             <tbody></tbody>
           </table>
         </div>
+        <div id="paginacaoTiny" class="mt-4 flex justify-center items-center space-x-2 text-sm"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- allow simultaneous filters like user and day for Tiny tracking
- paginate Tiny orders, 20 per page, with navigation and filter-aware summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b98346ee98832aba17da8fb0539a93