### PR TITLE
Fix Labelary ZPL rendering headers

### DIFF
--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -260,6 +260,10 @@
     const blocks = zpl.match(/\^XA[\s\S]*?\^XZ/g) || [];
     return blocks;
   }
+  function buildPrefixWithDG(allZplText){
+    const dg = (allZplText.match(/^~DG[^\r\n]+/gmi) || []).join('\n');
+    return dg ? dg + '\n' : '';
+  }
   function extractFDText(zpl){ // concatena texto entre ^FD ... ^FS
     const out=[]; const re=/\^FD([\s\S]*?)\^FS/g; let m; while((m=re.exec(zpl))!==null){ out.push(m[1].trim()); }
     return out.join('\n');
@@ -276,16 +280,23 @@
     }
     return null;
   }
-  async function renderZplToPngBlob(zpl, dpmm=8, widthIn=4.0, heightIn=5.2){
+  async function renderZplToPngBlob(zpl, dpmm=8, widthIn=4.0, heightIn=5.2, index=0){
     if(!zpl || !zpl.trim()){
       throw new Error('ZPL vazio não pode ser renderizado');
     }
-    const url = `https://api.labelary.com/v1/printers/${dpmm}dpmm/labels/${widthIn}x${heightIn}/0/`;
-    const res = await fetch(url, {
+    const url = `https://api.labelary.com/v1/printers/${dpmm}dpmm/labels/${widthIn}x${heightIn}/${index}/`;
+    // Tentativa #1 — x-www-form-urlencoded
+    let res = await fetch(url, {
       method:'POST',
-      headers:{'Accept':'image/png'},
+      headers:{ 'Accept':'image/png', 'Content-Type':'application/x-www-form-urlencoded' },
       body: zpl
     });
+    // Fallback #2 — multipart/form-data com campo 'file'
+    if(res.status === 415){
+      const fd = new FormData();
+      fd.append('file', new Blob([zpl], { type:'text/plain' }), 'label.zpl');
+      res = await fetch(url, { method:'POST', headers:{ 'Accept':'image/png' }, body: fd });
+    }
     if(!res.ok){
       let msg = '';
       try { msg = await res.text(); } catch {}
@@ -429,6 +440,7 @@
     try{
       $(el.btnProcessar).disabled = true; setProgress(2,'Lendo arquivo…');
       const zplText = await readFileAsText(file);
+      const zplPrefix = buildPrefixWithDG(zplText);
       const blocks = splitZplBlocks(zplText);
       if(blocks.length<2 || blocks.length%2!==0){ throw new Error('Arquivo não contém pares válidos de etiqueta + checklist.'); }
 
@@ -463,7 +475,7 @@
         // Extrair itens (primeiro tentando ^FD, depois OCR)
         let text = extractFDText(checklistZpl);
         if(!text || text.length<3){
-          const chkBlob = await renderZplToPngBlob(checklistZpl, dpmm, widthIn, heightIn);
+          const chkBlob = await renderZplToPngBlob(zplPrefix + checklistZpl, dpmm, widthIn, heightIn);
           const bin = await binarizeBlob(chkBlob, 200);
           text = await ocrBlobToText(bin);
         }
@@ -472,7 +484,7 @@
 
         // Montar ZPL combinado e renderizar
         const combinedZpl = buildCombinedZpl(labelZpl, items, { dpmm, widthIn, heightIn, labelNumber: labelCounter });
-        const imgBlob = await renderZplToPngBlob(combinedZpl, dpmm, widthIn, heightIn + 1.0); // +1" margem de segurança
+        const imgBlob = await renderZplToPngBlob(zplPrefix + combinedZpl, dpmm, widthIn, heightIn + 1.0); // +1" margem de segurança
         const imgBytes = new Uint8Array(await imgBlob.arrayBuffer());
         const png = await pdfDoc.embedPng(imgBytes);
         const page = pdfDoc.addPage([widthIn*72, (png.height/png.width)*widthIn*72]);


### PR DESCRIPTION
## Summary
- Ensure Labelary API calls use `application/x-www-form-urlencoded` and fallback to multipart upload
- Prefix Labelary requests with `~DG` graphics definitions to avoid missing images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0067f4714832aa8073fd0f06e9822