### PR TITLE
feat: modernize color palette with SaaS styling

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -609,7 +609,7 @@ let consulta;
           </td>
           <td>${dataFormatada}</td>
           <td>
-            <button onclick="editarMeta(this, '${sku}')" class="btn btn-sm" style="background: rgba(67, 97, 238, 0.1); color: var(--primary);">
+            <button onclick="editarMeta(this, '${sku}')" class="btn btn-sm" style="background: rgba(99, 102, 241, 0.1); color: var(--primary);">
               <i class="fas fa-edit"></i>
             </button>
             <button onclick="excluirMeta('${sku}', this)" class="btn btn-sm" style="background: rgba(239, 71, 111, 0.1); color: var(--danger);">
@@ -1049,7 +1049,7 @@ let consulta;
             <h3>Resumo Financeiro</h3>
           </div>
           <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.5rem;">
-            <div style="background: rgba(67, 97, 238, 0.05); padding: 1.5rem; border-radius: 12px; border-left: 4px solid var(--primary);">
+            <div style="background: rgba(99, 102, 241, 0.05); padding: 1.5rem; border-radius: 12px; border-left: 4px solid var(--primary);">
               <h4 style="color: var(--primary); margin-bottom: 0.5rem;">Sobra Total</h4>
               <h2>R$ ${totalSobra.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</h2>
             </div>

--- a/acompanhamento-promocoes.js
+++ b/acompanhamento-promocoes.js
@@ -42,8 +42,8 @@ const promocoes = [
 const tipoConfig = {
   'Desconto': { color: '#dc2626', icon: '🔻' },
   'Oferta Relâmpago': { color: '#f97316', icon: '⚡' },
-  'Cupom de Vendedor': { color: '#a855f7', icon: '🎫' },
-  'Shopee Ads': { color: '#3b82f6', icon: '📢' },
+  'Cupom de Vendedor': { color: 'var(--primary-light)', icon: '🎫' },
+  'Shopee Ads': { color: 'var(--primary)', icon: '📢' },
   'Shopee Live': { color: '#16a34a', icon: '🎥' },
   'Moedas': { color: '#fbbf24', icon: '💰' },
   'Avaliação': { color: '#86efac', icon: '⭐' },
@@ -121,7 +121,7 @@ function verDetalhes(id) {
       datasets: [
         { label: 'Vendas', data: vendas, borderColor: '#f97316', fill: false },
         { label: 'Fora da promoção', data: fora, borderColor: '#94a3b8', borderDash: [5,5], fill: false },
-        { label: 'Outra promoção', data: comparacao, borderColor: '#3b82f6', fill: false }
+        { label: 'Outra promoção', data: comparacao, borderColor: 'var(--primary)', fill: false }
       ]
     }
   });

--- a/css/components.css
+++ b/css/components.css
@@ -116,13 +116,13 @@
 
 /* Color variations for financeiro cards */
 .card-blue {
-  border-top: 4px solid #3b82f6;
+  border-top: 4px solid var(--primary);
 }
 .card-blue .card-header {
-  background-color: #eff6ff;
+  background-color: #eef2ff;
 }
 .card-blue .card-header h2 {
-  color: #1e3a8a;
+  color: var(--primary-dark);
 }
 
 .card-green {

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,31 +1,31 @@
 
 :root {
   /* VendedorPro brand color palette */
-  --primary: #5E60CE;
-  --primary-hover: #7678ED;
-  --primary-dark: #4B4DAA;
-  --primary-light: #B8B9F2;
-  --brand: #5E60CE;
-  --hover: #7678ED;
-  --dark: #1C2B36;
-  --secondary: #F5F5F5;
+  --primary: #6366F1;
+  --primary-hover: #818CF8;
+  --primary-dark: #4F46E5;
+  --primary-light: #A5B4FC;
+  --brand: #6366F1;
+  --hover: #818CF8;
+  --dark: #0F172A;
+  --secondary: #F3F4F6;
   --nav-bg: var(--primary);
   --success: #4CAF50;
   --error: #F44336;
   --danger: #F44336;
-  --bg-light: #F5F5F5;
+  --bg-light: #F3F4F6;
   --background: #FFFFFF;
   --bg: #FFFFFF;
   --border: #e5e7eb;
-  --card: #F5F5F5;
-  --card-bg: #F5F5F5;
+  --card: #FFFFFF;
+  --card-bg: #FFFFFF;
   --card-shadow: 0 4px 6px rgba(0,0,0,0.1);
   --gray: #6B7280;
-  --text: #212121;
-  --text-dark: #212121;
-  --text-light: #9E9E9E;
-  --highlight: #FF6F61;
-  --highlight-hover: #E65B54;
+  --text: #0F172A;
+  --text-dark: #0F172A;
+  --text-light: #6B7280;
+  --highlight: #14B8A6;
+  --highlight-hover: #0D9488;
   --transition: all 0.3s ease;
   --navbar-height: 64px;
   --sidebar-width: 16rem;
@@ -113,7 +113,7 @@ body.has-sidebar .content-wrapper {
   align-items: center;
  justify-content: center;
   margin-right: 15px;
-  background-color: rgba(255,112,67,0.1); /* subtle highlight */
+  background-color: rgba(20,184,166,0.1); /* subtle highlight */
   color: var(--primary);
 }
 
@@ -233,7 +233,7 @@ input:checked + .dark-mode-slider:before {
 }
 
 #tarefasCard .card-header-icon {
-  background-color: rgba(255,112,67,0.1);
+  background-color: rgba(20,184,166,0.1);
   color: var(--primary);
 }
 
@@ -1173,16 +1173,18 @@ h4 {
   }
 }
 body.dark-mode {
-  --background: #1a202c;
-  --primary: #5E60CE;
-  --primary-hover: #7678ED;
-  --secondary: #2D3748;
+  --background: #0F172A;
+  --primary: #6366F1;
+  --primary-hover: #818CF8;
+  --secondary: #1E293B;
   --bg: #1E293B;
-  --card: #1F2937;
-  --card-bg: #1F2937;
-  --text: #CBD5E1;
+  --card: #1E293B;
+  --card-bg: #1E293B;
+  --text: #E5E7EB;
   --text-light: #94A3B8;
-  --border: #475569;
+  --border: #334155;
+  --highlight: #14B8A6;
+  --highlight-hover: #0D9488;
   --card-shadow: 0 4px 6px rgba(0,0,0,0.4);
   color: var(--text);
   background: var(--background);
@@ -1207,13 +1209,13 @@ body.dark-mode .navbar .menu-item:hover {
   color: #fff;
 }
 body.dark-mode .form-control {
-  background: #4a5568;
-  border-color: #4a5568;
+  background: #334155;
+  border-color: #334155;
   color: var(--text);
 }
 body.dark-mode .table th,
 body.dark-mode .data-table th {
-  background: #4a5568;
+  background: #334155;
 }
 
 .submenu .nav-item {

--- a/dashboard-geral.js
+++ b/dashboard-geral.js
@@ -276,8 +276,8 @@ function renderCharts(diarioBruto, diarioLiquido, diasAcima, diasAbaixo, porLoja
           {
             label: 'Bruto',
             data: dias.map(d => diarioBruto[d]),
-            borderColor: '#3b82f6',
-            backgroundColor: 'rgba(59,130,246,0.2)',
+            borderColor: 'var(--primary)',
+            backgroundColor: 'rgba(99,102,241,0.2)',
             tension: 0.3
           },
           {
@@ -317,7 +317,7 @@ function renderCharts(diarioBruto, diarioLiquido, diasAcima, diasAbaixo, porLoja
         labels: lojas,
         datasets: [{
           data: lojas.map(l => porLoja[l]),
-          backgroundColor: ['#3b82f6','#f97316','#6366f1','#10b981','#f59e0b','#ef4444']
+          backgroundColor: ['var(--primary-light)','var(--highlight)','var(--primary)','var(--success)','#f59e0b','#ef4444']
         }]
       },
       options: opts
@@ -376,7 +376,7 @@ function renderTopSkusComparativo(lista, rentabilidade, root = document) {
     data: {
       labels,
       datasets: [
-        { type: 'bar', label: 'Vendas', data: vendas, backgroundColor: '#3b82f6', yAxisID: 'y' },
+        { type: 'bar', label: 'Vendas', data: vendas, backgroundColor: 'var(--primary)', yAxisID: 'y' },
         { type: 'line', label: 'Margem (%)', data: margens, borderColor: '#f59e0b', backgroundColor: 'rgba(245,158,11,0.2)', yAxisID: 'y1', tension: 0.3 }
       ]
     },
@@ -430,7 +430,7 @@ function renderComparativoMeta(liquido, meta, diarioLiquido, totalDiasMes, mesAt
         datasets: [{
           label: 'Valor (R$)',
           data: [meta, liquido],
-          backgroundColor: ['#9ca3af', '#3b82f6']
+          backgroundColor: ['#9ca3af', 'var(--primary)']
         }]
       },
       options: opts
@@ -464,8 +464,8 @@ function renderComparativoMeta(liquido, meta, diarioLiquido, totalDiasMes, mesAt
           {
             label: 'Realizado',
             data: realAcum,
-            borderColor: '#3b82f6',
-            backgroundColor: 'rgba(59,130,246,0.2)',
+            borderColor: 'var(--primary)',
+            backgroundColor: 'rgba(99,102,241,0.2)',
             tension: 0.3
           },
           {
@@ -727,16 +727,16 @@ async function exportarFechamentoMes() {
           {
             label: 'Bruto',
             data: dias.map(d => dashboardData.diarioBruto[d] || 0),
-            borderColor: '#4C1D95',
-            backgroundColor: 'rgba(76,29,149,0.15)',
+            borderColor: 'var(--primary-dark)',
+            backgroundColor: 'rgba(79,70,229,0.15)',
             fill: false,
             tension: 0.3
           },
           {
             label: 'Líquido',
             data: dias.map(d => dashboardData.diarioLiquido[d] || 0),
-            borderColor: '#3b82f6',
-            backgroundColor: 'rgba(59,130,246,0.15)',
+            borderColor: 'var(--primary)',
+            backgroundColor: 'rgba(99,102,241,0.15)',
             fill: false,
             tension: 0.3
           }
@@ -780,8 +780,8 @@ async function exportarFechamentoMes() {
           {
             label: 'Acumulado',
             data: acumulado,
-            borderColor: '#4C1D95',
-            backgroundColor: 'rgba(76,29,149,0.2)',
+            borderColor: 'var(--primary-dark)',
+            backgroundColor: 'rgba(79,70,229,0.2)',
             tension: 0.3
           },
           {
@@ -824,7 +824,7 @@ async function exportarFechamentoMes() {
         labels: ['Atingido', 'Restante'],
         datasets: [{
           data: [pct, Math.max(100 - pct, 0)],
-          backgroundColor: ['#4C1D95', '#e5e7eb'],
+          backgroundColor: ['var(--primary-dark)', '#e5e7eb'],
           borderWidth: 0
         }]
       },
@@ -851,7 +851,7 @@ async function exportarFechamentoMes() {
         labels: ['Bruto', 'Líquido'],
         datasets: [{
           data: [dashboardData.totalBruto, dashboardData.totalLiquido],
-          backgroundColor: ['#4C1D95', '#3b82f6']
+          backgroundColor: ['var(--primary-dark)', 'var(--primary)']
         }]
       },
       options: opts
@@ -913,8 +913,8 @@ function gerarHTMLFechamento() {
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
         @import url('https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css');
         :root {
-          --primary-color: #4C1D95;
-          --secondary-color: #3b82f6;
+          --primary-color: #6366F1;
+          --secondary-color: #14B8A6;
           --text-color: #111827;
           --bg-color: #f8f8f8;
           --card-bg: #ffffff;

--- a/desempenho.js
+++ b/desempenho.js
@@ -129,7 +129,7 @@ function renderEvolucao(diaria) {
         datasets: [{
           label: 'Vendas diárias',
           data: dias.map(d => diaria[d]),
-          borderColor: '#6366f1',
+          borderColor: 'var(--primary)',
           backgroundColor: 'rgba(99,102,241,0.2)',
           tension: 0.3
         }]
@@ -148,7 +148,7 @@ function renderEvolucao(diaria) {
         datasets: [{
           label: 'Vendas semanais',
           data: semanas.map(s => semanal[s]),
-          backgroundColor: '#6366f1'
+          backgroundColor: 'var(--primary)'
         }]
       },
       options: { responsive: true, maintainAspectRatio: false }
@@ -165,7 +165,7 @@ function renderEvolucao(diaria) {
         datasets: [{
           label: 'Vendas mensais',
           data: meses.map(m => mensal[m]),
-          backgroundColor: '#3b82f6'
+          backgroundColor: 'var(--primary)'
         }]
       },
       options: { responsive: true, maintainAspectRatio: false }

--- a/etiquetas-ocr.html
+++ b/etiquetas-ocr.html
@@ -27,7 +27,7 @@
       box-shadow: 0 2px 16px rgba(0,0,0,0.08);
     }
     .progress-bar-fill {
-      background: linear-gradient(90deg, #06b6d4 0%, #3b82f6 100%);
+      background: linear-gradient(90deg, #14B8A6 0%, #6366F1 100%);
       height: 100%;
       border-radius: 9999px 0 0 9999px;
       transition: width 0.3s cubic-bezier(.4,0,.2,1);
@@ -55,20 +55,20 @@
       justify-content: flex-start;
     }
     .btn-main {
-      background: linear-gradient(90deg, #06b6d4 0%, #3b82f6 100%);
+      background: linear-gradient(90deg, #14B8A6 0%, #6366F1 100%);
       color: #fff;
       font-weight: 500;
       border-radius: 0.75rem;
       padding: 0.75rem 2.5rem;
       margin-top: 1rem;
       font-size: 1.1rem;
-      box-shadow: 0 4px 16px rgba(59, 130, 246, 0.08);
+      box-shadow: 0 4px 16px rgba(99, 102, 241, 0.08);
       border: none;
       outline: none;
       transition: background 0.2s, transform 0.2s;
     }
     .btn-main:hover {
-      background: linear-gradient(90deg, #3b82f6 0%, #06b6d4 100%);
+      background: linear-gradient(90deg, #6366F1 0%, #14B8A6 100%);
       transform: translateY(-2px) scale(1.03);
     }
     #status {

--- a/financeiro-manifest.json
+++ b/financeiro-manifest.json
@@ -4,7 +4,7 @@
   "start_url": "financeiro.html",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#2196f3",
+  "theme_color": "#6366F1",
   "icons": [
     {
       "src": "icons/icon-192.png",

--- a/financeiro.html
+++ b/financeiro.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Financeiro</title>
     <link rel="manifest" href="financeiro-manifest.json">
-  <meta name="theme-color" content="#2196f3">
+  <meta name="theme-color" content="#6366F1">
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">

--- a/financeiro.js
+++ b/financeiro.js
@@ -729,8 +729,8 @@ function updateSalesChart(labels, data) {
         datasets: [{
           label: 'Vendas',
           data,
-          borderColor: '#3b82f6',
-          backgroundColor: 'rgba(59,130,246,0.2)',
+          borderColor: 'var(--primary)',
+          backgroundColor: 'rgba(99,102,241,0.2)',
           tension: 0.3
         }]
       },

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <link rel="apple-touch-icon" href="icons/icon-192.png">
-  <meta name="theme-color" content="#2196f3">
+  <meta name="theme-color" content="#6366F1">
   <title>VendedorPro - Sistema Premium</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">

--- a/index.js
+++ b/index.js
@@ -340,7 +340,7 @@ async function carregarTopSkus(uid, isAdmin) {
     return;
   }
   const max = ordenado[0][1];
-  const cores = ['var(--primary)', 'var(--success)', 'var(--secondary)', '#3b82f6', '#a855f7'];
+  const cores = ['var(--primary)', 'var(--success)', 'var(--highlight)', 'var(--primary-dark)', 'var(--primary-light)'];
   const linhas = ordenado.map(([ch,q],i) => {
     const [sku] = ch.split('||');
     const largura = (q / max) * 100;

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "start_url": "index.html",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#2196f3",
+  "theme_color": "#6366F1",
   "icons": [
     {
       "src": "icons/icon-192.png",


### PR DESCRIPTION
## Summary
- adopt Indigo primary and teal highlight colors across styles
- refresh charts and components to use new palette
- update manifest and theme colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c017f58ed4832a9f20d9f0103ce71d