### PR TITLE
Solicitar gestor de expedição ao importar etiquetas

### DIFF
--- a/etiquetas-ocr.html
+++ b/etiquetas-ocr.html
@@ -121,9 +121,21 @@
       <div class="flex justify-center mt-8">
         <span class="text-xs text-gray-500">Desenvolvido por Matheus Ferraretto &nbsp;·&nbsp; <i class="fa-solid fa-robot"></i></span>
       </div>
+      </div>
+    </div>
+
+  <div id="gestorModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
+    <div class="bg-white w-full max-w-md p-4 rounded shadow-lg">
+      <h2 class="text-lg font-semibold mb-2">Enviar arquivo para qual gestor?</h2>
+      <select id="gestorSelect" class="form-control mb-4"></select>
+      <div class="flex justify-end gap-2">
+        <button id="gestorCancel" class="btn btn-secondary">Cancelar</button>
+        <button id="gestorConfirm" class="btn btn-primary">Confirmar</button>
+      </div>
     </div>
   </div>
-    <script type="module">
+
+      <script type="module">
     import { firebaseConfig } from './firebase-config.js';
 
     pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js';
@@ -137,10 +149,41 @@
     let responsavelExpedicaoUid = null;
 
     function escolherGestorEmail(emails) {
-      if (!emails || !emails.length) return [];
-      if (emails.length === 1) return [emails[0]];
-      const escolha = prompt('Enviar arquivo para qual gestor?', emails[0]) || emails[0];
-      return emails.includes(escolha) ? [escolha] : [emails[0]];
+      return new Promise(resolve => {
+        if (!emails || !emails.length) return resolve([]);
+        if (emails.length === 1) return resolve([emails[0]]);
+
+        const modal = document.getElementById('gestorModal');
+        const select = document.getElementById('gestorSelect');
+        const confirmBtn = document.getElementById('gestorConfirm');
+        const cancelBtn = document.getElementById('gestorCancel');
+
+        select.innerHTML = '';
+        emails.forEach(email => {
+          const opt = document.createElement('option');
+          opt.value = email;
+          opt.textContent = email;
+          select.appendChild(opt);
+        });
+
+        function close(value) {
+          modal.classList.add('hidden');
+          confirmBtn.removeEventListener('click', onConfirm);
+          cancelBtn.removeEventListener('click', onCancel);
+          modal.removeEventListener('click', onBackdrop);
+          resolve([value]);
+        }
+
+        function onConfirm() { close(select.value || emails[0]); }
+        function onCancel() { close(emails[0]); }
+        function onBackdrop(e) { if (e.target === modal) close(emails[0]); }
+
+        confirmBtn.addEventListener('click', onConfirm);
+        cancelBtn.addEventListener('click', onCancel);
+        modal.addEventListener('click', onBackdrop);
+
+        modal.classList.remove('hidden');
+      });
     }
 firebase.auth().onAuthStateChanged(async u => {
       currentUser = u;
@@ -397,7 +440,7 @@ completoCtx.drawImage(
  const fileName = `etiquetas_editadas_${Date.now()}.pdf`;
     const gestoresRaw = document.getElementById('gestoresEmails').value || '';
     const gestoresEmails = gestoresRaw.split(',').map(e => e.trim()).filter(e => e);
-    const selecionado = escolherGestorEmail(gestoresEmails);
+    const selecionado = await escolherGestorEmail(gestoresEmails);
     const docRef = await db.collection('pdfDocs').add({
       ownerUid: currentUser.uid,
       ownerEmail: currentUser.email,
@@ -479,7 +522,7 @@ completoCtx.drawImage(
         const gestoresRaw = document.getElementById('gestoresEmails').value || '';
         const gestoresEmails = gestoresRaw.split(',').map(e => e.trim()).filter(e => e);
         const fileName = `mercado_livre_${Date.now()}.pdf`;
-        const selecionado = escolherGestorEmail(gestoresEmails);
+        const selecionado = await escolherGestorEmail(gestoresEmails);
         const docRef = await db.collection('pdfDocs').add({
           ownerUid: currentUser.uid,
           ownerEmail: currentUser.email,

--- a/expedicao.html
+++ b/expedicao.html
@@ -89,6 +89,17 @@
     </div>
   </div>
 
+  <div id="gestorModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
+    <div class="bg-white w-full max-w-md p-4 rounded shadow-lg">
+      <h2 class="text-lg font-semibold mb-2">Enviar arquivo para qual gestor?</h2>
+      <select id="gestorSelect" class="form-control mb-4"></select>
+      <div class="flex justify-end gap-2">
+        <button id="gestorCancel" class="btn btn-secondary">Cancelar</button>
+        <button id="gestorConfirm" class="btn btn-primary">Confirmar</button>
+      </div>
+    </div>
+  </div>
+
  <script type="module">
     import { firebaseConfig, getPassphrase } from './firebase-config.js';
     import { decryptString } from './crypto.js';
@@ -116,10 +127,41 @@
     let attentionOnly = false;
 
     function escolherGestorEmail(emails) {
-      if (!emails || !emails.length) return [];
-      if (emails.length === 1) return [emails[0]];
-      const escolha = prompt('Enviar arquivo para qual gestor?', emails[0]) || emails[0];
-      return emails.includes(escolha) ? [escolha] : [emails[0]];
+      return new Promise(resolve => {
+        if (!emails || !emails.length) return resolve([]);
+        if (emails.length === 1) return resolve([emails[0]]);
+
+        const modal = document.getElementById('gestorModal');
+        const select = document.getElementById('gestorSelect');
+        const confirmBtn = document.getElementById('gestorConfirm');
+        const cancelBtn = document.getElementById('gestorCancel');
+
+        select.innerHTML = '';
+        emails.forEach(email => {
+          const opt = document.createElement('option');
+          opt.value = email;
+          opt.textContent = email;
+          select.appendChild(opt);
+        });
+
+        function close(value) {
+          modal.classList.add('hidden');
+          confirmBtn.removeEventListener('click', onConfirm);
+          cancelBtn.removeEventListener('click', onCancel);
+          modal.removeEventListener('click', onBackdrop);
+          resolve([value]);
+        }
+
+        function onConfirm() { close(select.value || emails[0]); }
+        function onCancel() { close(emails[0]); }
+        function onBackdrop(e) { if (e.target === modal) close(emails[0]); }
+
+        confirmBtn.addEventListener('click', onConfirm);
+        cancelBtn.addEventListener('click', onCancel);
+        modal.addEventListener('click', onBackdrop);
+
+        modal.classList.remove('hidden');
+      });
     }
 
     const startBtn = document.getElementById('startDayBtn');
@@ -610,7 +652,7 @@
         return;
       }
       try {
-        const selecionado = escolherGestorEmail(gestoresEmails);
+        const selecionado = await escolherGestorEmail(gestoresEmails);
         const docRef = await db.collection('pdfDocs').add({
           ownerUid: currentUser.uid,
           ownerEmail: currentUser.email,

--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -72,11 +72,22 @@
         <div id="preview-image-container" class="flex justify-center mb-4 p-4 border border-gray-300 rounded-lg"> 
             <img id="preview-image" src="" alt="Pré-visualização da etiqueta" class="max-w-full h-auto"> 
         </div> 
-        <div id="pdf-links" class="flex flex-col items-center gap-2"> 
-            <!-- O link para o PDF será inserido aqui --> 
-        </div> 
-    </div> 
+        <div id="pdf-links" class="flex flex-col items-center gap-2">
+            <!-- O link para o PDF será inserido aqui -->
+        </div>
+    </div>
 </div>
+</div>
+
+<div id="gestorModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
+  <div class="bg-white w-full max-w-md p-4 rounded shadow-lg">
+    <h2 class="text-lg font-semibold mb-2">Enviar arquivo para qual gestor?</h2>
+    <select id="gestorSelect" class="form-control mb-4"></select>
+    <div class="flex justify-end gap-2">
+      <button id="gestorCancel" class="btn btn-secondary">Cancelar</button>
+      <button id="gestorConfirm" class="btn btn-primary">Confirmar</button>
+    </div>
+  </div>
 </div>
 
 <script>
@@ -89,10 +100,41 @@
          let responsavelExpedicaoEmail = null;
 
         function escolherGestorEmail(emails) {
-            if (!emails || !emails.length) return [];
-            if (emails.length === 1) return [emails[0]];
-            const escolha = prompt('Enviar arquivo para qual gestor?', emails[0]) || emails[0];
-            return emails.includes(escolha) ? [escolha] : [emails[0]];
+            return new Promise(resolve => {
+                if (!emails || !emails.length) return resolve([]);
+                if (emails.length === 1) return resolve([emails[0]]);
+
+                const modal = document.getElementById('gestorModal');
+                const select = document.getElementById('gestorSelect');
+                const confirmBtn = document.getElementById('gestorConfirm');
+                const cancelBtn = document.getElementById('gestorCancel');
+
+                select.innerHTML = '';
+                emails.forEach(email => {
+                    const opt = document.createElement('option');
+                    opt.value = email;
+                    opt.textContent = email;
+                    select.appendChild(opt);
+                });
+
+                function close(value) {
+                    modal.classList.add('hidden');
+                    confirmBtn.removeEventListener('click', onConfirm);
+                    cancelBtn.removeEventListener('click', onCancel);
+                    modal.removeEventListener('click', onBackdrop);
+                    resolve([value]);
+                }
+
+                function onConfirm() { close(select.value || emails[0]); }
+                function onCancel() { close(emails[0]); }
+                function onBackdrop(e) { if (e.target === modal) close(emails[0]); }
+
+                confirmBtn.addEventListener('click', onConfirm);
+                cancelBtn.addEventListener('click', onCancel);
+                modal.addEventListener('click', onBackdrop);
+
+                modal.classList.remove('hidden');
+            });
         }
         firebase.auth().onAuthStateChanged(async u => {
             currentUser = u;
@@ -118,7 +160,7 @@
             if (!currentUser) return;
             const gestoresRaw = document.getElementById('gestoresEmails').value || '';
             const gestoresEmails = gestoresRaw.split(',').map(e => e.trim()).filter(e => e);
-            const selecionado = escolherGestorEmail(gestoresEmails);
+            const selecionado = await escolherGestorEmail(gestoresEmails);
             const docRef = await db.collection('pdfDocs').add({
                 ownerUid: currentUser.uid,
                 ownerEmail: currentUser.email,

--- a/zpl-import.html
+++ b/zpl-import.html
@@ -70,6 +70,17 @@
 </div>
 </div>
 
+<div id="gestorModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
+  <div class="bg-white w-full max-w-md p-4 rounded shadow-lg">
+    <h2 class="text-lg font-semibold mb-2">Enviar arquivo para qual gestor?</h2>
+    <select id="gestorSelect" class="form-control mb-4"></select>
+    <div class="flex justify-end gap-2">
+      <button id="gestorCancel" class="btn btn-secondary">Cancelar</button>
+      <button id="gestorConfirm" class="btn btn-primary">Confirmar</button>
+    </div>
+  </div>
+</div>
+
 <script>
     document.addEventListener('DOMContentLoaded', () => {
         if (!firebase.apps.length) { firebase.initializeApp(firebaseConfig); }
@@ -80,10 +91,41 @@
          let responsavelExpedicaoEmail = null;
 
         function escolherGestorEmail(emails) {
-            if (!emails || !emails.length) return [];
-            if (emails.length === 1) return [emails[0]];
-            const escolha = prompt('Enviar arquivo para qual gestor?', emails[0]) || emails[0];
-            return emails.includes(escolha) ? [escolha] : [emails[0]];
+            return new Promise(resolve => {
+                if (!emails || !emails.length) return resolve([]);
+                if (emails.length === 1) return resolve([emails[0]]);
+
+                const modal = document.getElementById('gestorModal');
+                const select = document.getElementById('gestorSelect');
+                const confirmBtn = document.getElementById('gestorConfirm');
+                const cancelBtn = document.getElementById('gestorCancel');
+
+                select.innerHTML = '';
+                emails.forEach(email => {
+                    const opt = document.createElement('option');
+                    opt.value = email;
+                    opt.textContent = email;
+                    select.appendChild(opt);
+                });
+
+                function close(value) {
+                    modal.classList.add('hidden');
+                    confirmBtn.removeEventListener('click', onConfirm);
+                    cancelBtn.removeEventListener('click', onCancel);
+                    modal.removeEventListener('click', onBackdrop);
+                    resolve([value]);
+                }
+
+                function onConfirm() { close(select.value || emails[0]); }
+                function onCancel() { close(emails[0]); }
+                function onBackdrop(e) { if (e.target === modal) close(emails[0]); }
+
+                confirmBtn.addEventListener('click', onConfirm);
+                cancelBtn.addEventListener('click', onCancel);
+                modal.addEventListener('click', onBackdrop);
+
+                modal.classList.remove('hidden');
+            });
         }
         firebase.auth().onAuthStateChanged(async u => {
             currentUser = u;
@@ -118,7 +160,7 @@
             if (!currentUser) return;
             const gestoresRaw = document.getElementById('gestoresEmails').value || '';
             const gestoresEmails = gestoresRaw.split(',').map(e => e.trim()).filter(e => e);
-            const selecionado = escolherGestorEmail(gestoresEmails);
+            const selecionado = await escolherGestorEmail(gestoresEmails);
             const docRef = await db.collection('pdfDocs').add({
                 ownerUid: currentUser.uid,
                 ownerEmail: currentUser.email,


### PR DESCRIPTION
## Summary
- exibir modal para escolher gestor ao importar etiquetas manualmente na expedição
- solicitar gestor ao salvar etiquetas no sistema OCR
- pedir seleção de gestor nos fluxos de importação ZPL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf006c56fc832a8111d7d03118b444