### PR TITLE
Refine navbar and index page color scheme

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -30,10 +30,18 @@
   --navbar-height: 64px;
   --sidebar-width: 16rem;
 }
-    
-  
 
-body {
+
+.text-brand {
+  color: var(--brand);
+}
+
+.bg-brand {
+  background-color: var(--brand);
+}
+
+
+  body {
   font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
 }
 
@@ -1291,8 +1299,8 @@ body.dark-mode .data-table th {
   justify-content: space-between;
   height: var(--navbar-height);
   padding: 0 1rem;
-  background: var(--card);
-  color: var(--text-dark);
+  background: var(--nav-bg);
+  color: #fff;
   border-bottom: 1px solid rgba(229,231,235,0.7);
 }
 @media (min-width:768px) {
@@ -1307,7 +1315,7 @@ body.dark-mode .data-table th {
   gap: 20px;
 }
 .navbar .menu-item {
-  color: var(--text-light);
+  color: #fff;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1317,8 +1325,8 @@ body.dark-mode .data-table th {
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 .navbar .menu-item:hover {
-  background-color: #f5f5f5;
-  color: var(--text-dark);
+  background-color: rgba(255,255,255,0.1);
+  color: #fff;
 }
 .user-dropdown {
   display: flex;

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
           <div id="lastUpdate" class="absolute top-0 right-0 text-xs text-gray-500"></div>
           <div class="flex items-center space-x-4 mb-4">
             <h1 class="text-3xl md:text-4xl font-bold text-gray-900">
-              <span class="text-orange-600 font-extrabold">Sistemas de Gestão</span> para sua Loja
+              <span class="font-extrabold text-brand">Sistemas de Gestão</span> para sua Loja
             </h1>
             <input type="month" id="filtroMes" class="border rounded p-1 text-sm" />
           </div>

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -20,12 +20,12 @@
   </div>
   <div class="flex items-center gap-1">
     <a href="cadastro-interesse.html" class="menu-item" title="Cadastre-se">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-orange-500">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
         <path stroke-linecap="round" stroke-linejoin="round" d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3M12.75 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3.001 19.234c-.001-.037-.001-.074-.001-.111 0-3.52 2.854-6.375 6.375-6.375S15.75 15.604 15.75 19.125v.003a12.318 12.318 0 0 1-6.375 1.872A12.32 12.32 0 0 1 3.001 19.234Z"/>
       </svg>
     </a>
     <button id="loginBtn" class="menu-item" title="Login">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-orange-500">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
         <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.118a8.999 8.999 0 0 1 15 0"/>
       </svg>
     </button>
@@ -34,12 +34,12 @@
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082A23.86 23.86 0 0 0 20.312 15.772 8.966 8.966 0 0 1 18 9.75V9a6 6 0 1 0-12 0v.75a8.966 8.966 0 0 1-2.312 6.021A23.86 23.86 0 0 0 9.143 17.082M14.857 17.082A24.255 24.255 0 0 1 12 17.25c-1.035 0-2.06-.068-3.057-.199M14.857 17.082c.092.29.143.599.143.918a3 3 0 1 1-6 0c0-.319.051-.628.143-.918"/>
         </svg>
-        <span id="notificationBadge" data-count="0" class="hidden absolute -top-1 -right-1 bg-orange-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs"></span>
+        <span id="notificationBadge" data-count="0" class="hidden absolute -top-1 -right-1 bg-brand text-white rounded-full w-5 h-5 flex items-center justify-center text-xs"></span>
       </button>
       <div id="notificationList" class="hidden absolute right-0 mt-2 w-64 bg-white text-gray-700 rounded shadow-lg z-20"></div>
     </div>
     <button id="startTourBtn" class="menu-item hidden" title="Introdução">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-orange-500">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519a3.75 3.75 0 1 1 4.243 6.212c-.203.178-.43.325-.67.441-.555.26-.903.816-.903 1.43V16.5m0 2.25h.008v.008H12v-.008Z"/>
       </svg>
     </button>


### PR DESCRIPTION
## Summary
- use brand color variables for navbar background and items
- add utility classes for brand text and background; apply to index hero and notification badge

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0147da4e8832a8938736308331482