### PR TITLE
fix: prevent summary totals from increasing after filter

### DIFF
--- a/acompanhamento-tiny.js
+++ b/acompanhamento-tiny.js
@@ -51,6 +51,7 @@ export async function carregarPedidosTiny() {
   try {
     todosPedidos = [];
     custosProdutos = {};
+    filtradosAtuais = [];
     await Promise.all(
       usuariosCache.map(async u => {
         const pass = getPassphrase() || `chave-${u.uid}`;
@@ -237,7 +238,8 @@ export function aplicarFiltros(resetPage = false) {
     return true;
   });
 
-  filtradosAtuais = filtrados;
+  filtradosAtuais = [];
+  filtradosAtuais.push(...filtrados);
   const totalPaginas = Math.ceil(filtradosAtuais.length / pedidosPorPagina) || 1;
   if (paginaAtual > totalPaginas) paginaAtual = totalPaginas;
   const inicioPaginacao = (paginaAtual - 1) * pedidosPorPagina;


### PR DESCRIPTION
## Summary
- Reset filtered order cache when reloading Tiny orders
- Rebuild filtered list on each Acompanhamento Tiny filter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b987d08374832aa1f12e13301dbdb7