### PR TITLE
Adiciona aba de SKU Associado

### DIFF
--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -131,6 +131,14 @@
       </a>
     </li>
     <li>
+      <a href="sku-associado.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-sku-associado" data-perfil="gestor,responsavel financeiro">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"/>
+        </svg>
+        <span class="link-text">SKU Associado</span>
+      </a>
+    </li>
+    <li>
       <a href="desempenho.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-desempenho" data-perfil="gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v6.75A1.125 1.125 0 0 1 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 9.75 19.875V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 16.5 19.875V4.125Z"/>

--- a/shared.js
+++ b/shared.js
@@ -486,6 +486,7 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-perfil-mentorado',
     'menu-equipes',
     'menu-produtos',
+    'menu-sku-associado',
     'menu-produtos-vendidos',
     'menu-desempenho',
   ];
@@ -532,6 +533,7 @@ document.addEventListener('sidebarLoaded', async () => {
     const mentoria = getLi('menu-mentoria');
     const perfilMentorado = getLi('menu-perfil-mentorado');
     const produtos = getLi('menu-produtos');
+    const skuAssociado = getLi('menu-sku-associado');
     const comunicacao = getLi('menu-comunicacao');
     const equipes = getLi('menu-equipes');
     const desempenho = getLi('menu-desempenho');
@@ -564,7 +566,7 @@ document.addEventListener('sidebarLoaded', async () => {
     }
 
     const financeiroGroup = createGroup(financeiro, 'menuFinanceiro', [saques, tiny]);
-    const gestaoGroup = createGroup(gestao, 'menuGestao', [acompGestor, acompVendas, produtosVendidos, mentoria, perfilMentorado, produtos]);
+    const gestaoGroup = createGroup(gestao, 'menuGestao', [acompGestor, acompVendas, produtosVendidos, mentoria, perfilMentorado, produtos, skuAssociado]);
     const comunicacaoGroup = createGroup(comunicacao, 'menuComunicacao', [equipes]);
 
     menu.innerHTML = '';
@@ -587,6 +589,9 @@ document.addEventListener('sidebarLoaded', async () => {
 
       if (isADM || isGestor) {
         showOnly(ADMIN_GESTOR_MENU_IDS);
+        if (isGestor && !["gestor","responsavel financeiro"].includes(perfil)) {
+          hideIds(["menu-sku-associado"]);
+        }
         buildGestorSidebarLayout();
       } else if (isCliente) {
         hideIds(CLIENTE_HIDDEN_MENU_IDS);

--- a/sku-associado.html
+++ b/sku-associado.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>SKU Associado</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css?v=20240826">
+  <link rel="stylesheet" href="css/components.css">
+</head>
+<body class="bg-gray-100 text-gray-800">
+  <div id="sidebar-container"></div>
+  <div id="navbar-container"></div>
+  <main class="main-content p-4 space-y-4">
+    <div class="card">
+      <div class="card-header"><h2 class="text-xl font-bold">Cadastrar SKU Associado</h2></div>
+      <div class="card-body space-y-4">
+        <div class="grid gap-4 md:grid-cols-2">
+          <div>
+            <label for="skuPrincipal" class="block text-sm font-medium mb-1">SKU Principal</label>
+            <input id="skuPrincipal" class="w-full p-2 border rounded" placeholder="SKU principal" />
+          </div>
+          <div>
+            <label for="skuAssociados" class="block text-sm font-medium mb-1">SKUs Associados</label>
+            <input id="skuAssociados" class="w-full p-2 border rounded" placeholder="Separados por vírgula" />
+          </div>
+        </div>
+        <button id="salvarSku" class="btn-primary">Salvar</button>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header"><h3 class="text-lg font-bold">SKUs Cadastrados</h3></div>
+      <div class="card-body overflow-x-auto">
+        <table class="min-w-full text-sm" id="skuTable">
+          <thead>
+            <tr class="text-left">
+              <th class="px-2 py-1">SKU Principal</th>
+              <th class="px-2 py-1">Associados</th>
+              <th class="px-2 py-1">Ações</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
+  </main>
+  <script type="module" src="firebase-config.js"></script>
+  <script type="module" src="sku-associado.js"></script>
+  <script>window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';</script>
+  <script src="shared.js"></script>
+</body>
+</html>

--- a/sku-associado.js
+++ b/sku-associado.js
@@ -1,0 +1,84 @@
+import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { getFirestore, collection, doc, setDoc, getDocs, deleteDoc } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { firebaseConfig } from './firebase-config.js';
+
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+const db = getFirestore(app);
+const auth = getAuth(app);
+
+let editId = null;
+
+function parseAssociados(value) {
+  return value.split(',').map(s => s.trim()).filter(Boolean);
+}
+
+async function carregarSkus() {
+  const tbody = document.querySelector('#skuTable tbody');
+  tbody.innerHTML = '';
+  const snap = await getDocs(collection(db, 'skuAssociado'));
+  snap.forEach(docSnap => {
+    const data = docSnap.data();
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td class="px-2 py-1">${data.skuPrincipal || docSnap.id}</td>
+      <td class="px-2 py-1">${(data.associados || []).join(', ')}</td>
+      <td class="px-2 py-1 space-x-2">
+        <button class="text-blue-600" data-edit="${docSnap.id}">Editar</button>
+        <button class="text-red-600" data-del="${docSnap.id}">Excluir</button>
+      </td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+async function salvarSku() {
+  const principalEl = document.getElementById('skuPrincipal');
+  const associadosEl = document.getElementById('skuAssociados');
+  const skuPrincipal = principalEl.value.trim();
+  if (!skuPrincipal) {
+    alert('Informe o SKU principal');
+    return;
+  }
+  const associados = parseAssociados(associadosEl.value);
+  const id = editId && editId !== skuPrincipal ? editId : skuPrincipal;
+  if (editId && editId !== skuPrincipal) {
+    await deleteDoc(doc(db, 'skuAssociado', editId));
+  }
+  await setDoc(doc(db, 'skuAssociado', skuPrincipal), { skuPrincipal, associados });
+  principalEl.value = '';
+  associadosEl.value = '';
+  editId = null;
+  await carregarSkus();
+}
+
+function preencherFormulario(id, data) {
+  document.getElementById('skuPrincipal').value = data.skuPrincipal || id;
+  document.getElementById('skuAssociados').value = (data.associados || []).join(', ');
+  editId = id;
+}
+
+function registrarEventos() {
+  document.getElementById('salvarSku').addEventListener('click', salvarSku);
+  document.querySelector('#skuTable tbody').addEventListener('click', async (e) => {
+    const idEdit = e.target.getAttribute('data-edit');
+    const idDel = e.target.getAttribute('data-del');
+    if (idEdit) {
+      const snap = await getDocs(collection(db, 'skuAssociado'));
+      const docSnap = snap.docs.find(d => d.id === idEdit);
+      if (docSnap) preencherFormulario(docSnap.id, docSnap.data());
+    } else if (idDel) {
+      if (confirm('Excluir este registro?')) {
+        await deleteDoc(doc(db, 'skuAssociado', idDel));
+        await carregarSkus();
+      }
+    }
+  });
+}
+
+onAuthStateChanged(auth, user => {
+  if (user) {
+    carregarSkus();
+    registrarEventos();
+  }
+});


### PR DESCRIPTION
## Summary
- adiciona página para cadastrar e gerenciar SKUs associados no Firestore
- inclui item "SKU Associado" no sidebar visível apenas para gestores e responsáveis financeiros
- ajusta lógica de permissões do sidebar para restringir o acesso à nova aba

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb32e93e7c832a8ad14ed50da469be