### PR TITLE
Fix visibility of Sold Products tab

### DIFF
--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -90,7 +90,7 @@
         </li>
 
       <li>
-        <a href="produtos-vendidos.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-produtos-vendidos" data-perfil="gestor,mentor">
+        <a href="produtos-vendidos.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-produtos-vendidos" data-perfil="gestor,mentor,responsavel,gestor financeiro,responsavel financeiro">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"/>
         </svg>

--- a/shared.js
+++ b/shared.js
@@ -486,6 +486,7 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-perfil-mentorado',
     'menu-equipes',
     'menu-produtos',
+    'menu-produtos-vendidos',
     'menu-desempenho',
   ];
 
@@ -527,6 +528,7 @@ document.addEventListener('sidebarLoaded', async () => {
     const gestao = getLi('menu-gestao');
     const acompGestor = getLi('menu-acompanhamento-gestor');
     const acompVendas = getLi('menu-acompanhamento-vendas');
+    const produtosVendidos = getLi('menu-produtos-vendidos');
     const mentoria = getLi('menu-mentoria');
     const perfilMentorado = getLi('menu-perfil-mentorado');
     const produtos = getLi('menu-produtos');
@@ -562,7 +564,7 @@ document.addEventListener('sidebarLoaded', async () => {
     }
 
     const financeiroGroup = createGroup(financeiro, 'menuFinanceiro', [saques, tiny]);
-    const gestaoGroup = createGroup(gestao, 'menuGestao', [acompGestor, acompVendas, mentoria, perfilMentorado, produtos]);
+    const gestaoGroup = createGroup(gestao, 'menuGestao', [acompGestor, acompVendas, produtosVendidos, mentoria, perfilMentorado, produtos]);
     const comunicacaoGroup = createGroup(comunicacao, 'menuComunicacao', [equipes]);
 
     menu.innerHTML = '';


### PR DESCRIPTION
## Summary
- show 'Produtos Vendidos' menu only for managers and finance roles
- include sold products item in gestor sidebar layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb2ba46188832a9d3487134e3c0730