### PR TITLE
Fix Labelary ZPL upload

### DIFF
--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -264,6 +264,13 @@
     const out=[]; const re=/\^FD([\s\S]*?)\^FS/g; let m; while((m=re.exec(zpl))!==null){ out.push(m[1].trim()); }
     return out.join('\n');
   }
+  function ensureWrapped(z){
+    const hasXA=/\^XA/i.test(z); const hasXZ=/\^XZ/i.test(z);
+    return hasXA && hasXZ ? z : `^XA${z}^XZ`;
+  }
+  function sanitize(z){
+    return z.replace(/^\uFEFF/, '').replace(/^[\s\r\n]+/, '');
+  }
   function detectLojaFromZpl(labelZpl){
     // tenta ^FDRemetente: NOME^FS ou linhas com "REMENTE"/"REMETENTE"
     let m = labelZpl.match(/\^FD\s*Remetente:?\s*([^\^]+)\^FS/i);
@@ -280,19 +287,23 @@
     if(!zpl || !zpl.trim()){
       throw new Error('ZPL vazio não pode ser renderizado');
     }
+    if(window.__zplPrefix){ zpl = window.__zplPrefix + zpl; }
+    zpl = sanitize(ensureWrapped(zpl));
     const url = `https://api.labelary.com/v1/printers/${dpmm}dpmm/labels/${widthIn}x${heightIn}/0/`;
     const res = await fetch(url, {
       method:'POST',
-      headers:{'Accept':'image/png','Content-Type':'application/x-www-form-urlencoded'},
+      headers:{'Accept':'image/png','Content-Type':'text/plain'},
       body: zpl
     });
     if(!res.ok){
       let msg = '';
       try { msg = await res.text(); } catch {}
+      console.warn('Labelary erro', res.status, msg);
+      console.warn('ZPL preview:', (zpl || '').slice(0,500));
       if(res.status === 404 && msg.includes('no labels')){
         throw new Error('Labelary falhou: ZPL não gerou nenhuma etiqueta. Verifique se o bloco está completo.');
       }
-      throw new Error(`Labelary falhou (${res.status}) ${msg}`);
+      throw new Error(`Labelary falhou (${res.status}) ${msg}`.trim());
     }
     return await res.blob();
   }
@@ -429,6 +440,8 @@
     try{
       $(el.btnProcessar).disabled = true; setProgress(2,'Lendo arquivo…');
       const zplText = await readFileAsText(file);
+      const dgDefs = (zplText.match(/^~DG[^\r\n]+/gmi) || []).join('\n');
+      window.__zplPrefix = dgDefs ? dgDefs+'\n' : '';
       const blocks = splitZplBlocks(zplText);
       if(blocks.length<2 || blocks.length%2!==0){ throw new Error('Arquivo não contém pares válidos de etiqueta + checklist.'); }
 


### PR DESCRIPTION
## Summary
- sanitize and wrap ZPL blocks before sending to Labelary
- send ZPL as text/plain and prefix graphic definitions for each request
- log Labelary errors for debugging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c004306bf8832a8b68a580ff16a390