### PR TITLE
Fix invisible gestor modal in ZPL Import OCR

### DIFF
--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -40,10 +40,11 @@
 
     /* Modal */
     .modal-backdrop{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(10,12,18,.6);backdrop-filter:blur(6px);z-index:50}
-    .modal{width:100%;max-width:520px;background:#0f1420;border:1px solid #223049;border-radius:16px;box-shadow:0 20px 50px rgba(0,0,0,.45)}
-    .modal .hd{padding:16px 18px;border-bottom:1px solid #1f283c;font-weight:700}
-    .modal .ct{padding:18px}
-    .modal .ft{padding:16px 18px;border-top:1px solid #1f283c;display:flex;gap:10px;justify-content:flex-end}
+    /* Use a unique class to avoid conflict with global .modal styles */
+    .modal-card{display:block;width:100%;max-width:520px;background:#0f1420;border:1px solid #223049;border-radius:16px;box-shadow:0 20px 50px rgba(0,0,0,.45)}
+    .modal-card .hd{padding:16px 18px;border-bottom:1px solid #1f283c;font-weight:700}
+    .modal-card .ct{padding:18px}
+    .modal-card .ft{padding:16px 18px;border-top:1px solid #1f283c;display:flex;gap:10px;justify-content:flex-end}
 
     /* Auth */
     .auth{display:grid;gap:10px}
@@ -126,7 +127,7 @@
     const wrap = document.createElement('div');
     wrap.innerHTML = `
     <div id="gestorModal" class="modal-backdrop hidden">
-      <div class="modal">
+      <div class="modal-card">
         <div class="hd">Selecionar Gestor</div>
         <div class="ct">
           <p class="muted">Selecione qual gestor receberá o PDF gerado.</p>


### PR DESCRIPTION
## Summary
- Prevent global `.modal` styles from hiding gestor selection modal
- Ensure modal content uses unique `.modal-card` class

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf8400b218832a99d30ca81a6554f2