### PR TITLE
Improve dashboard card layout

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -2,9 +2,11 @@
 .card {
   border-radius: 1rem;
   border: 1px solid var(--border);
-  background-color: var(--secondary);
+  background-color: var(--background);
   padding: 1.25rem;
   box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+  display: flex;
+  flex-direction: column;
 }
 
 .btn-primary {

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
       </div>
       
       <!-- Painel Inicial -->
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <!-- Visão Geral -->
         <section class="section">
           <h2 class="section-title">Visão Geral</h2>
@@ -62,26 +62,28 @@
         <!-- Análise de Vendas -->
         <section class="section">
           <h2 class="section-title">Análise de Vendas</h2>
-          <div id="resumoFaturamento" class="space-y-4"></div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+            <div id="resumoFaturamento"></div>
 
-          <div class="card cursor-pointer" id="faturamentoMetaCard" onclick="location.href='/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=metas';">
-            <div class="card-header">
-              <div class="card-header-icon">
-                <i class="fas fa-bullseye text-xl"></i>
+            <div class="card cursor-pointer h-full" id="faturamentoMetaCard" onclick="location.href='/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=metas';">
+              <div class="card-header">
+                <div class="card-header-icon">
+                  <i class="fas fa-bullseye text-xl"></i>
+                </div>
+                <div>
+                  <h2 class="text-xl font-extrabold text-gray-800">Faturamento x Meta</h2>
+                </div>
+                <div class="ml-auto">
+                  <input type="month" id="filtroMesFaturamento" class="border rounded p-1 text-sm" />
+                </div>
               </div>
-              <div>
-                <h2 class="text-xl font-extrabold text-gray-800">Faturamento x Meta</h2>
+              <div class="card-body space-y-4">
+                <canvas id="chartFaturamentoMeta" height="200"></canvas>
+                <div class="progress-wrapper">
+                  <div id="metaProgressBar" class="progress-bar"></div>
+                </div>
+                <div id="metaProgressText" class="text-sm text-gray-600"></div>
               </div>
-              <div class="ml-auto">
-                <input type="month" id="filtroMesFaturamento" class="border rounded p-1 text-sm" />
-              </div>
-            </div>
-            <div class="card-body space-y-4">
-              <canvas id="chartFaturamentoMeta" height="200"></canvas>
-              <div class="progress-wrapper">
-                <div id="metaProgressBar" class="progress-bar"></div>
-              </div>
-              <div id="metaProgressText" class="text-sm text-gray-600"></div>
             </div>
           </div>
         </section>

--- a/index.js
+++ b/index.js
@@ -255,7 +255,7 @@ async function carregarResumoFaturamento(uid, isAdmin) {
       }).join('');
   }
     el.innerHTML = `
-        <div id="resumoFaturamentoCard" data-blur-id="resumoFaturamentoCard" class="cursor-pointer" onclick="location.href='/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=registroFaturamento';">
+        <div id="resumoFaturamentoCard" data-blur-id="resumoFaturamentoCard" class="card cursor-pointer h-full" onclick="location.href='/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=registroFaturamento';">
           <div class="flex items-center mb-4">
             <div class="card-header-icon"><span class="text-2xl">💰</span></div>
             <div>


### PR DESCRIPTION
## Summary
- Align dashboard sections side-by-side on medium screens and wrap sales analysis cards in a grid
- Style revenue summary as a proper card and ensure cards fill equal heights
- Use flex-based card styling with white background for a cleaner appearance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bec6142404832abed2a1f68f7426ec