### PR TITLE
Organize gestor sidebar layout

### DIFF
--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -11,33 +11,9 @@
   </div>
 
   <ul class="sidebar-menu py-4">
+    <!-- Layout para Gestores e Responsáveis Financeiros -->
     <li>
-      <a href="dashboard-geral.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-dashboard" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 3.001a.75.75 0 0 0-.75.75V11.25H3.75a.75.75 0 0 0-.75.75 9 9 0 1 0 9-9Z" />
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12.75 2.243A9.004 9.004 0 0 1 21.757 11.25H12.75V2.243Z" />
-        </svg>
-        <span class="link-text">Dashboard Geral</span>
-      </a>
-    </li>
-    <li>
-      <a href="gestor.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12H12.75M9 15H12.75M9 18H12.75M15.75 18.75H18A2.25 2.25 0 0 0 20.25 16.5V6.108A2.25 2.25 0 0 0 18.273 3.916c-.374-.031-.748-.058-1.123-.08M11.35 3.836A2.251 2.251 0 0 1 13.5 2.25h1.5a2.25 2.25 0 0 1 2.151 1.586M11.35 3.836c-.376.022-.75.049-1.124.08A2.25 2.25 0 0 0 8.25 6.108V8.25M8.25 8.25H4.875a1.125 1.125 0 0 0-1.125 1.125V20.625c0 .621.504 1.125 1.125 1.125H14.625a1.125 1.125 0 0 0 1.125-1.125V9.375A1.125 1.125 0 0 0 14.625 8.25H8.25ZM6.75 12h.007v.008H6.75V12Zm0 3h.007v.008H6.75V15Zm0 3h.007v.008H6.75V18Z"/>
-        </svg>
-        <span class="link-text">Gestão</span>
-      </a>
-    </li>
-    <li>
-      <a href="financeiro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-financeiro" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182A3.221 3.221 0 0 0 12 12c-.725 0-1.45-.219-2.003-.659-1.106-.879-1.106-2.303 0-3.182 1.106-.879 2.899-.879 4.005 0l.415.33M21 12c0 4.971-4.029 9-9 9s-9-4.029-9-9 4.029-9 9-9 9 4.029 9 9Z"/>
-        </svg>
-        <span class="link-text">Financeiro</span>
-      </a>
-    </li>
-    <li>
-      <a href="atualizacoes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-atualizacoes" data-perfil="gestor,mentor">
+      <a href="atualizacoes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-atualizacoes" data-perfil="gestor,mentor,responsavel,gestor financeiro">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M18.375 12.739 10.682 20.432a5.25 5.25 0 0 1-7.424-7.424L15.257 3.129a3 3 0 0 1 4.243 4.243L8.552 18.32m.009-.009a1.5 1.5 0 0 1-2.121 0 1.5 1.5 0 0 1 0-2.122L14.25 8.379"/>
         </svg>
@@ -45,81 +21,65 @@
       </a>
     </li>
     <li>
-      <a href="comunicacao.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-comunicacao" data-perfil="cliente,usuario,gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m21.75 0-9.423 6.615a2.25 2.25 0 0 1-2.654 0L1.5 6.75" />
-        </svg>
+      <a id="menu-financeiro" class="sidebar-link flex items-center py-2 px-4 font-semibold pointer-events-none" data-perfil="gestor,mentor,responsavel,gestor financeiro">
+        <span class="link-text">Financeiro</span>
+      </a>
+      <ul class="pl-8 space-y-1">
+        <li>
+          <a href="saques.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-saques" data-perfil="gestor,mentor,responsavel,gestor financeiro">
+            <span class="link-text">Saques</span>
+          </a>
+        </li>
+        <li>
+          <a href="acompanhamento-tiny.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-acompanhamento-tiny" data-perfil="gestor,mentor,gestor financeiro">
+            <span class="link-text">Acompanhamento Tiny</span>
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li>
+      <a id="menu-gestao" class="sidebar-link flex items-center py-2 px-4 font-semibold pointer-events-none" data-perfil="gestor,mentor,responsavel,gestor financeiro">
+        <span class="link-text">Gestão</span>
+      </a>
+      <ul class="pl-8 space-y-1">
+        <li>
+          <a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamentoGestor" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-acompanhamento-gestor" data-perfil="gestor,mentor">
+            <span class="link-text">Acompanhamento Gestor</span>
+          </a>
+        </li>
+        <li>
+          <a href="acompanhamento-vendas.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-acompanhamento-vendas" data-perfil="gestor,responsavel,gestor financeiro">
+            <span class="link-text">Acompanhamento Vendas</span>
+          </a>
+        </li>
+        <li>
+          <a href="mentoria.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-mentoria" data-perfil="gestor,mentor">
+            <span class="link-text">Visão Geral do Mentor</span>
+          </a>
+        </li>
+        <li>
+          <a href="perfil-mentorado.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-perfil-mentorado" data-perfil="gestor,mentor">
+            <span class="link-text">Perfil do Mentorado</span>
+          </a>
+        </li>
+        <li>
+          <a href="gestao-produtos.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-produtos" data-perfil="gestor,mentor">
+            <span class="link-text">Gestão de Produtos</span>
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li>
+      <a id="menu-comunicacao" class="sidebar-link flex items-center py-2 px-4 font-semibold pointer-events-none" data-perfil="gestor,mentor,responsavel,gestor financeiro">
         <span class="link-text">Comunicação</span>
       </a>
