### PR TITLE
Fix Labelary rendering error by removing Content-Type header

### DIFF
--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -283,7 +283,7 @@
     const url = `https://api.labelary.com/v1/printers/${dpmm}dpmm/labels/${widthIn}x${heightIn}/0/`;
     const res = await fetch(url, {
       method:'POST',
-      headers:{'Accept':'image/png','Content-Type':'application/x-www-form-urlencoded'},
+      headers:{'Accept':'image/png'},
       body: zpl
     });
     if(!res.ok){

--- a/zpl-import.html
+++ b/zpl-import.html
@@ -437,8 +437,7 @@ async function generateImageFromZpl(zplCode, dpmm, width, height) {
             const response = await fetch(apiUrl, {
                 method: 'POST',
                 headers: {
-                    'Accept': 'image/png',
-                    'Content-Type': 'application/x-www-form-urlencoded'
+                    'Accept': 'image/png'
                 },
                 body: zplCode
             });


### PR DESCRIPTION
## Summary
- Avoid misparsed ZPL by dropping the explicit `Content-Type` header on Labelary requests in OCR and standard import pages.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c002ff424c832a82dfb7ed6586aeba