### PR TITLE
fix: initialize firebase config before use

### DIFF
--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -120,7 +120,7 @@
   <script type="module" src="firebase-config.js"></script>
 
 
-  <script>
+  <script type="module">
   // ===== Utilitários UI =====
   const $ = (sel) => document.querySelector(sel);
   const sleep = (ms) => new Promise(r=>setTimeout(r, ms));
@@ -137,7 +137,7 @@
     gestorModal:'#gestorModal', gestorSelect:'#gestorSelect', gestorConfirm:'#gestorConfirm', gestorCancel:'#gestorCancel'
   };
 
-  if (!firebase.apps.length) { firebase.initializeApp(firebaseConfig); }
+  if (!firebase.apps.length) { firebase.initializeApp(window.firebaseConfig); }
   const auth = firebase.auth();
   const db = firebase.firestore();
   const storage = firebase.storage();


### PR DESCRIPTION
## Summary
- ensure zpl-import-ocr page initializes Firebase using global config after module load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf7b31070c832a8aefe5cb12bf677a