### PR TITLE
fix: support object schedules in zpl-import-ocr

### DIFF
--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -203,7 +203,13 @@
     if(!horariosEtiquetas?.length) return true; // se não configurado, permite
     const now = new Date();
     return horariosEtiquetas.some(intv => {
-      const [ini, fim] = (intv||'').split('-');
+      let ini, fim;
+      if(typeof intv === 'string'){
+        [ini, fim] = intv.split('-');
+      } else if(intv && typeof intv === 'object'){
+        ini = intv.inicio;
+        fim = intv.fim;
+      }
       if(!ini||!fim) return false;
       const [h1,m1] = ini.split(':').map(Number);
       const [h2,m2] = fim.split(':').map(Number);


### PR DESCRIPTION
## Summary
- handle schedule entries as strings or objects to avoid split errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf7e3e7818832ab6d144f4eeceb587