### PR TITLE
refactor: improve expedicao layout

### DIFF
--- a/expedicao.html
+++ b/expedicao.html
@@ -26,42 +26,44 @@
   </div>
   <div class="main-content p-4">
     <h1 class="text-2xl font-bold mb-4">Expedição</h1>
-    <div id="actionBar" class="sticky top-0 z-10 bg-white border-b shadow-sm mb-4 flex flex-wrap items-center gap-2 p-2">
-      <button id="startDayBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg bg-green-600 text-white"><i class="fas fa-play"></i><span>Iniciar Dia</span></button>
-      <button id="closeDayBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg bg-green-600 text-white hidden"><i class="fas fa-check"></i><span>Concluir</span></button>
-      <label for="manualPdfInput" class="btn flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-600 text-white cursor-pointer"><i class="fas fa-file-upload"></i><span>Escolher Arquivo</span></label>
-      <input type="file" id="manualPdfInput" accept="application/pdf" class="hidden" />
-      <button id="uploadManualBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-600 text-white"><i class="fas fa-plus"></i><span>Adicionar Etiqueta</span></button>
-      <button id="gestorUsersBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg bg-indigo-600 text-white"><i class="fas fa-users"></i><span>Equipe</span></button>
-      <button id="sobrasBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg bg-yellow-600 text-white"><i class="fas fa-box-open"></i><span>Sobras</span></button>
-    </div>
-    <div id="statusFilters" class="flex flex-wrap gap-2 mb-4">
-      <button class="filter-btn px-4 py-2 rounded-full bg-indigo-600 text-white text-sm font-medium" data-status="all">Todas</button>
-      <button class="filter-btn px-4 py-2 rounded-full bg-gray-100 text-gray-700 text-sm font-medium hover:bg-gray-200 transition" data-status="nao_impresso">Não impresso</button>
-      <button class="filter-btn px-4 py-2 rounded-full bg-gray-100 text-gray-700 text-sm font-medium hover:bg-gray-200 transition" data-status="impresso">Impresso</button>
-      <button class="filter-btn px-4 py-2 rounded-full bg-gray-100 text-gray-700 text-sm font-medium hover:bg-gray-200 transition" data-status="concluido">Concluído</button>
+    <div class="card mb-4 space-y-4">
+      <div id="actionBar" class="flex flex-wrap items-center gap-2">
+        <button id="startDayBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg bg-green-600 text-white"><i class="fas fa-play"></i><span>Iniciar Dia</span></button>
+        <button id="closeDayBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg bg-green-600 text-white hidden"><i class="fas fa-check"></i><span>Concluir</span></button>
+        <label for="manualPdfInput" class="btn flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-700 cursor-pointer"><i class="fas fa-file-upload"></i><span>Escolher Arquivo</span></label>
+        <input type="file" id="manualPdfInput" accept="application/pdf" class="hidden" />
+        <button id="uploadManualBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-700"><i class="fas fa-plus"></i><span>Adicionar Etiqueta</span></button>
+        <button id="gestorUsersBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-700"><i class="fas fa-users"></i><span>Equipe</span></button>
+        <button id="sobrasBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-700"><i class="fas fa-box-open"></i><span>Sobras</span></button>
+      </div>
+      <div id="statusFilters" class="flex flex-wrap gap-2">
+        <button class="filter-btn px-4 py-2 rounded-full border border-indigo-600 bg-indigo-600 text-white text-sm font-medium" data-status="all">Todas</button>
+        <button class="filter-btn px-4 py-2 rounded-full border border-gray-300 bg-white text-gray-700 text-sm font-medium" data-status="nao_impresso">Não impresso (0)</button>
+        <button class="filter-btn px-4 py-2 rounded-full border border-gray-300 bg-white text-gray-700 text-sm font-medium" data-status="impresso">Impresso (0)</button>
+        <button class="filter-btn px-4 py-2 rounded-full border border-gray-300 bg-white text-gray-700 text-sm font-medium" data-status="concluido">Concluído (0)</button>
+      </div>
+      <div id="searchBar" class="flex flex-wrap gap-2">
+        <input id="searchInput" type="text" class="form-control w-64" placeholder="Buscar por nome, ID, e-mail, data" />
+        <select id="sortSelect" class="form-control">
+          <option value="createdAt">Ordenar por data</option>
+          <option value="owner">Ordenar por responsável</option>
+          <option value="status">Ordenar por status</option>
+        </select>
+        <button id="advancedToggle" class="px-4 py-2 border border-gray-300 rounded-lg bg-white text-gray-700">Filtros Avançados</button>
+      </div>
+      <div id="advancedFilters" class="flex flex-wrap gap-2 hidden">
+        <input type="date" id="startDate" class="form-control" />
+        <input type="date" id="endDate" class="form-control" />
+        <input type="text" id="responsavelFilter" class="form-control w-48" placeholder="Responsável" />
+        <label class="flex items-center gap-1 text-sm">
+          <input type="checkbox" id="attentionOnly" class="mr-1" />
+          <span>Somente Atenção</span>
+        </label>
+      </div>
     </div>
     <div id="viewToggle" class="flex gap-2 mb-4">
       <button class="view-btn px-4 py-2 rounded-full bg-indigo-600 text-white text-sm font-medium" data-view="cards" title="Exibição em cartões"><i class="fas fa-th"></i></button>
       <button class="view-btn px-4 py-2 rounded-full bg-gray-100 text-gray-700 text-sm font-medium hover:bg-gray-200 transition" data-view="list" title="Exibição em lista"><i class="fas fa-list"></i></button>
