### PR TITLE
Fix duplicated label storage for shipping managers

### DIFF
--- a/etiquetas-ocr.html
+++ b/etiquetas-ocr.html
@@ -490,21 +490,10 @@ completoCtx.drawImage(
         };
         await db.collection('users').doc(currentUser.uid).collection('etiquetaenvio').add({ ...record });
         if (responsavelExpedicaoUid) {
-          const respDocRef = await db.collection('pdfDocs').add({
-            ownerUid: responsavelExpedicaoUid,
-            ownerEmail: '',
-            gestoresExpedicaoEmails: gestoresEmails,
-            createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-            name: fileName
-          });
-          const respFileRef = storage.ref().child(`pdfs/${responsavelExpedicaoUid}/${respDocRef.id}.pdf`);
-          await respFileRef.put(pdfFile);
-          const respUrl = await respFileRef.getDownloadURL();
-          await respDocRef.update({ url: respUrl, storagePath: respFileRef.fullPath });
           const respRecord = {
             name: fileName,
-            url: respUrl,
-            path: respFileRef.fullPath,
+            url: url,
+            path: fileRef.fullPath,
             createdAt: firebase.firestore.FieldValue.serverTimestamp()
           };
           await db.collection('users').doc(responsavelExpedicaoUid).collection('etiquetaenvio').add({ ...respRecord });

--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -129,22 +129,11 @@
                 createdAt: firebase.firestore.FieldValue.serverTimestamp()
             };
             await db.collection('users').doc(currentUser.uid).collection('etiquetaenvio').add({ ...record });
-             if (responsavelExpedicaoUid) {
-                const respDocRef = await db.collection('pdfDocs').add({
-                    ownerUid: responsavelExpedicaoUid,
-                    ownerEmail: responsavelExpedicaoEmail || '',
-                    gestoresExpedicaoEmails: gestoresEmails,
-                    createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-                    name: name
-                });
-                const respFileRef = storage.ref().child(`pdfs/${responsavelExpedicaoUid}/${respDocRef.id}.pdf`);
-                await respFileRef.put(blob);
-                const respUrl = await respFileRef.getDownloadURL();
-                await respDocRef.update({ url: respUrl, storagePath: respFileRef.fullPath });
+            if (responsavelExpedicaoUid) {
                 const respRecord = {
                     name: name,
-                    url: respUrl,
-                    path: respFileRef.fullPath,
+                    url: url,
+                    path: fileRef.fullPath,
                     createdAt: firebase.firestore.FieldValue.serverTimestamp()
                 };
                 await db.collection('users').doc(responsavelExpedicaoUid).collection('etiquetaenvio').add({ ...respRecord });

--- a/zpl-import.html
+++ b/zpl-import.html
@@ -137,22 +137,11 @@
                 createdAt: firebase.firestore.FieldValue.serverTimestamp()
             };
             await db.collection('users').doc(currentUser.uid).collection('etiquetaenvio').add({ ...record });
-             if (responsavelExpedicaoUid) {
-                const respDocRef = await db.collection('pdfDocs').add({
-                    ownerUid: responsavelExpedicaoUid,
-                    ownerEmail: responsavelExpedicaoEmail || '',
-                    gestoresExpedicaoEmails: gestoresEmails,
-                    createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-                    name: name
-                });
-                const respFileRef = storage.ref().child(`pdfs/${responsavelExpedicaoUid}/${respDocRef.id}.pdf`);
-                await respFileRef.put(blob);
-                const respUrl = await respFileRef.getDownloadURL();
-                await respDocRef.update({ url: respUrl, storagePath: respFileRef.fullPath });
+            if (responsavelExpedicaoUid) {
                 const respRecord = {
                     name: name,
-                    url: respUrl,
-                    path: respFileRef.fullPath,
+                    url: url,
+                    path: fileRef.fullPath,
                     createdAt: firebase.firestore.FieldValue.serverTimestamp()
                 };
                 await db.collection('users').doc(responsavelExpedicaoUid).collection('etiquetaenvio').add({ ...respRecord });


### PR DESCRIPTION
## Summary
- avoid creating duplicate pdfDocs and storage uploads when sharing processed labels with a shipping manager
- reuse original label file and simply record it for the responsible expedition user

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bac7c54d48832a90ded02bf37bf223