### PR TITLE
feat: refresh navbar layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -27,7 +27,7 @@
   --highlight: #FF6F61;
   --highlight-hover: #E65B54;
   --transition: all 0.3s ease;
-  --navbar-height: 70px;
+  --navbar-height: 64px;
   --sidebar-width: 16rem;
 }
     
@@ -1281,9 +1281,7 @@ body.dark-mode .data-table th {
 
 .navbar {
   height: var(--navbar-height);
-  background: var(--card);
-  color: var(--text-dark);
-  box-shadow: 0 2px 10px rgba(0,0,0,.05);
+  background: #fff;
   position: fixed;
   top: 0;
   left: var(--sidebar-width);
@@ -1291,8 +1289,9 @@ body.dark-mode .data-table th {
   z-index: 99;
   display: flex;
   align-items: center;
-  padding: 0 25px;
   justify-content: space-between;
+  padding: 0 1rem;
+  border-bottom: 1px solid rgba(229,229,229,0.7);
 }
 .navbar .hamburger {
   display: none;
@@ -1300,14 +1299,48 @@ body.dark-mode .data-table th {
 .navbar-right {
   display: flex;
   align-items: center;
-  gap: 20px
+  gap: 0.5rem;
 }
 .navbar .menu-item {
-  color: var(--text-light);
-  transition: color 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  color: #4b5563;
+  border-radius: 0.375rem;
+  transition: background-color 0.2s ease;
 }
 .navbar .menu-item:hover {
-  color: var(--text-dark);
+  background-color: #f5f5f5;
+}
+
+#notificationBtn[data-count]:after {
+  content: attr(data-count);
+  position: absolute;
+  top: -0.25rem;
+  right: -0.25rem;
+  background-color: #ef4444;
+  color: #fff;
+  font-size: 0.75rem;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 9999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#notificationBtn[data-count=""]:after,
+#notificationBtn[data-count="0"]:after {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .navbar {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
 }
 .user-dropdown {
   display: flex;
@@ -1713,7 +1746,7 @@ input:checked + .toggle-slider:before {
 
     
   @media (max-width:768px) {
-    :root { --navbar-height: 50px; }
+    :root { --navbar-height: 64px; }
     .grid-cols-2 {
       grid-template-columns: 1fr
     }
@@ -1724,12 +1757,7 @@ input:checked + .toggle-slider:before {
     .navbar {
       left: 0;
       height: var(--navbar-height);
-      padding: 0 10px;
-      background-color: rgba(0,0,0,0.8);
-      color: #fff;
-    }
-    .navbar .menu-item {
-      display: none;
+      padding: 0 1rem;
     }
     .navbar .hamburger {
       display: block;

--- a/login.js
+++ b/login.js
@@ -416,9 +416,8 @@ window.requireLogin = (event) => {
 
 function initNotificationListener(uid) {
   const btn = document.getElementById('notificationBtn');
-  const badge = document.getElementById('notificationBadge');
   const list = document.getElementById('notificationList');
-  if (!btn || !badge || !list) return;
+  if (!btn || !list) return;
   if (notifUnsub) notifUnsub();
   if (expNotifUnsub) expNotifUnsub();
   if (updNotifUnsub) updNotifUnsub();
@@ -439,10 +438,9 @@ function initNotificationListener(uid) {
       count++;
     });
     if (count > 0) {
-      badge.textContent = count;
-      badge.classList.remove('hidden');
+      btn.dataset.count = count;
     } else {
-      badge.classList.add('hidden');
+      btn.dataset.count = '';
     }
   };
 

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,60 +1,75 @@
-  <div class="navbar">
-      <div class="flex items-center">
-        <button class="mobile-menu-btn hamburger mr-4 menu-item" aria-label="Abrir menu" aria-expanded="false">
+<div class="navbar h-16 px-4 md:px-6 flex items-center justify-between border-b border-neutral-200/70 bg-white">
+  <div class="flex items-center gap-3">
+    <button class="mobile-menu-btn hamburger menu-item mr-2" aria-label="Abrir menu" aria-expanded="false">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5" />
+      </svg>
+    </button>
+    <h2 class="text-lg md:text-xl font-semibold text-neutral-800">Dashboard</h2>
+  </div>
+
+  <div class="flex items-center gap-2">
+    <div class="relative hidden md:block mr-2">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 text-neutral-500 absolute left-2 top-1/2 -translate-y-1/2 pointer-events-none">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 1 0 16.65 16.65z" />
+      </svg>
+      <input id="navbarSearch" type="text" placeholder="Buscar" class="pl-8 pr-2 py-2 text-sm border border-neutral-300 rounded-md focus:outline-none focus:ring-0" />
+    </div>
+
+    <a href="cadastro-interesse.html" class="menu-item" title="Cadastre-se">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-orange-500">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3M12.75 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3.001 19.234c-.001-.037-.001-.074-.001-.111 0-3.52 2.854-6.375 6.375-6.375S15.75 15.604 15.75 19.125v.003a12.318 12.318 0 0 1-6.375 1.872A12.32 12.32 0 0 1 3.001 19.234Z" />
+      </svg>
+    </a>
+
+    <button id="loginBtn" class="menu-item" title="Login">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.118a8.999 8.999 0 0 1 15 0" />
+      </svg>
+    </button>
+
+    <div id="notificationWrapper" class="relative">
+      <button id="notificationBtn" class="menu-item" title="Notificações" data-count="">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082A23.86 23.86 0 0 0 20.312 15.772 8.966 8.966 0 0 1 18 9.75V9a6 6 0 1 0-12 0v.75a8.966 8.966 0 0 1-2.312 6.021A23.86 23.86 0 0 0 9.143 17.082M14.857 17.082A24.255 24.255 0 0 1 12 17.25c-1.035 0-2.06-.068-3.057-.199M14.857 17.082c.092.29.143.599.143.918a3 3 0 1 1-6 0c0-.319.051-.628.143-.918" />
+        </svg>
+      </button>
+      <div id="notificationList" class="hidden absolute right-0 mt-2 w-64 bg-white text-gray-700 rounded-md shadow-lg z-20"></div>
+    </div>
+
+    <button id="startTourBtn" class="menu-item hidden" title="Introdução">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519a3.75 3.75 0 1 1 4.243 6.212c-.203.178-.43.325-.67.441-.555.26-.903.816-.903 1.43V16.5m0 2.25h.008v.008H12v-.008Z" />
+      </svg>
+    </button>
+
+    <div class="relative">
+      <button id="userMenuButton" class="menu-item rounded-full overflow-hidden">
+        <div class="w-10 h-10 rounded-full bg-neutral-200 flex items-center justify-center text-neutral-600">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.118a8.999 8.999 0 0 1 15 0" />
           </svg>
-        </button>
-        <h2 class="text-lg font-semibold">Dashboard</h2>
-      </div>
-
-      <div class="flex items-center space-x-5">
-        <!-- Botão de cadastro -->
-        <a href="cadastro-interesse.html" class="menu-item" title="Cadastre-se">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3M12.75 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3.001 19.234c-.001-.037-.001-.074-.001-.111 0-3.52 2.854-6.375 6.375-6.375S15.75 15.604 15.75 19.125v.003a12.318 12.318 0 0 1-6.375 1.872A12.32 12.32 0 0 1 3.001 19.234Z"/>
-          </svg>
-        </a>
-
-        <!-- Login button -->
-        <button id="loginBtn" class="menu-item" title="Login">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.118a8.999 8.999 0 0 1 15 0"/>
-          </svg>
-        </button>
-
-        <!-- Notificações -->
-        <div id="notificationWrapper" class="relative tooltip menu-item" data-tooltip="Notificações">
-          <button id="notificationBtn">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082A23.86 23.86 0 0 0 20.312 15.772 8.966 8.966 0 0 1 18 9.75V9a6 6 0 1 0-12 0v.75a8.966 8.966 0 0 1-2.312 6.021A23.86 23.86 0 0 0 9.143 17.082M14.857 17.082A24.255 24.255 0 0 1 12 17.25c-1.035 0-2.06-.068-3.057-.199M14.857 17.082c.092.29.143.599.143.918a3 3 0 1 1-6 0c0-.319.051-.628.143-.918"/>
-            </svg>
-          </button>
-          <span id="notificationBadge" class="hidden absolute top-0 right-0 bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs"></span>
-          <div id="notificationList" class="hidden absolute right-0 mt-2 w-64 bg-white text-gray-700 rounded shadow-lg z-20"></div>
         </div>
-
-        <!-- Modo Introdução -->
-        <button id="startTourBtn" class="menu-item hidden tooltip" data-tooltip="Introdução">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519a3.75 3.75 0 1 1 4.243 6.212c-.203.178-.43.325-.67.441-.555.26-.903.816-.903 1.43V16.5m0 2.25h.008v.008H12v-.008Z"/>
-          </svg>
-        </button>
-
-        <!-- Perfil do usuário -->
-        <div class="flex items-center space-x-3 menu-item">
-          <div class="bg-gray-200 rounded-xl w-10 h-10 overflow-hidden flex items-center justify-center">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-gray-400">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.118a8.999 8.999 0 0 1 15 0"/>
-            </svg>
-          </div>
-          <span id="currentUser" class="font-medium cursor-pointer" title="Alterar nome">Usuário</span>
-          <button id="logoutBtn" class="ml-2 hidden">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6A2.25 2.25 0 0 0 5.25 5.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9"/>
-            </svg>
-          </button>
-        </div>
-
+        <span id="currentUser" class="sr-only">Usuário</span>
+      </button>
+      <div id="userMenu" class="hidden absolute right-0 mt-2 w-40 bg-white border border-neutral-200 rounded-md shadow-md z-20">
+        <a href="perfil-mentorado.html" class="block px-4 py-2 text-sm text-neutral-700 hover:bg-neutral-100">Perfil</a>
+        <button id="logoutBtn" class="hidden w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-neutral-100">Sair</button>
       </div>
     </div>
+  </div>
+</div>
+
+<script>
+document.addEventListener('click', function(e) {
+  var btn = document.getElementById('userMenuButton');
+  var menu = document.getElementById('userMenu');
+  if (!btn || !menu) return;
+  if (btn.contains(e.target)) {
+    menu.classList.toggle('hidden');
+  } else if (!menu.contains(e.target)) {
+    menu.classList.add('hidden');
+  }
+});
+</script>
+

--- a/public/login.js
+++ b/public/login.js
@@ -320,9 +320,8 @@ window.requireLogin = (event) => {
 
 function initNotificationListener(uid) {
   const btn = document.getElementById('notificationBtn');
-  const badge = document.getElementById('notificationBadge');
   const list = document.getElementById('notificationList');
-  if (!btn || !badge || !list) return;
+  if (!btn || !list) return;
   if (notifUnsub) notifUnsub();
   const q = query(
     collection(db, 'financeiroAtualizacoes'),
@@ -345,10 +344,9 @@ function initNotificationListener(uid) {
       count++;
     });
     if (count > 0) {
-      badge.textContent = count;
-      badge.classList.remove('hidden');
+      btn.dataset.count = count;
     } else {
-      badge.classList.add('hidden');
+      btn.dataset.count = '';
     }
   }, err => {
     console.error('Erro no listener de notificações:', err);


### PR DESCRIPTION
## Summary
- standardize navbar spacing and typography
- add search box, icon buttons and profile dropdown
- render notification count via data attribute

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c00f52fe38832a9eda0f5cdcad0019