### PR TITLE
feat: enable iOS app installation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="manifest" href="manifest.json">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <link rel="apple-touch-icon" href="icons/icon-192.png">
+  <meta name="theme-color" content="#2196f3">
   <title>VendedorPro - Sistema Premium</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">

--- a/index.js
+++ b/index.js
@@ -531,3 +531,9 @@ async function carregarGraficoFaturamento(uid, isAdmin) {
     metaText.textContent = `${percent.toFixed(0)}% da meta alcançada`;
   }
 }
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker
+    .register('service-worker.js')
+    .catch(err => console.error('SW registration failed', err));
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "VendedorPro",
+  "short_name": "VendedorPro",
+  "start_url": "index.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#2196f3",
+  "icons": [
+    {
+      "src": "icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,9 @@
 const CACHE_VERSION = '20240826';
-const CACHE_PREFIX  = 'financeiro-cache-v';
+const CACHE_PREFIX  = 'app-cache-v';
 const CACHE_NAME    = `${CACHE_PREFIX}${CACHE_VERSION}`;
 const URLS_TO_CACHE = [
+  'index.html',
+  'index.js',
   'financeiro.html',
   'financeiro.js',
   `css/styles.css?v=${CACHE_VERSION}`,


### PR DESCRIPTION
## Summary
- add PWA manifest and iOS meta tags for home screen support
- register service worker and cache base files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baceb9801c832aaa1a54f46bd14f10