### PR TITLE
Seleção de gestor de expedição por etiqueta

### DIFF
--- a/email-expedicao.html
+++ b/email-expedicao.html
@@ -17,7 +17,7 @@
   <div class="main-content p-4">
     <h1 class="text-2xl font-bold mb-4">E-mails do Responsável pela Expedição</h1>
     <form id="emailForm" class="space-y-4 max-w-lg">
-      <input type="text" id="emailExpedicao" placeholder="email@empresa.com, outro@empresa.com" class="w-full p-2 border rounded">
+      <input type="text" id="emailExpedicao" placeholder="email@empresa.com, outro@empresa.com (máximo 2)" class="w-full p-2 border rounded">
       <input type="email" id="emailFinanceiro" placeholder="financeiro@empresa.com" class="w-full p-2 border rounded">
       <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Salvar</button>
     </form>
@@ -102,6 +102,13 @@
       statusEl.classList.add('hidden');
       const emailsRaw = input.value.trim();
       const emails = emailsRaw.split(',').map(e => e.trim()).filter(e => e);
+      if (emails.length > 2) {
+        statusEl.textContent = 'Informe no máximo 2 e-mails de gestores de expedição.';
+        statusEl.classList.remove('hidden');
+        statusEl.classList.remove('text-green-600');
+        statusEl.classList.add('text-red-600');
+        return;
+      }
       const emailFinanceiro = financeInput.value.trim();
       try {
         await db.collection('uid').doc(currentUser.uid).set({

--- a/etiquetas-ocr.html
+++ b/etiquetas-ocr.html
@@ -135,6 +135,13 @@
     const storage = firebase.storage();
     let currentUser = null;
     let responsavelExpedicaoUid = null;
+
+    function escolherGestorEmail(emails) {
+      if (!emails || !emails.length) return [];
+      if (emails.length === 1) return [emails[0]];
+      const escolha = prompt('Enviar arquivo para qual gestor?', emails[0]) || emails[0];
+      return emails.includes(escolha) ? [escolha] : [emails[0]];
+    }
 firebase.auth().onAuthStateChanged(async u => {
       currentUser = u;
       if (!u) return;
@@ -390,10 +397,11 @@ completoCtx.drawImage(
  const fileName = `etiquetas_editadas_${Date.now()}.pdf`;
     const gestoresRaw = document.getElementById('gestoresEmails').value || '';
     const gestoresEmails = gestoresRaw.split(',').map(e => e.trim()).filter(e => e);
+    const selecionado = escolherGestorEmail(gestoresEmails);
     const docRef = await db.collection('pdfDocs').add({
       ownerUid: currentUser.uid,
       ownerEmail: currentUser.email,
-      gestoresExpedicaoEmails: gestoresEmails,
+      gestoresExpedicaoEmails: selecionado,
       createdAt: firebase.firestore.FieldValue.serverTimestamp(),
       name: fileName
     });
@@ -471,10 +479,11 @@ completoCtx.drawImage(
         const gestoresRaw = document.getElementById('gestoresEmails').value || '';
         const gestoresEmails = gestoresRaw.split(',').map(e => e.trim()).filter(e => e);
         const fileName = `mercado_livre_${Date.now()}.pdf`;
+        const selecionado = escolherGestorEmail(gestoresEmails);
         const docRef = await db.collection('pdfDocs').add({
           ownerUid: currentUser.uid,
           ownerEmail: currentUser.email,
-          gestoresExpedicaoEmails: gestoresEmails,
+          gestoresExpedicaoEmails: selecionado,
           createdAt: firebase.firestore.FieldValue.serverTimestamp(),
           name: fileName
         });

--- a/expedicao.html
+++ b/expedicao.html
@@ -115,6 +115,13 @@
     let responsavelFiltro = '';
     let attentionOnly = false;
 
+    function escolherGestorEmail(emails) {
+      if (!emails || !emails.length) return [];
+      if (emails.length === 1) return [emails[0]];
+      const escolha = prompt('Enviar arquivo para qual gestor?', emails[0]) || emails[0];
+      return emails.includes(escolha) ? [escolha] : [emails[0]];
+    }
+
     const startBtn = document.getElementById('startDayBtn');
     const closeBtn = document.getElementById('closeDayBtn');
     startBtn.addEventListener('click', iniciarDia);
@@ -603,11 +610,12 @@
         return;
       }
       try {
+        const selecionado = escolherGestorEmail(gestoresEmails);
         const docRef = await db.collection('pdfDocs').add({
           ownerUid: currentUser.uid,
           ownerEmail: currentUser.email,
           ownerName: currentUserName,
-          gestoresExpedicaoEmails: gestoresEmails,
+          gestoresExpedicaoEmails: selecionado,
           createdAt: firebase.firestore.FieldValue.serverTimestamp(),
           name: file.name,
           status: 'nao_impresso'

--- a/painel-usuarios.html
+++ b/painel-usuarios.html
@@ -25,7 +25,7 @@
           <input type="text" id="uid" placeholder="UID do Usuário" class="w-full p-2 border rounded">
           <input type="text" id="nome" placeholder="Nome do Usuário" class="w-full p-2 border rounded">
           <input type="email" id="email" placeholder="E-mail do Usuário" class="w-full p-2 border rounded">
-          <input type="text" id="emailExpedicao" placeholder="E-mails Responsável Expedição (separados por vírgula)" class="w-full p-2 border rounded">
+          <input type="text" id="emailExpedicao" placeholder="E-mails Responsável Expedição (até 2, separados por vírgula)" class="w-full p-2 border rounded">
       <select id="perfil" class="w-full p-2 border rounded">
         <option value="Cliente">Cliente</option>
         <option value="ADM">ADM</option>
@@ -83,6 +83,10 @@ if (!firebase.apps.length) {
       const email = document.getElementById("email").value.trim();
  const emailExpedicaoRaw = document.getElementById("emailExpedicao").value.trim();
       const gestoresEmails = emailExpedicaoRaw.split(',').map(e => e.trim()).filter(e => e);
+      if (gestoresEmails.length > 2) {
+        alert("Informe no máximo 2 e-mails de gestores de expedição.");
+        return;
+      }
       const perfil = document.getElementById("perfil").value;
 
       if (uid && nome && email) {

--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -87,6 +87,13 @@
         let currentUser = null;
  let responsavelExpedicaoUid = null;
          let responsavelExpedicaoEmail = null;
+
+        function escolherGestorEmail(emails) {
+            if (!emails || !emails.length) return [];
+            if (emails.length === 1) return [emails[0]];
+            const escolha = prompt('Enviar arquivo para qual gestor?', emails[0]) || emails[0];
+            return emails.includes(escolha) ? [escolha] : [emails[0]];
+        }
         firebase.auth().onAuthStateChanged(async u => {
             currentUser = u;
             if (!u) return;
@@ -111,10 +118,11 @@
             if (!currentUser) return;
             const gestoresRaw = document.getElementById('gestoresEmails').value || '';
             const gestoresEmails = gestoresRaw.split(',').map(e => e.trim()).filter(e => e);
+            const selecionado = escolherGestorEmail(gestoresEmails);
             const docRef = await db.collection('pdfDocs').add({
                 ownerUid: currentUser.uid,
                 ownerEmail: currentUser.email,
-                gestoresExpedicaoEmails: gestoresEmails,
+                gestoresExpedicaoEmails: selecionado,
                 createdAt: firebase.firestore.FieldValue.serverTimestamp(),
                 name: name
             });

--- a/zpl-import.html
+++ b/zpl-import.html
@@ -78,6 +78,13 @@
         let currentUser = null;
  let responsavelExpedicaoUid = null;
          let responsavelExpedicaoEmail = null;
+
+        function escolherGestorEmail(emails) {
+            if (!emails || !emails.length) return [];
+            if (emails.length === 1) return [emails[0]];
+            const escolha = prompt('Enviar arquivo para qual gestor?', emails[0]) || emails[0];
+            return emails.includes(escolha) ? [escolha] : [emails[0]];
+        }
         firebase.auth().onAuthStateChanged(async u => {
             currentUser = u;
             if (!u) return;
@@ -111,10 +118,11 @@
             if (!currentUser) return;
             const gestoresRaw = document.getElementById('gestoresEmails').value || '';
             const gestoresEmails = gestoresRaw.split(',').map(e => e.trim()).filter(e => e);
+            const selecionado = escolherGestorEmail(gestoresEmails);
             const docRef = await db.collection('pdfDocs').add({
                 ownerUid: currentUser.uid,
                 ownerEmail: currentUser.email,
-                gestoresExpedicaoEmails: gestoresEmails,
+                gestoresExpedicaoEmails: selecionado,
                 createdAt: firebase.firestore.FieldValue.serverTimestamp(),
                 name: name
             });


### PR DESCRIPTION
## Summary
- Permite cadastrar até dois e-mails de gestores de expedição
- Ao gerar etiquetas ou importar arquivos, o sistema pergunta qual gestor deve receber o arquivo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68befb7e7084832a94db230779d9a8cc