### PR TITLE
Add expedition configuration tab with schedule slots

### DIFF
--- a/configuracao-expedicao.html
+++ b/configuracao-expedicao.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Configuração Expedição</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css?v=20240826">
+  <link rel="stylesheet" href="css/components.css">
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
+</head>
+<body class="bg-gray-50">
+  <div id="sidebar-container"></div>
+  <div id="navbar-container"></div>
+  <div class="main-content p-4">
+    <h1 class="text-2xl font-bold mb-4">Configuração Expedição</h1>
+    <form id="horariosForm" class="space-y-4 max-w-md">
+      <div class="flex items-center gap-2">
+        <input type="time" id="inicio1" class="form-control">
+        <input type="time" id="fim1" class="form-control">
+      </div>
+      <div class="flex items-center gap-2">
+        <input type="time" id="inicio2" class="form-control">
+        <input type="time" id="fim2" class="form-control">
+      </div>
+      <div class="flex items-center gap-2">
+        <input type="time" id="inicio3" class="form-control">
+        <input type="time" id="fim3" class="form-control">
+      </div>
+      <div class="flex items-center gap-2">
+        <input type="time" id="inicio4" class="form-control">
+        <input type="time" id="fim4" class="form-control">
+      </div>
+      <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Salvar</button>
+    </form>
+    <p id="status" class="mt-4 text-green-600 hidden"></p>
+  </div>
+  <script type="module">
+    import { firebaseConfig } from './firebase-config.js';
+    if (!firebase.apps.length) {
+      firebase.initializeApp(firebaseConfig);
+    }
+    const db = firebase.firestore();
+    let currentUser = null;
+    const form = document.getElementById('horariosForm');
+    const statusEl = document.getElementById('status');
+    const inputs = [1,2,3,4].map(i => ({
+      inicio: document.getElementById(`inicio${i}`),
+      fim: document.getElementById(`fim${i}`)
+    }));
+    firebase.auth().onAuthStateChanged(async user => {
+      if (!user) {
+        window.location.href = 'index.html?login=1';
+        return;
+      }
+      currentUser = user;
+      try {
+        const doc = await db.collection('uid').doc(user.uid).get();
+        const data = doc.data() || {};
+        const horarios = data.horariosEtiquetas || [];
+        horarios.forEach((h, idx) => {
+          if (inputs[idx]) {
+            inputs[idx].inicio.value = h.inicio || '';
+            inputs[idx].fim.value = h.fim || '';
+          }
+        });
+      } catch (e) {
+        console.error('Erro ao carregar horários:', e);
+      }
+    });
+    form.addEventListener('submit', async e => {
+      e.preventDefault();
+      if (!currentUser) return;
+      const horarios = inputs.map(({inicio, fim}) => ({inicio: inicio.value, fim: fim.value}))
+        .filter(h => h.inicio && h.fim);
+      try {
+        await db.collection('uid').doc(currentUser.uid).set({ horariosEtiquetas: horarios }, { merge: true });
+        statusEl.textContent = 'Horários salvos com sucesso!';
+        statusEl.classList.remove('hidden');
+        statusEl.classList.remove('text-red-600');
+        statusEl.classList.add('text-green-600');
+      } catch (err) {
+        console.error('Erro ao salvar horários:', err);
+        statusEl.textContent = 'Erro ao salvar horários.';
+        statusEl.classList.remove('hidden');
+        statusEl.classList.remove('text-green-600');
+        statusEl.classList.add('text-red-600');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/etiquetas-ocr.html
+++ b/etiquetas-ocr.html
@@ -147,8 +147,7 @@
     const storage = firebase.storage();
     let currentUser = null;
     let responsavelExpedicaoUid = null;
-    let horarioInicioEtiquetas = null;
-    let horarioFimEtiquetas = null;
+    let horariosEtiquetas = [];
 
     function escolherGestorEmail(emails) {
       return new Promise(resolve => {
@@ -218,23 +217,25 @@ firebase.auth().onAuthStateChanged(async u => {
       try {
         const doc = await db.collection('uid').doc(responsavelExpedicaoUid).get();
         const data = doc.data() || {};
-        horarioInicioEtiquetas = data.horarioInicioEtiquetas || null;
-        horarioFimEtiquetas = data.horarioFimEtiquetas || null;
+        horariosEtiquetas = data.horariosEtiquetas || [];
       } catch (e) {
         console.error('Erro ao carregar horários:', e);
       }
     }
 
     function foraDoHorario() {
-      if (!horarioInicioEtiquetas || !horarioFimEtiquetas) return false;
+      if (!horariosEtiquetas.length) return false;
       const now = new Date();
-      const [ih, im] = horarioInicioEtiquetas.split(':').map(Number);
-      const [fh, fm] = horarioFimEtiquetas.split(':').map(Number);
-      const start = new Date(now);
-      start.setHours(ih, im, 0, 0);
-      const end = new Date(now);
-      end.setHours(fh, fm, 0, 0);
-      return now < start || now > end;
+      return !horariosEtiquetas.some(h => {
+        if (!h.inicio || !h.fim) return false;
+        const [ih, im] = h.inicio.split(':').map(Number);
+        const [fh, fm] = h.fim.split(':').map(Number);
+        const start = new Date(now);
+        start.setHours(ih, im, 0, 0);
+        const end = new Date(now);
+        end.setHours(fh, fm, 0, 0);
+        return now >= start && now <= end;
+      });
     }
 
     async function extractSkuQuantitiesFromCanvas(canvas) {

--- a/expedicao.html
+++ b/expedicao.html
@@ -36,11 +36,6 @@
         <button id="gestorUsersBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-700"><i class="fas fa-users"></i><span>Equipe</span></button>
         <button id="sobrasBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-700"><i class="fas fa-box-open"></i><span>Sobras</span></button>
       </div>
-      <div id="horarioForm" class="flex flex-wrap items-center gap-2 hidden">
-        <input type="time" id="horarioInicio" class="form-control" />
-        <input type="time" id="horarioFim" class="form-control" />
-        <button id="salvarHorarioBtn" class="btn btn-primary">Salvar horário</button>
-      </div>
       <div id="statusFilters" class="flex flex-wrap gap-2">
         <button class="filter-btn px-4 py-2 rounded-full border border-indigo-600 bg-indigo-600 text-white text-sm font-medium" data-status="all">Todas</button>
         <button class="filter-btn px-4 py-2 rounded-full border border-gray-300 bg-white text-gray-700 text-sm font-medium" data-status="nao_impresso">Não impresso (0)</button>
@@ -124,8 +119,7 @@
     let gestoresEmails = [];
     let currentUserName = '';
     let responsavelExpedicaoUid = null;
-    let horarioInicioEtiquetas = null;
-    let horarioFimEtiquetas = null;
+    let horariosEtiquetas = [];
     let searchTerm = '';
     let sortOption = 'createdAt';
     let startDateFilter = '';
@@ -183,10 +177,7 @@
     const sobrasResponsavelSelect = document.getElementById('sobrasResponsavel');
     const manualPdfInput = document.getElementById('manualPdfInput');
     const uploadManualBtn = document.getElementById('uploadManualBtn');
-    const horarioForm = document.getElementById('horarioForm');
-    const horarioInicioInput = document.getElementById('horarioInicio');
-    const horarioFimInput = document.getElementById('horarioFim');
-    const salvarHorarioBtn = document.getElementById('salvarHorarioBtn');
+    
     if (uploadManualBtn) {
       uploadManualBtn.addEventListener('click', () => {
         if (manualPdfInput && manualPdfInput.files && manualPdfInput.files.length) {
@@ -203,7 +194,6 @@
         }
       });
     }
-    if (salvarHorarioBtn) salvarHorarioBtn.addEventListener('click', salvarHorario);
     const gestorUsersBtn = document.getElementById('gestorUsersBtn');
     if (gestorUsersBtn) {
       gestorUsersBtn.addEventListener('click', () => {
@@ -379,45 +369,25 @@
       try {
         const doc = await db.collection('uid').doc(responsavelExpedicaoUid).get();
         const data = doc.data() || {};
-        horarioInicioEtiquetas = data.horarioInicioEtiquetas || null;
-        horarioFimEtiquetas = data.horarioFimEtiquetas || null;
-        if (isResponsavel && horarioForm) {
-          if (horarioInicioEtiquetas) horarioInicioInput.value = horarioInicioEtiquetas;
-          if (horarioFimEtiquetas) horarioFimInput.value = horarioFimEtiquetas;
-          horarioForm.classList.remove('hidden');
-        }
+        horariosEtiquetas = data.horariosEtiquetas || [];
       } catch (e) {
         console.error('Erro ao carregar horários:', e);
       }
     }
 
-    async function salvarHorario(e) {
-      e.preventDefault();
-      if (!responsavelExpedicaoUid) return;
-      try {
-        await db.collection('uid').doc(responsavelExpedicaoUid).update({
-          horarioInicioEtiquetas: horarioInicioInput.value,
-          horarioFimEtiquetas: horarioFimInput.value
-        });
-        horarioInicioEtiquetas = horarioInicioInput.value;
-        horarioFimEtiquetas = horarioFimInput.value;
-        showToast('Horário salvo');
-      } catch (e) {
-        console.error('Erro ao salvar horário:', e);
-        alert('Erro ao salvar horário');
-      }
-    }
-
     function foraDoHorario() {
-      if (!horarioInicioEtiquetas || !horarioFimEtiquetas) return false;
+      if (!horariosEtiquetas.length) return false;
       const now = new Date();
-      const [ih, im] = horarioInicioEtiquetas.split(':').map(Number);
-      const [fh, fm] = horarioFimEtiquetas.split(':').map(Number);
-      const start = new Date(now);
-      start.setHours(ih, im, 0, 0);
-      const end = new Date(now);
-      end.setHours(fh, fm, 0, 0);
-      return now < start || now > end;
+      return !horariosEtiquetas.some(h => {
+        if (!h.inicio || !h.fim) return false;
+        const [ih, im] = h.inicio.split(':').map(Number);
+        const [fh, fm] = h.fim.split(':').map(Number);
+        const start = new Date(now);
+        start.setHours(ih, im, 0, 0);
+        const end = new Date(now);
+        end.setHours(fh, fm, 0, 0);
+        return now >= start && now <= end;
+      });
     }
 
     async function carregarEquipeGestor() {

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -269,6 +269,7 @@
         <li><a href="expedicao-historico.html" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a></li>
         <li><a href="atualizacoes-dia.html" class="sidebar-link block py-2 px-4 transition-colors">Atualizações do Dia</a></li>
         <li><a href="zpl-import.html" class="sidebar-link block py-2 px-4 transition-colors">ZPL Import</a></li>
+        <li><a href="configuracao-expedicao.html" class="sidebar-link block py-2 px-4 transition-colors">Configuração Expedição</a></li>
       </ul>
     </li>
     <li>

--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -98,8 +98,7 @@
         let currentUser = null;
         let responsavelExpedicaoUid = null;
         let responsavelExpedicaoEmail = null;
-        let horarioInicioEtiquetas = null;
-        let horarioFimEtiquetas = null;
+        let horariosEtiquetas = [];
 
         function escolherGestorEmail(emails) {
             return new Promise(resolve => {
@@ -222,23 +221,25 @@
             try {
                 const doc = await db.collection('uid').doc(responsavelExpedicaoUid).get();
                 const data = doc.data() || {};
-                horarioInicioEtiquetas = data.horarioInicioEtiquetas || null;
-                horarioFimEtiquetas = data.horarioFimEtiquetas || null;
+                horariosEtiquetas = data.horariosEtiquetas || [];
             } catch (e) {
                 console.error('Erro ao carregar horários:', e);
             }
         }
 
         function foraDoHorario() {
-            if (!horarioInicioEtiquetas || !horarioFimEtiquetas) return false;
+            if (!horariosEtiquetas.length) return false;
             const now = new Date();
-            const [ih, im] = horarioInicioEtiquetas.split(':').map(Number);
-            const [fh, fm] = horarioFimEtiquetas.split(':').map(Number);
-            const start = new Date(now);
-            start.setHours(ih, im, 0, 0);
-            const end = new Date(now);
-            end.setHours(fh, fm, 0, 0);
-            return now < start || now > end;
+            return !horariosEtiquetas.some(h => {
+                if (!h.inicio || !h.fim) return false;
+                const [ih, im] = h.inicio.split(':').map(Number);
+                const [fh, fm] = h.fim.split(':').map(Number);
+                const start = new Date(now);
+                start.setHours(ih, im, 0, 0);
+                const end = new Date(now);
+                end.setHours(fh, fm, 0, 0);
+                return now >= start && now <= end;
+            });
         }
 
         const fileInput = document.getElementById('zplFile');

--- a/zpl-import.html
+++ b/zpl-import.html
@@ -89,8 +89,7 @@
         let currentUser = null;
         let responsavelExpedicaoUid = null;
         let responsavelExpedicaoEmail = null;
-        let horarioInicioEtiquetas = null;
-        let horarioFimEtiquetas = null;
+        let horariosEtiquetas = [];
 
         function escolherGestorEmail(emails) {
             return new Promise(resolve => {
@@ -221,23 +220,25 @@
             try {
                 const doc = await db.collection('uid').doc(responsavelExpedicaoUid).get();
                 const data = doc.data() || {};
-                horarioInicioEtiquetas = data.horarioInicioEtiquetas || null;
-                horarioFimEtiquetas = data.horarioFimEtiquetas || null;
+                horariosEtiquetas = data.horariosEtiquetas || [];
             } catch (e) {
                 console.error('Erro ao carregar horários:', e);
             }
         }
 
         function foraDoHorario() {
-            if (!horarioInicioEtiquetas || !horarioFimEtiquetas) return false;
+            if (!horariosEtiquetas.length) return false;
             const now = new Date();
-            const [ih, im] = horarioInicioEtiquetas.split(':').map(Number);
-            const [fh, fm] = horarioFimEtiquetas.split(':').map(Number);
-            const start = new Date(now);
-            start.setHours(ih, im, 0, 0);
-            const end = new Date(now);
-            end.setHours(fh, fm, 0, 0);
-            return now < start || now > end;
+            return !horariosEtiquetas.some(h => {
+                if (!h.inicio || !h.fim) return false;
+                const [ih, im] = h.inicio.split(':').map(Number);
+                const [fh, fm] = h.fim.split(':').map(Number);
+                const start = new Date(now);
+                start.setHours(ih, im, 0, 0);
+                const end = new Date(now);
+                end.setHours(fh, fm, 0, 0);
+                return now >= start && now <= end;
+            });
         }
 
         const fileInput = document.getElementById('zplFile');


### PR DESCRIPTION
## Summary
- add Configuração Expedição page with four time range inputs
- expose new configuration link in expedition sidebar
- update expedition flows to respect multiple allowed time slots

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf20d79aec832aab8760f138645ad7