### PR TITLE
Center intro modals with flex display

### DIFF
--- a/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
+++ b/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
@@ -1886,7 +1886,7 @@ function applyPriceUpdate(type) {
     }
 
     function openModal(modalId) {
-      document.getElementById(modalId).style.display = 'block';
+      document.getElementById(modalId).style.display = 'flex';
     }
 
     function openRecoverModal() {
@@ -1936,7 +1936,7 @@ function applyPriceUpdate(type) {
           tbody.appendChild(tr);
         });
       }
-      document.getElementById('duplicadosModal').style.display = 'block';
+      document.getElementById('duplicadosModal').style.display = 'flex';
     }
 
     async function removerProdutosDuplicados() {

--- a/login.js
+++ b/login.js
@@ -144,7 +144,7 @@ window.openModal = (id) => {
       document.getElementById('loginForm')?.classList.add('hidden');
       selectedRole = null;
     }
-    el.style.display = 'block';
+    el.style.display = 'flex';
   }
 };
 

--- a/precificacao-tabs/lista-precos.js
+++ b/precificacao-tabs/lista-precos.js
@@ -162,7 +162,7 @@ function verDetalhes(id) {
   if (typeof openModal === 'function') {
     openModal('detalhesModal');
   } else {
-    document.getElementById('detalhesModal').style.display = 'block';
+    document.getElementById('detalhesModal').style.display = 'flex';
   }
 }
 
@@ -187,7 +187,7 @@ function editarProduto(id) {
   if (typeof openModal === 'function') {
     openModal('detalhesModal');
   } else {
-    document.getElementById('detalhesModal').style.display = 'block';
+    document.getElementById('detalhesModal').style.display = 'flex';
   }
 }
 

--- a/public/login.js
+++ b/public/login.js
@@ -112,7 +112,7 @@ window.saveDisplayName = async () => {
 window.openModal = (id) => {
   const el = document.getElementById(id);
   if (el) {
-    el.style.display = 'block';
+    el.style.display = 'flex';
   }
 };
 

--- a/public/tiny.js
+++ b/public/tiny.js
@@ -40,7 +40,7 @@ function showLoginModal() {
   const modal = document.getElementById('loginModal');
   if (modal) {
     console.log('Modal encontrado, exibindo...');
-    modal.style.display = 'block';
+    modal.style.display = 'flex';
     return;
   }
   
@@ -52,7 +52,7 @@ function showLoginModal() {
     const modalRetry = document.getElementById('loginModal');
     if (modalRetry) {
       console.log('Modal encontrado na segunda tentativa, exibindo...');
-      modalRetry.style.display = 'block';
+      modalRetry.style.display = 'flex';
     } else {
       console.log('Modal ainda não disponível, aguardando...');
       // Continua aguardando em vez de redirecionar

--- a/tiny.js
+++ b/tiny.js
@@ -15,7 +15,7 @@ if (typeof window !== 'undefined' && window.loadAuthModals) {
 function showLoginModal() {
   const modal = document.getElementById('loginModal');
   if (modal) {
-    modal.style.display = 'block';
+    modal.style.display = 'flex';
   } else {
     // Re-tenta após um pequeno atraso caso os modais ainda não tenham sido carregados
     setTimeout(showLoginModal, 500);


### PR DESCRIPTION
## Summary
- Ensure intro modals open centered by switching modal display from `block` to `flex`
- Apply consistent flex display for login and Tiny integration fallback modal logic
- Align detail modal fallback styling to flex for consistent centering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bebfe50c10832a92b38a78a5a95ddb