### PR TITLE
refactor: improve navbar readability

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1191,6 +1191,12 @@ body.dark-mode .navbar {
   color: var(--text);
   box-shadow: 0 2px 4px rgba(0,0,0,.2);
 }
+body.dark-mode .navbar .menu-item {
+  color: var(--text);
+}
+body.dark-mode .navbar .menu-item:hover {
+  color: #fff;
+}
 body.dark-mode .form-control {
   background: #4a5568;
   border-color: #4a5568;
@@ -1276,6 +1282,7 @@ body.dark-mode .data-table th {
 .navbar {
   height: var(--navbar-height);
   background: var(--card);
+  color: var(--text-dark);
   box-shadow: 0 2px 10px rgba(0,0,0,.05);
   position: fixed;
   top: 0;
@@ -1285,7 +1292,7 @@ body.dark-mode .data-table th {
   display: flex;
   align-items: center;
   padding: 0 25px;
- justify-content: space-between
+  justify-content: space-between;
 }
 .navbar .hamburger {
   display: none;
@@ -1294,6 +1301,13 @@ body.dark-mode .data-table th {
   display: flex;
   align-items: center;
   gap: 20px
+}
+.navbar .menu-item {
+  color: var(--text-light);
+  transition: color 0.2s ease;
+}
+.navbar .menu-item:hover {
+  color: var(--text-dark);
 }
 .user-dropdown {
   display: flex;
@@ -1712,6 +1726,7 @@ input:checked + .toggle-slider:before {
       height: var(--navbar-height);
       padding: 0 10px;
       background-color: rgba(0,0,0,0.8);
+      color: #fff;
     }
     .navbar .menu-item {
       display: none;

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,23 +1,23 @@
   <div class="navbar">
       <div class="flex items-center">
-        <button class="mobile-menu-btn hamburger mr-4 text-gray-200" aria-label="Abrir menu" aria-expanded="false">
+        <button class="mobile-menu-btn hamburger mr-4 menu-item" aria-label="Abrir menu" aria-expanded="false">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5" />
           </svg>
         </button>
-        <h2 class="text-lg font-semibold text-white">Dashboard</h2>
+        <h2 class="text-lg font-semibold">Dashboard</h2>
       </div>
 
       <div class="flex items-center space-x-5">
         <!-- Botão de cadastro -->
-        <a href="cadastro-interesse.html" class="menu-item text-gray-200 hover:text-white" title="Cadastre-se">
+        <a href="cadastro-interesse.html" class="menu-item" title="Cadastre-se">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3M12.75 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3.001 19.234c-.001-.037-.001-.074-.001-.111 0-3.52 2.854-6.375 6.375-6.375S15.75 15.604 15.75 19.125v.003a12.318 12.318 0 0 1-6.375 1.872A12.32 12.32 0 0 1 3.001 19.234Z"/>
           </svg>
         </a>
 
         <!-- Login button -->
-        <button id="loginBtn" class="menu-item text-gray-200 hover:text-white" title="Login">
+        <button id="loginBtn" class="menu-item" title="Login">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.118a8.999 8.999 0 0 1 15 0"/>
           </svg>
@@ -25,7 +25,7 @@
 
         <!-- Notificações -->
         <div id="notificationWrapper" class="relative tooltip menu-item" data-tooltip="Notificações">
-          <button id="notificationBtn" class="text-gray-200 hover:text-white">
+          <button id="notificationBtn">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082A23.86 23.86 0 0 0 20.312 15.772 8.966 8.966 0 0 1 18 9.75V9a6 6 0 1 0-12 0v.75a8.966 8.966 0 0 1-2.312 6.021A23.86 23.86 0 0 0 9.143 17.082M14.857 17.082A24.255 24.255 0 0 1 12 17.25c-1.035 0-2.06-.068-3.057-.199M14.857 17.082c.092.29.143.599.143.918a3 3 0 1 1-6 0c0-.319.051-.628.143-.918"/>
             </svg>
@@ -35,7 +35,7 @@
         </div>
 
         <!-- Modo Introdução -->
-        <button id="startTourBtn" class="menu-item text-gray-200 hover:text-white hidden tooltip" data-tooltip="Introdução">
+        <button id="startTourBtn" class="menu-item hidden tooltip" data-tooltip="Introdução">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519a3.75 3.75 0 1 1 4.243 6.212c-.203.178-.43.325-.67.441-.555.26-.903.816-.903 1.43V16.5m0 2.25h.008v.008H12v-.008Z"/>
           </svg>
@@ -48,8 +48,8 @@
               <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.118a8.999 8.999 0 0 1 15 0"/>
             </svg>
           </div>
-          <span id="currentUser" class="font-medium text-white cursor-pointer" title="Alterar nome">Usuário</span>
-          <button id="logoutBtn" class="ml-2 text-gray-200 hover:text-white hidden">
+          <span id="currentUser" class="font-medium cursor-pointer" title="Alterar nome">Usuário</span>
+          <button id="logoutBtn" class="ml-2 hidden">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6A2.25 2.25 0 0 0 5.25 5.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9"/>
             </svg>


### PR DESCRIPTION
## Summary
- remove hardcoded white text from navbar partial and use menu-item class
- style navbar menu items with theme colors and dark-mode support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bec38a1328832a810d1149b2cbe8e1