-    </li>
-    <li>
-      <a href="saques.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-saques" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75C7.717 18.75 13.014 19.481 18.047 20.851c.728.198 1.454-.343 1.454-1.096V18.75M3.75 4.5V5.25A.75.75 0 0 1 3 6H2.25M2.25 6V5.625A1.125 1.125 0 0 1 3.375 4.5H20.25M2.25 6v9M20.25 4.5V5.25A.75.75 0 0 0 21 6h.75M20.25 4.5h.375A1.125 1.125 0 0 1 21.75 5.625V15.375A1.125 1.125 0 0 1 20.625 16.5H20.25M21.75 15H21a.75.75 0 0 0-.75.75V16.5M20.25 16.5H3.75m0 0H3.375A1.125 1.125 0 0 1 2.25 15.375V15M3.75 16.5V15.75A.75.75 0 0 0 3 15H2.25M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z"/>
-        </svg>
-        <span class="link-text">Saques</span>
-      </a>
-    </li>
-    <li>
-  <a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamentoGestor" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-acompanhamento-gestor" data-perfil="gestor,mentor">
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-      <path stroke-linecap="round" stroke-linejoin="round" 
-            d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
-    </svg>
-    
-    <!-- Texto do link -->
-    <span class="link-text">Acompanhamento Gestor</span>
-  </a>
-</li>
-
-    <li>
-      <a href="acompanhamento-tiny.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-acompanhamento-tiny" data-perfil="gestor,mentor,gestor financeiro">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3 3h18v4H3V3zm0 6h18v12H3V9zm5 2v2h2v-2H8zm0 4v2h2v-2H8zm4-4v2h2v-2h-2zm0 4v2h2v-2h-2z"/>
-        </svg>
-        <span class="link-text">Acompanhamento Tiny</span>
-      </a>
-    </li>
-      <li>
-        <a href="acompanhamento-vendas.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-acompanhamento-vendas" data-perfil="gestor,responsavel,gestor financeiro">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v6.75A1.125 1.125 0 0 1 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 9.75 19.875V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 16.5 19.875V4.125Z" />
-          </svg>
-          <span class="link-text">Acompanhamento Vendas</span>
-        </a>
+      <ul class="pl-8 space-y-1">
+        <li>
+          <a href="equipes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-equipes" data-perfil="gestor,mentor">
+            <span class="link-text">Equipes</span>
+          </a>
         </li>
