### PR TITLE
Add Financeiro entry to gestor sidebar

### DIFF
--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -24,19 +24,24 @@
       <a id="menu-financeiro" class="sidebar-link flex items-center py-2 px-4 font-semibold pointer-events-none" data-perfil="gestor,mentor,responsavel,gestor financeiro">
         <span class="link-text">Financeiro</span>
       </a>
-      <ul class="pl-8 space-y-1">
-        <li>
-          <a href="saques.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-saques" data-perfil="gestor,mentor,responsavel,gestor financeiro">
-            <span class="link-text">Saques</span>
-          </a>
-        </li>
-        <li>
-          <a href="acompanhamento-tiny.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-acompanhamento-tiny" data-perfil="gestor,mentor,gestor financeiro">
-            <span class="link-text">Acompanhamento Tiny</span>
-          </a>
-        </li>
-      </ul>
-    </li>
+        <ul class="pl-8 space-y-1">
+          <li>
+            <a href="financeiro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-financeiro-inicio" data-perfil="gestor,mentor,responsavel,gestor financeiro">
+              <span class="link-text">Financeiro</span>
+            </a>
+          </li>
+          <li>
+            <a href="saques.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-saques" data-perfil="gestor,mentor,responsavel,gestor financeiro">
+              <span class="link-text">Saques</span>
+            </a>
+          </li>
+          <li>
+            <a href="acompanhamento-tiny.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-acompanhamento-tiny" data-perfil="gestor,mentor,gestor financeiro">
+              <span class="link-text">Acompanhamento Tiny</span>
+            </a>
+          </li>
+        </ul>
+      </li>
     <li>
       <a id="menu-gestao" class="sidebar-link flex items-center py-2 px-4 font-semibold pointer-events-none" data-perfil="gestor,mentor,responsavel,gestor financeiro">
         <span class="link-text">Gestão</span>

--- a/shared.js
+++ b/shared.js
@@ -476,6 +476,7 @@ document.addEventListener('sidebarLoaded', async () => {
   const GESTOR_RESP_MENU_IDS = [
     'menu-atualizacoes',
     'menu-financeiro',
+    'menu-financeiro-inicio',
     'menu-saques',
     'menu-acompanhamento-tiny',
     'menu-gestao',


### PR DESCRIPTION
## Summary
- Add Financeiro page link to gestor/responsável sidebar
- Update sidebar permissions to include Financeiro entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb135665b8832a86a773726b0178f6