### PR TITLE
Add refund problem tracking

### DIFF
--- a/problemas.html
+++ b/problemas.html
@@ -18,8 +18,56 @@
       <button class="tab-btn active px-4 py-2 rounded bg-orange-500 text-white" data-tab="tab-reembolsos">Reembolsos</button>
       <button class="tab-btn px-4 py-2 rounded bg-gray-200" data-tab="tab-pecas">Peças Faltando</button>
     </div>
-    <div id="tab-reembolsos" class="tab-panel">
-      <p class="text-sm text-gray-600">Em breve.</p>
+    <div id="tab-reembolsos" class="tab-panel space-y-4">
+      <form id="reembolsosForm" class="card p-4 grid grid-cols-1 md:grid-cols-7 gap-4">
+        <div class="flex flex-col">
+          <label for="dataR" class="text-sm font-medium">Data</label>
+          <input type="date" id="dataR" name="data" class="border rounded p-2" required>
+        </div>
+        <div class="flex flex-col">
+          <label for="numeroR" class="text-sm font-medium">Número</label>
+          <input type="text" id="numeroR" name="numero" class="border rounded p-2" required>
+        </div>
+        <div class="flex flex-col">
+          <label for="apelidoR" class="text-sm font-medium">Apelido</label>
+          <input type="text" id="apelidoR" name="apelido" class="border rounded p-2">
+        </div>
+        <div class="flex flex-col">
+          <label for="nfR" class="text-sm font-medium">NF</label>
+          <input type="text" id="nfR" name="nf" class="border rounded p-2">
+        </div>
+        <div class="flex flex-col">
+          <label for="lojaR" class="text-sm font-medium">Loja</label>
+          <input type="text" id="lojaR" name="loja" class="border rounded p-2">
+        </div>
+        <div class="flex flex-col">
+          <label for="problemaR" class="text-sm font-medium">Problema</label>
+          <input type="text" id="problemaR" name="problema" class="border rounded p-2" required>
+        </div>
+        <div class="flex flex-col">
+          <label for="valorR" class="text-sm font-medium">Valor</label>
+          <input type="number" step="0.01" id="valorR" name="valor" class="border rounded p-2" required>
+        </div>
+        <div class="md:col-span-7">
+          <button type="submit" class="btn btn-primary w-full md:w-auto">Salvar</button>
+        </div>
+      </form>
+      <div class="card p-4 overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead>
+            <tr class="text-left">
+              <th class="p-2">Data</th>
+              <th class="p-2">Número</th>
+              <th class="p-2">Apelido</th>
+              <th class="p-2">NF</th>
+              <th class="p-2">Loja</th>
+              <th class="p-2">Problema</th>
+              <th class="p-2 text-right">Valor</th>
+            </tr>
+          </thead>
+          <tbody id="reembolsosTableBody"></tbody>
+        </table>
+      </div>
     </div>
     <div id="tab-pecas" class="tab-panel hidden space-y-4">
       <form id="pecasForm" class="card p-4 grid grid-cols-1 md:grid-cols-7 gap-4">


### PR DESCRIPTION
## Summary
- add UI for recording refund issues including Data, Número, Apelido, NF, Loja, Problema and Valor
- store and list refund entries in Firestore

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bec9d957dc832ab5e6fd525a2b51ea