### PR TITLE
fix: remove sidebar list bullets interfering with navbar

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1841,6 +1841,13 @@ input:checked + .toggle-slider:before {
   padding-top: 1rem;
 }
 
+.sidebar-menu,
+.sidebar-menu ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 .sidebar-link {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- remove default list bullets and spacing from sidebar menu to avoid stray markers overlapping navbar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c012c7a118832aaf7d31ae959d2aee