### PR TITLE
Handle object intervals in zpl-import-ocr schedule

### DIFF
--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -203,13 +203,19 @@
     if(!horariosEtiquetas?.length) return true; // se não configurado, permite
     const now = new Date();
     return horariosEtiquetas.some(intv => {
-      const [ini, fim] = (intv||'').split('-');
-      if(!ini||!fim) return false;
-      const [h1,m1] = ini.split(':').map(Number);
-      const [h2,m2] = fim.split(':').map(Number);
-      const a = new Date(); a.setHours(h1||0,m1||0,0,0);
-      const b = new Date(); b.setHours(h2||23,m2||59,59,999);
-      return now>=a && now<=b;
+      let ini, fim;
+      if(typeof intv === 'string'){
+        [ini, fim] = intv.split('-');
+      }else if(intv && typeof intv === 'object'){
+        ini = intv.inicio;
+        fim = intv.fim;
+      }
+      if(!ini || !fim) return false;
+      const [h1, m1] = (ini||'').split(':').map(Number);
+      const [h2, m2] = (fim||'').split(':').map(Number);
+      const a = new Date(); a.setHours(h1||0, m1||0, 0, 0);
+      const b = new Date(); b.setHours(h2||23, m2||59, 59, 999);
+      return now >= a && now <= b;
     });
   }
 


### PR DESCRIPTION
## Summary
- Avoid TypeError in schedule check by parsing intervals as strings or {inicio, fim} objects

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf7e3e7818832ab6d144f4eeceb587