### PR TITLE
fix: resolve duplicate inicio variable in acompanhamento-tiny

### DIFF
--- a/acompanhamento-tiny.js
+++ b/acompanhamento-tiny.js
@@ -240,8 +240,8 @@ export function aplicarFiltros(resetPage = false) {
   filtradosAtuais = filtrados;
   const totalPaginas = Math.ceil(filtradosAtuais.length / pedidosPorPagina) || 1;
   if (paginaAtual > totalPaginas) paginaAtual = totalPaginas;
-  const inicio = (paginaAtual - 1) * pedidosPorPagina;
-  const paginaPedidos = filtradosAtuais.slice(inicio, inicio + pedidosPorPagina);
+  const inicioPaginacao = (paginaAtual - 1) * pedidosPorPagina;
+  const paginaPedidos = filtradosAtuais.slice(inicioPaginacao, inicioPaginacao + pedidosPorPagina);
 
   tbody.innerHTML = '';
   paginaPedidos.forEach(p => {


### PR DESCRIPTION
## Summary
- rename pagination offset variable to avoid re-declaring `inicio`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9861a19a0832a8ad03bcf1c685b28