-    </div>
-    <div id="searchBar" class="flex flex-wrap gap-2 mb-4">
-      <input id="searchInput" type="text" class="form-control w-64" placeholder="Buscar por nome, ID, e-mail, data" />
-      <select id="sortSelect" class="form-control">
-        <option value="createdAt">Ordenar por data</option>
-        <option value="owner">Ordenar por responsável</option>
-        <option value="status">Ordenar por status</option>
-      </select>
-      <button id="advancedToggle" class="btn px-3 py-2 bg-gray-200 text-gray-700 rounded">Filtros avançados</button>
-    </div>
-    <div id="advancedFilters" class="flex flex-wrap gap-2 mb-4 hidden">
-      <input type="date" id="startDate" class="form-control" />
-      <input type="date" id="endDate" class="form-control" />
-      <input type="text" id="responsavelFilter" class="form-control w-48" placeholder="Responsável" />
-      <label class="flex items-center gap-1 text-sm">
-        <input type="checkbox" id="attentionOnly" class="mr-1" />
-        <span>Somente Atenção</span>
-      </label>
     </div>
     <div id="labelsList" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"></div>
   </div>
@@ -193,11 +195,11 @@
     document.querySelectorAll('.filter-btn').forEach(btn => {
       btn.addEventListener('click', () => {
         document.querySelectorAll('.filter-btn').forEach(b => {
-          b.classList.remove('bg-indigo-600','text-white');
-          b.classList.add('bg-gray-100','text-gray-700');
+          b.classList.remove('bg-indigo-600','text-white','border-indigo-600');
+          b.classList.add('bg-white','text-gray-700','border-gray-300');
         });
-        btn.classList.remove('bg-gray-100','text-gray-700');
-        btn.classList.add('bg-indigo-600','text-white');
+        btn.classList.remove('bg-white','text-gray-700','border-gray-300');
+        btn.classList.add('bg-indigo-600','text-white','border-indigo-600');
         currentFilter = btn.dataset.status;
         carregarEtiquetas();
       });
@@ -329,6 +331,15 @@
       }
     }
 
+    function updateStatusCounts(counts) {
+      const naoBtn = document.querySelector('[data-status="nao_impresso"]');
+      const impBtn = document.querySelector('[data-status="impresso"]');
+      const concBtn = document.querySelector('[data-status="concluido"]');
+      if (naoBtn) naoBtn.textContent = `Não impresso (${counts.nao_impresso || 0})`;
+      if (impBtn) impBtn.textContent = `Impresso (${counts.impresso || 0})`;
+      if (concBtn) concBtn.textContent = `Concluído (${counts.concluido || 0})`;
+    }
+
     async function carregarEtiquetas() {
       const list = document.getElementById('labelsList');
       list.innerHTML = '';
@@ -342,6 +353,7 @@
         .get();
       const seen = new Set();
       const results = [];
+      const counts = { nao_impresso: 0, impresso: 0, concluido: 0 };
       for (const doc of snap.docs) {
         const data = doc.data();
         const allowed =
@@ -352,11 +364,6 @@
         if (seen.has(key)) continue;
         seen.add(key);
         const status = data.status || 'nao_impresso';
-        if (filter === 'all') {
-          if (status === 'concluido') continue;
-        } else if (status !== filter) {
-          continue;
-        }
         const ownerName = data.ownerName || await getOwnerName(data.ownerUid, data.ownerEmail);
         const createdAt = data.createdAt && data.createdAt.toDate ? data.createdAt.toDate() : null;
         const name = (data.name || '').toLowerCase();
@@ -377,8 +384,15 @@
           ownerEmail.includes(responsavelFiltro);
         if (!respMatch) continue;
         if (attentionOnly && !data.attention) continue;
+        counts[status] = (counts[status] || 0) + 1;
+        if (filter === 'all') {
+          if (status === 'concluido') continue;
+        } else if (status !== filter) {
+          continue;
+        }
         results.push({ doc, data, ownerName, createdAt });
       }
+      updateStatusCounts(counts);
       results.sort((a,b) => {
         if (sortOption === 'owner') return (a.ownerName || '').localeCompare(b.ownerName || '');
         if (sortOption === 'status') return (a.data.status || '').localeCompare(b.data.status || '');


### PR DESCRIPTION
## Summary
- polish expedição page layout with card container, button styling and inline filters
- show dynamic counts for Não impresso, Impresso and Concluído statuses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bad730c524832a8072234064b6ccbc