### PR TITLE
fix: reuse schedule check result for zpl OCR

### DIFF
--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -397,7 +397,11 @@
   $(el.btnProcessar).onclick = async ()=>{
     hideErr(); hideOk(); resetProgress();
     if(!currentUser){ showErr('Faça login para continuar.'); return; }
-    if(!isDentroHorario()){ showErr('Fora do horário permitido para impressão (ver Firestore: horariosEtiquetas).'); return; }
+    const dentroHorario = isDentroHorario();
+    if(!dentroHorario){
+      showErr('Fora do horário permitido para impressão (ver Firestore: horariosEtiquetas).');
+      return;
+    }
     const file = $(el.zplFile).files?.[0]; if(!file){ showErr('Selecione um arquivo .zpl/.txt.'); return; }
 
     // gestores
@@ -431,7 +435,7 @@
         created: firebase.firestore.FieldValue.serverTimestamp(),
         total: totalLabels,
         name,
-        foraHorario: !isDentroHorario()
+        foraHorario: !dentroHorario
       });
       const pdfPath = `pdfs/${currentUser.uid}/${metaRef.id}.pdf`;
 


### PR DESCRIPTION
## Summary
- avoid re-checking allowed printing hours after process starts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf7f29c260832a8857085880eeb597