### PR TITLE
Fix mobile sidebar toggle on updates page

### DIFF
--- a/atualizacoes.html
+++ b/atualizacoes.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="css/components.css" />
 </head>
 <body class="bg-gray-100 text-gray-800">
-  <button class="mobile-menu-btn" onclick="toggleSidebar()" aria-label="Abrir menu" aria-expanded="false">☰</button>
+  <button class="mobile-menu-btn" aria-label="Abrir menu" aria-expanded="false">☰</button>
   <div id="sidebar-container"></div>
   <div id="navbar-container"></div>
   <main class="main-content p-4 space-y-4">

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,6 +1,6 @@
   <div class="navbar">
       <div class="flex items-center">
-        <button class="mobile-menu-btn hamburger mr-4 text-gray-200" aria-label="Abrir menu" aria-expanded="false" onclick="toggleSidebar()">
+        <button class="mobile-menu-btn hamburger mr-4 text-gray-200" aria-label="Abrir menu" aria-expanded="false">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5" />
           </svg>


### PR DESCRIPTION
## Summary
- Remove inline sidebar toggle from updates page's mobile menu
- Drop redundant click handler from navbar partial

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b98576c80c832a82ef1023b981c6c0