-
-    <li>
-      <a href="mentoria.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-mentoria" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5M3.75 3h16.5m0 0h1.5m-1.5 0v11.25a2.25 2.25 0 0 1-2.25 2.25H15.75M8.25 16.5h7.5m-7.5 0L7.25 19.5m8.5-3L16.75 19.5m0 0 .5 1.5m-.5-1.5H7.25m0 0-.5 1.5m1.75-9L10.5 9l2.148 2.148A9.013 9.013 0 0 1 16.5 7.605"/>
-        </svg>
-        <span class="link-text">Visão Geral do Mentor</span>
-      </a>
-    </li>
-    <li>
-      <a href="perfil-mentorado.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-perfil-mentorado" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15 9h3.75M15 12h3.75M15 15h3.75M4.5 19.5h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15A2.25 2.25 0 0 0 2.25 6.75v10.5A2.25 2.25 0 0 0 4.5 19.5Zm6-10.125a1.875 1.875 0 1 1-3.75 0 1.875 1.875 0 0 1 3.75 0Zm1.294 6.336A5.985 5.985 0 0 0 8.625 13.5a5.985 5.985 0 0 0-3.169 2.211"/>
-        </svg>
-        <span class="link-text">Perfil do Mentorado</span>
-      </a>
-    </li>
-    <li>
-      <a href="equipes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-equipes" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128c.833.242 1.714.372 2.625.372 1.479 0 2.878-.342 4.122-.952v-.173c0-2.278-1.847-4.125-4.125-4.125-1.418 0-2.669.716-3.411 1.806M15 19.128V19.125c0-3.52-2.854-6.375-6.375-6.375S2.25 15.605 2.25 19.125v.009A11.953 11.953 0 0 0 12 21c2.678 0 5.218-.585 7.499-1.632M12.75 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM20.25 8.625a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z"/>
-        </svg>
-        <span class="link-text">Equipes</span>
-      </a>
-    </li>
-    <li>
-      <a href="gestao-produtos.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-produtos" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M21 7.5 12 2.25 3 7.5m18 0L12 12.75M21 7.5v9L12 21.75M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"/>
-        </svg>
-        <span class="link-text">Gestão de Produtos</span>
-      </a>
+      </ul>
     </li>
     <li>
       <a href="desempenho.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-desempenho" data-perfil="gestor,mentor">

--- a/shared.js
+++ b/shared.js
@@ -473,23 +473,23 @@ document.addEventListener('sidebarLoaded', async () => {
   const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
   const db = getFirestore(app);
 
-  const ADMIN_GESTOR_MENU_IDS = [
-    'menu-gestao',
-    'menu-financeiro',
+  const GESTOR_RESP_MENU_IDS = [
     'menu-atualizacoes',
-    'menu-comunicacao',
+    'menu-financeiro',
     'menu-saques',
-    'menu-acompanhamento-gestor',
     'menu-acompanhamento-tiny',
+    'menu-gestao',
+    'menu-acompanhamento-gestor',
     'menu-acompanhamento-vendas',
     'menu-mentoria',
     'menu-perfil-mentorado',
-    'menu-equipes',
     'menu-produtos',
+    'menu-comunicacao',
+    'menu-equipes',
     'menu-desempenho',
   ];
 
-  const CLIENTE_HIDDEN_MENU_IDS = ADMIN_GESTOR_MENU_IDS.filter(id => id !== 'menu-comunicacao');
+  const CLIENTE_HIDDEN_MENU_IDS = GESTOR_RESP_MENU_IDS.filter(id => id !== 'menu-comunicacao');
 
   function showOnly(ids) {
     document.querySelectorAll('#sidebar .sidebar-link').forEach(a => {
@@ -517,11 +517,11 @@ document.addEventListener('sidebarLoaded', async () => {
       const perfil = (snap.exists() && String(snap.data().perfil || '') || '').trim().toLowerCase();
 
       const isADM = ['adm', 'admin', 'administrador'].includes(perfil);
-      const isGestor = ['gestor', 'mentor'].includes(perfil);
+      const isGestor = ['gestor', 'mentor', 'responsavel', 'responsável', 'responsavel financeiro', 'gestor financeiro'].includes(perfil);
       const isCliente = ['cliente', 'user', 'usuario'].includes(perfil);
 
-      if (isADM || isGestor) {
-        showOnly(ADMIN_GESTOR_MENU_IDS);
+      if (isGestor) {
+        showOnly(GESTOR_RESP_MENU_IDS);
       } else if (isCliente) {
         hideIds(CLIENTE_HIDDEN_MENU_IDS);
         document.querySelectorAll('#sidebar .sidebar-link').forEach(a => {


### PR DESCRIPTION
## Summary
- group gestor/finance menus under Financeiro, Gestão, Comunicação and Desempenho
- show grouped sidebar only to gestor and responsável financeiro profiles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baf37284b4832a9527d6cf190bd472