### PR TITLE
feat: controlar horário de envio de etiquetas

### DIFF
--- a/etiquetas-ocr.html
+++ b/etiquetas-ocr.html
@@ -147,6 +147,8 @@
     const storage = firebase.storage();
     let currentUser = null;
     let responsavelExpedicaoUid = null;
+    let horarioInicioEtiquetas = null;
+    let horarioFimEtiquetas = null;
 
     function escolherGestorEmail(emails) {
       return new Promise(resolve => {
@@ -197,6 +199,7 @@ firebase.auth().onAuthStateChanged(async u => {
         if (respEmail) {
           const snap = await db.collection('uid').where('email', '==', respEmail).limit(1).get();
           if (!snap.empty) responsavelExpedicaoUid = snap.docs[0].id;
+          await carregarHorarios();
         }
       } catch (err) {
         console.error('Erro ao carregar gestor de expedição:', err);
@@ -208,6 +211,30 @@ firebase.auth().onAuthStateChanged(async u => {
       const messageText = document.getElementById("messageText");
       messageText.textContent = text;
       messageBox.style.display = "block";
+    }
+
+    async function carregarHorarios() {
+      if (!responsavelExpedicaoUid) return;
+      try {
+        const doc = await db.collection('uid').doc(responsavelExpedicaoUid).get();
+        const data = doc.data() || {};
+        horarioInicioEtiquetas = data.horarioInicioEtiquetas || null;
+        horarioFimEtiquetas = data.horarioFimEtiquetas || null;
+      } catch (e) {
+        console.error('Erro ao carregar horários:', e);
+      }
+    }
+
+    function foraDoHorario() {
+      if (!horarioInicioEtiquetas || !horarioFimEtiquetas) return false;
+      const now = new Date();
+      const [ih, im] = horarioInicioEtiquetas.split(':').map(Number);
+      const [fh, fm] = horarioFimEtiquetas.split(':').map(Number);
+      const start = new Date(now);
+      start.setHours(ih, im, 0, 0);
+      const end = new Date(now);
+      end.setHours(fh, fm, 0, 0);
+      return now < start || now > end;
     }
 
     async function extractSkuQuantitiesFromCanvas(canvas) {
@@ -446,7 +473,8 @@ completoCtx.drawImage(
       ownerEmail: currentUser.email,
       gestoresExpedicaoEmails: selecionado,
       createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-      name: fileName
+      name: fileName,
+      foraHorario: foraDoHorario()
     });
     const fileRef = storage
       .ref()
@@ -528,7 +556,8 @@ completoCtx.drawImage(
           ownerEmail: currentUser.email,
           gestoresExpedicaoEmails: selecionado,
           createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-          name: fileName
+          name: fileName,
+          foraHorario: foraDoHorario()
         });
         const fileRef = storage.ref().child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
         await fileRef.put(pdfFile);

--- a/expedicao.html
+++ b/expedicao.html
@@ -36,6 +36,11 @@
         <button id="gestorUsersBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-700"><i class="fas fa-users"></i><span>Equipe</span></button>
         <button id="sobrasBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-700"><i class="fas fa-box-open"></i><span>Sobras</span></button>
       </div>
+      <div id="horarioForm" class="flex flex-wrap items-center gap-2 hidden">
+        <input type="time" id="horarioInicio" class="form-control" />
+        <input type="time" id="horarioFim" class="form-control" />
+        <button id="salvarHorarioBtn" class="btn btn-primary">Salvar horário</button>
+      </div>
       <div id="statusFilters" class="flex flex-wrap gap-2">
         <button class="filter-btn px-4 py-2 rounded-full border border-indigo-600 bg-indigo-600 text-white text-sm font-medium" data-status="all">Todas</button>
         <button class="filter-btn px-4 py-2 rounded-full border border-gray-300 bg-white text-gray-700 text-sm font-medium" data-status="nao_impresso">Não impresso (0)</button>
@@ -119,6 +124,8 @@
     let gestoresEmails = [];
     let currentUserName = '';
     let responsavelExpedicaoUid = null;
+    let horarioInicioEtiquetas = null;
+    let horarioFimEtiquetas = null;
     let searchTerm = '';
     let sortOption = 'createdAt';
     let startDateFilter = '';
@@ -176,6 +183,10 @@
     const sobrasResponsavelSelect = document.getElementById('sobrasResponsavel');
     const manualPdfInput = document.getElementById('manualPdfInput');
     const uploadManualBtn = document.getElementById('uploadManualBtn');
+    const horarioForm = document.getElementById('horarioForm');
+    const horarioInicioInput = document.getElementById('horarioInicio');
+    const horarioFimInput = document.getElementById('horarioFim');
+    const salvarHorarioBtn = document.getElementById('salvarHorarioBtn');
     if (uploadManualBtn) {
       uploadManualBtn.addEventListener('click', () => {
         if (manualPdfInput && manualPdfInput.files && manualPdfInput.files.length) {
@@ -192,6 +203,7 @@
         }
       });
     }
+    if (salvarHorarioBtn) salvarHorarioBtn.addEventListener('click', salvarHorario);
     const gestorUsersBtn = document.getElementById('gestorUsersBtn');
     if (gestorUsersBtn) {
       gestorUsersBtn.addEventListener('click', () => {
@@ -287,6 +299,7 @@
         currentUser = user;
         await carregarDadosUsuario();
         await verificarResponsavel();
+        await carregarHorarios();
         carregarEtiquetas();
         if (isResponsavel) {
           verificarDia();
@@ -359,6 +372,52 @@
         gestoresEmails = [];
         currentUserName = currentUser.email;
       }
+    }
+
+    async function carregarHorarios() {
+      if (!responsavelExpedicaoUid) return;
+      try {
+        const doc = await db.collection('uid').doc(responsavelExpedicaoUid).get();
+        const data = doc.data() || {};
+        horarioInicioEtiquetas = data.horarioInicioEtiquetas || null;
+        horarioFimEtiquetas = data.horarioFimEtiquetas || null;
+        if (isResponsavel && horarioForm) {
+          if (horarioInicioEtiquetas) horarioInicioInput.value = horarioInicioEtiquetas;
+          if (horarioFimEtiquetas) horarioFimInput.value = horarioFimEtiquetas;
+          horarioForm.classList.remove('hidden');
+        }
+      } catch (e) {
+        console.error('Erro ao carregar horários:', e);
+      }
+    }
+
+    async function salvarHorario(e) {
+      e.preventDefault();
+      if (!responsavelExpedicaoUid) return;
+      try {
+        await db.collection('uid').doc(responsavelExpedicaoUid).update({
+          horarioInicioEtiquetas: horarioInicioInput.value,
+          horarioFimEtiquetas: horarioFimInput.value
+        });
+        horarioInicioEtiquetas = horarioInicioInput.value;
+        horarioFimEtiquetas = horarioFimInput.value;
+        showToast('Horário salvo');
+      } catch (e) {
+        console.error('Erro ao salvar horário:', e);
+        alert('Erro ao salvar horário');
+      }
+    }
+
+    function foraDoHorario() {
+      if (!horarioInicioEtiquetas || !horarioFimEtiquetas) return false;
+      const now = new Date();
+      const [ih, im] = horarioInicioEtiquetas.split(':').map(Number);
+      const [fh, fm] = horarioFimEtiquetas.split(':').map(Number);
+      const start = new Date(now);
+      start.setHours(ih, im, 0, 0);
+      const end = new Date(now);
+      end.setHours(fh, fm, 0, 0);
+      return now < start || now > end;
     }
 
     async function carregarEquipeGestor() {
@@ -702,7 +761,8 @@
           gestoresExpedicaoEmails: selecionado,
           createdAt: firebase.firestore.FieldValue.serverTimestamp(),
           name: file.name,
-          status: 'nao_impresso'
+          status: 'nao_impresso',
+          foraHorario: foraDoHorario()
         });
         const fileRef = storage.ref().child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
         await fileRef.put(file);
@@ -802,6 +862,7 @@
       const data = doc.data();
       const status = data.status || 'nao_impresso';
       const attention = data.attention || false;
+      const foraHorario = data.foraHorario || false;
       const name = data.name || 'PDF';
       const url = data.url;
       const owner = ownerName || 'Desconhecido';
@@ -825,7 +886,10 @@
             <p class="font-semibold text-gray-800">${owner}</p>
             <p class="text-xs text-gray-500 break-words">${name}</p>
           </div>
-          <span class="status-badge text-xs text-white px-2 py-0.5 rounded-full ${statusInfo[status].color}">${statusInfo[status].text}</span>
+          <div class="flex flex-col items-end gap-1">
+            <span class="status-badge text-xs text-white px-2 py-0.5 rounded-full ${statusInfo[status].color}">${statusInfo[status].text}</span>
+            ${foraHorario ? '<span class="text-xs text-white px-2 py-0.5 rounded-full bg-red-600">Fora do horário</span>' : ''}
+          </div>
         </div>
         <div class="mt-auto flex items-center justify-between pt-2">
           <select class="border rounded px-2 py-1 text-xs" onchange="updateStatus('${doc.id}', this, this.closest('.pdf-card'))">
@@ -846,6 +910,7 @@
       const status = data.status || 'nao_impresso';
       const attention = data.attention || false;
       const observacao = data.observacao || '';
+      const foraHorario = data.foraHorario || false;
       const name = data.name || 'PDF';
       const url = data.url;
       const owner = ownerName || 'Desconhecido';
@@ -863,6 +928,7 @@
         <div class="flex-1">
           <p class="font-semibold text-gray-800">${name}</p>
           <p class="text-sm text-gray-500">Criado por: ${owner} em ${createdAt}</p>
+          ${foraHorario ? '<p class="text-xs text-red-600 font-semibold">Fora do horário</p>' : ''}
           <div class="mt-2 flex flex-wrap gap-2">
             <button class="text-indigo-600 hover:text-indigo-800" onclick="visualizar('${url}')" title="Visualizar"><i class="fas fa-eye"></i></button>
             <button class="text-indigo-600 hover:text-indigo-800" onclick="imprimir('${url}')" title="Imprimir"><i class="fas fa-print"></i></button>

--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -96,8 +96,10 @@
         const db = firebase.firestore();
         const storage = firebase.storage();
         let currentUser = null;
- let responsavelExpedicaoUid = null;
-         let responsavelExpedicaoEmail = null;
+        let responsavelExpedicaoUid = null;
+        let responsavelExpedicaoEmail = null;
+        let horarioInicioEtiquetas = null;
+        let horarioFimEtiquetas = null;
 
         function escolherGestorEmail(emails) {
             return new Promise(resolve => {
@@ -148,9 +150,10 @@
                     ? data.gestoresExpedicaoEmails[0]
                     : data.responsavelExpedicaoEmail;
                 if (respEmail) {
-              responsavelExpedicaoEmail = respEmail;
+                    responsavelExpedicaoEmail = respEmail;
                     const snap = await db.collection('uid').where('email', '==', respEmail).limit(1).get();
                     if (!snap.empty) responsavelExpedicaoUid = snap.docs[0].id;
+                    await carregarHorarios();
                 }
             } catch (e) {
                 console.error('Erro ao carregar gestor de expedição:', e);
@@ -166,7 +169,8 @@
                 ownerEmail: currentUser.email,
                 gestoresExpedicaoEmails: selecionado,
                 createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-                name: name
+                name: name,
+                foraHorario: foraDoHorario()
             });
             const fileRef = storage.ref().child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
             await fileRef.put(blob);
@@ -211,6 +215,30 @@
                 }
             });
             await batch.commit();
+        }
+
+        async function carregarHorarios() {
+            if (!responsavelExpedicaoUid) return;
+            try {
+                const doc = await db.collection('uid').doc(responsavelExpedicaoUid).get();
+                const data = doc.data() || {};
+                horarioInicioEtiquetas = data.horarioInicioEtiquetas || null;
+                horarioFimEtiquetas = data.horarioFimEtiquetas || null;
+            } catch (e) {
+                console.error('Erro ao carregar horários:', e);
+            }
+        }
+
+        function foraDoHorario() {
+            if (!horarioInicioEtiquetas || !horarioFimEtiquetas) return false;
+            const now = new Date();
+            const [ih, im] = horarioInicioEtiquetas.split(':').map(Number);
+            const [fh, fm] = horarioFimEtiquetas.split(':').map(Number);
+            const start = new Date(now);
+            start.setHours(ih, im, 0, 0);
+            const end = new Date(now);
+            end.setHours(fh, fm, 0, 0);
+            return now < start || now > end;
         }
 
         const fileInput = document.getElementById('zplFile');

--- a/zpl-import.html
+++ b/zpl-import.html
@@ -87,8 +87,10 @@
         const db = firebase.firestore();
         const storage = firebase.storage();
         let currentUser = null;
- let responsavelExpedicaoUid = null;
-         let responsavelExpedicaoEmail = null;
+        let responsavelExpedicaoUid = null;
+        let responsavelExpedicaoEmail = null;
+        let horarioInicioEtiquetas = null;
+        let horarioFimEtiquetas = null;
 
         function escolherGestorEmail(emails) {
             return new Promise(resolve => {
@@ -139,9 +141,10 @@
                     ? data.gestoresExpedicaoEmails[0]
                     : data.responsavelExpedicaoEmail;
                 if (respEmail) {
-              responsavelExpedicaoEmail = respEmail;
+                    responsavelExpedicaoEmail = respEmail;
                     const snap = await db.collection('uid').where('email', '==', respEmail).limit(1).get();
                     if (!snap.empty) responsavelExpedicaoUid = snap.docs[0].id;
+                    await carregarHorarios();
                 }
             } catch (e) {
                 console.error('Erro ao carregar gestor de expedição:', e);
@@ -166,7 +169,8 @@
                 ownerEmail: currentUser.email,
                 gestoresExpedicaoEmails: selecionado,
                 createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-                name: name
+                name: name,
+                foraHorario: foraDoHorario()
             });
             const fileRef = storage.ref().child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
             await fileRef.put(blob);
@@ -210,6 +214,30 @@
                 }
             });
             await batch.commit();
+        }
+
+        async function carregarHorarios() {
+            if (!responsavelExpedicaoUid) return;
+            try {
+                const doc = await db.collection('uid').doc(responsavelExpedicaoUid).get();
+                const data = doc.data() || {};
+                horarioInicioEtiquetas = data.horarioInicioEtiquetas || null;
+                horarioFimEtiquetas = data.horarioFimEtiquetas || null;
+            } catch (e) {
+                console.error('Erro ao carregar horários:', e);
+            }
+        }
+
+        function foraDoHorario() {
+            if (!horarioInicioEtiquetas || !horarioFimEtiquetas) return false;
+            const now = new Date();
+            const [ih, im] = horarioInicioEtiquetas.split(':').map(Number);
+            const [fh, fm] = horarioFimEtiquetas.split(':').map(Number);
+            const start = new Date(now);
+            start.setHours(ih, im, 0, 0);
+            const end = new Date(now);
+            end.setHours(fh, fm, 0, 0);
+            return now < start || now > end;
         }
 
         const fileInput = document.getElementById('zplFile');


### PR DESCRIPTION
## Summary
- permitir que o gestor defina horário de envio das etiquetas
- marcar etiquetas adicionadas fora do horário permitido

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf1cb2b1d4832a9d9aa103bf06cd9e