### PR TITLE
feat: add global month filter on dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,14 +42,17 @@
       </div>
       
       <!-- Hero Section -->
-      <div class="max-w-6xl w-full text-center mb-6">
-      <h1 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
-  <span class="text-orange-600 font-extrabold">Sistemas de Gestão</span> para sua Loja
-</h1>
-        <p class="text-gray-600 max-w-2xl mx-auto mb-8">
-          Ferramentas poderosas para otimizar seus negócios na Shopee. Controle de estoque, precificação inteligente e análise de desempenho em um só lugar.
-        </p>
-      </div>
+        <div class="max-w-6xl w-full flex flex-col items-center mb-6">
+        <div class="flex items-center space-x-4 mb-4">
+          <h1 class="text-3xl md:text-4xl font-bold text-gray-900">
+    <span class="text-orange-600 font-extrabold">Sistemas de Gestão</span> para sua Loja
+  </h1>
+          <input type="month" id="filtroMes" class="border rounded p-1 text-sm" />
+        </div>
+          <p class="text-gray-600 max-w-2xl mx-auto mb-8 text-center">
+            Ferramentas poderosas para otimizar seus negócios na Shopee. Controle de estoque, precificação inteligente e análise de desempenho em um só lugar.
+          </p>
+        </div>
       
       <!-- Painel Inicial -->
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -72,9 +75,6 @@
                 </div>
                 <div>
                   <h2 class="text-xl font-extrabold text-gray-800">Faturamento x Meta</h2>
-                </div>
-                <div class="ml-auto">
-                  <input type="month" id="filtroMesFaturamento" class="border rounded p-1 text-sm" />
                 </div>
               </div>
               <div class="card-body space-y-4">

--- a/index.js
+++ b/index.js
@@ -98,9 +98,10 @@ async function carregarResumoFaturamento(uid, isAdmin) {
   if (!el) return;
   el.innerHTML = 'Carregando...';
   if (kpiEl) kpiEl.innerHTML = 'Carregando...';
-  const hoje = new Date();
-  const mesAtual = hoje.toISOString().slice(0,7);
-  const mesAnterior = new Date(hoje.getFullYear(), hoje.getMonth() - 1).toISOString().slice(0,7);
+  const filtro = document.getElementById('filtroMes');
+  const mesAtual = filtro?.value || new Date().toISOString().slice(0,7);
+  const mesAtualDate = new Date(mesAtual + '-01');
+  const mesAnterior = new Date(mesAtualDate.getFullYear(), mesAtualDate.getMonth() - 1).toISOString().slice(0,7);
 
   let totalLiquido = 0;
   let totalBruto = 0;
@@ -293,8 +294,8 @@ async function carregarTopSkus(uid, isAdmin) {
   const el = document.getElementById('topSkus');
   if (!el) return;
   el.innerHTML = 'Carregando...';
-  const hoje = new Date();
-  const mesAtual = hoje.toISOString().slice(0,7);
+  const filtro = document.getElementById('filtroMes');
+  const mesAtual = filtro?.value || new Date().toISOString().slice(0,7);
   const mapa = {};
   const snap = isAdmin
     ? await getDocs(collectionGroup(db, 'skusVendidos'))
@@ -442,6 +443,11 @@ async function iniciarPainel(user) {
     }
   }
 
+  const filtroMes = document.getElementById('filtroMes');
+  if (filtroMes) {
+    filtroMes.value = new Date().toISOString().slice(0,7);
+  }
+
   await Promise.all([
     carregarResumoFaturamento(uid, isAdmin),
     carregarGraficoFaturamento(uid, isAdmin),
@@ -449,12 +455,13 @@ async function iniciarPainel(user) {
     carregarTarefas(uid, isAdmin)
   ]);
 
-  const filtroMes = document.getElementById('filtroMesFaturamento');
   if (filtroMes) {
-    filtroMes.value = new Date().toISOString().slice(0,7);
-    filtroMes.addEventListener('change', () =>
-      carregarGraficoFaturamento(uid, isAdmin)
-    );
+    filtroMes.addEventListener('change', () => {
+      carregarResumoFaturamento(uid, isAdmin);
+      carregarGraficoFaturamento(uid, isAdmin);
+      carregarTopSkus(uid, isAdmin);
+      carregarTarefas(uid, isAdmin);
+    });
   }
 
   applyBlurStates();
@@ -470,7 +477,7 @@ async function carregarGraficoFaturamento(uid, isAdmin) {
   const ctxLinha = canvasLinha.getContext('2d');
   const { primary, secondary } = getPalette();
 
-  const filtro = document.getElementById('filtroMesFaturamento');
+  const filtro = document.getElementById('filtroMes');
   const mesFiltro = filtro?.value || new Date().toISOString().slice(0, 7);
 
   const snap = isAdmin


### PR DESCRIPTION
## Summary
- add month selector beside hero title
- hook dashboard sections to respond to selected month

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68beca475324832ab1b2a103407a4c0a