### PR TITLE
Organiza sidebar dos usuários

### DIFF
--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -45,14 +45,6 @@
       </a>
     </li>
     <li>
-      <a href="comunicacao.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-comunicacao" data-perfil="cliente,usuario,gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m21.75 0-9.423 6.615a2.25 2.25 0 0 1-2.654 0L1.5 6.75" />
-        </svg>
-        <span class="link-text">Comunicação</span>
-      </a>
-    </li>
-    <li>
       <a href="saques.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-saques" data-perfil="gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75C7.717 18.75 13.014 19.481 18.047 20.851c.728.198 1.454-.343 1.454-1.096V18.75M3.75 4.5V5.25A.75.75 0 0 1 3 6H2.25M2.25 6V5.625A1.125 1.125 0 0 1 3.375 4.5H20.25M2.25 6v9M20.25 4.5V5.25A.75.75 0 0 0 21 6h.75M20.25 4.5h.375A1.125 1.125 0 0 1 21.75 5.625V15.375A1.125 1.125 0 0 1 20.625 16.5H20.25M21.75 15H21a.75.75 0 0 0-.75.75V16.5M20.25 16.5H3.75m0 0H3.375A1.125 1.125 0 0 1 2.25 15.375V15M3.75 16.5V15.75A.75.75 0 0 0 3 15H2.25M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z"/>
@@ -156,7 +148,7 @@
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-vendas" data-perfil="usuario,gestor,mentor,responsavel,gestor financeiro">
+        <a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-vendas" data-perfil="usuario,gestor,mentor,responsavel,gestor financeiro">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
             <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"/>
           </svg>
@@ -169,17 +161,39 @@
         </button>
       </div>
       <ul id="menuVendas" class="submenu space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-        <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar" class="sidebar-link block py-2 px-4 transition-colors">Conferir Sobras</a></li>
         <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento" class="sidebar-link block py-2 px-4 transition-colors">Registrar Faturamento</a></li>
         <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=registroFaturamento" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Faturamento</a></li>
         <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=controleVendas" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Vendas</a></li>
         <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamento" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Mensal</a></li>
-        <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=sobras" class="sidebar-link block py-2 px-4 transition-colors">Sobras</a></li>
-        <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=previsao" class="sidebar-link block py-2 px-4 transition-colors">Previsão</a></li>
-        <li><a href="saques.html" class="sidebar-link block py-2 px-4 transition-colors">Saques</a></li>
-        <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a></li>
-        <li><a href="pedidos-tiny.html" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Tiny</a></li>
-        <li><a href="problemas.html" class="sidebar-link block py-2 px-4 transition-colors">Problemas</a></li>
+      </ul>
+    </li>
+    <li>
+      <a href="saques.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-saques" data-perfil="gestor,mentor">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75C7.717 18.75 13.014 19.481 18.047 20.851c.728.198 1.454-.343 1.454-1.096V18.75M3.75 4.5V5.25A.75.75 0 0 1 3 6H2.25M2.25 6V5.625A1.125 1.125 0 0 1 3.375 4.5H20.25M2.25 6v9M20.25 4.5V5.25A.75.75 0 0 0 21 6h.75M20.25 4.5h.375A1.125 1.125 0 0 1 21.75 5.625V15.375A1.125 1.125 0 0 1 20.625 16.5H20.25M21.75 15H21a.75.75 0 0 0-.75.75V16.5M20.25 16.5H3.75m0 0H3.375A1.125 1.125 0 0 1 2.25 15.375V15M3.75 16.5V15.75A.75.75 0 0 0 3 15H2.25M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z"/>
+        </svg>
+        <span class="link-text">Saques</span>
+      </a>
+    </li>
+    <li>
+      <div class="sidebar-item flex items-center justify-between">
+        <a href="etiquetas-ocr.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-etiquetas" data-perfil="usuario,gestor,mentor">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"/>
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6Z"/>
+          </svg>
+          <span class="link-text">Etiquetas</span>
+        </a>
+        <button class="submenu-toggle p-2" onclick="toggleMenu('menuEtiquetas', this)">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
+          </svg>
+        </button>
+      </div>
+      <ul id="menuEtiquetas" class="submenu pl-8 space-y-1 overflow-hidden transition-all duração-300" style="max-height:0;">
+        <li><a href="etiquetas-ocr.html" class="sidebar-link block py-2 px-4 transition-colors">Etiquetas OCR</a></li>
+        <li><a href="zpl-import.html" class="sidebar-link block py-2 px-4 transition-colors">ZPL Import</a></li>
+        <li><a href="zpl-import-ocr.html" class="sidebar-link block py-2 px-4 transition-colors">ZPL Import ocr</a></li>
       </ul>
     </li>
     <li>
@@ -197,7 +211,7 @@
           </svg>
         </button>
       </div>
-      <ul id="menuPrecificacao" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
+      <ul id="menuPrecificacao" class="submenu pl-8 space-y-1 overflow-hidden transition-all duração-300" style="max-height:0;">
         <li><a href="Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao" class="sidebar-link block py-2 px-4 transition-colors">Precificação</a></li>
         <li><a href="Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=lista-precos" class="sidebar-link block py-2 px-4 transition-colors">Lista Preços</a></li>
         <li><a href="SISTEMA%20DE%20CUSTEIO%20DE%20PRODU%C3%87%C3%83O%20E%20PRODUTOS.html#mdf" class="sidebar-link block py-2 px-4 transition-colors">Custeio de Produção</a></li>
@@ -218,7 +232,7 @@
           </svg>
         </button>
       </div>
-      <ul id="menuMarketing" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
+      <ul id="menuMarketing" class="submenu pl-8 space-y-1 overflow-hidden transition-all duração-300" style="max-height:0;">
         <li><a href="promocoes-shopee.html" class="sidebar-link block py-2 px-4 transition-colors">Promoções Shopee</a></li>
         <li><a href="ads.html" class="sidebar-link block py-2 px-4 transition-colors">Shopee Ads</a></li>
         <li><a href="ads-lista.html" class="sidebar-link block py-2 px-4 transition-colors">Anúncios Salvos</a></li>
@@ -230,7 +244,7 @@
         <a href="anuncios-tabs/cadastro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-anuncios" data-perfil="usuario,gestor,mentor">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
             <path stroke-linecap="round" stroke-linejoin="round" d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46"/>
-        </svg>
+          </svg>
           <span class="link-text">Anúncios</span>
         </a>
         <button class="submenu-toggle p-2" onclick="toggleMenu('menuAnuncios', this)">
@@ -239,7 +253,7 @@
           </svg>
         </button>
       </div>
-      <ul id="menuAnuncios" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
+      <ul id="menuAnuncios" class="submenu pl-8 space-y-1 overflow-hidden transition-all duração-300" style="max-height:0;">
         <li><a href="anuncios-tabs/cadastro.html" class="sidebar-link block py-2 px-4 transition-colors">Cadastro / Atualização</a></li>
         <li><a href="anuncios-tabs/anuncios.html" class="sidebar-link block py-2 px-4 transition-colors">Anúncios</a></li>
         <li><a href="anuncios-tabs/analise.html" class="sidebar-link block py-2 px-4 transition-colors">Análise IA</a></li>
@@ -254,7 +268,7 @@
         <a href="expedicao.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-expedicao" data-perfil="usuario,gestor,mentor">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
             <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 01-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 00-3.213-9.193 2.056 2.056 0 00-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 00-10.026 0 1.106 1.106 0 00-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12"/>
-        </svg>
+          </svg>
           <span class="link-text">Expedição</span>
         </a>
         <button class="submenu-toggle p-2" onclick="toggleMenu('menuExpedicao', this)">
@@ -263,13 +277,11 @@
           </svg>
         </button>
       </div>
-      <ul id="menuExpedicao" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-        <li><a href="relatorios.html" class="sidebar-link block py-2 px-4 transition-colors">Relatórios</a></li>
-        <li><a href="etiquetas-ocr.html" class="sidebar-link block py-2 px-4 transition-colors">Etiquetas OCR</a></li>
-        <li><a href="expedicao-historico.html" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a></li>
+      <ul id="menuExpedicao" class="submenu pl-8 space-y-1 overflow-hidden transition-all duração-300" style="max-height:0;">
         <li><a href="atualizacoes-dia.html" class="sidebar-link block py-2 px-4 transition-colors">Atualizações do Dia</a></li>
-        <li><a href="zpl-import.html" class="sidebar-link block py-2 px-4 transition-colors">ZPL Import</a></li>
         <li><a href="configuracao-expedicao.html" class="sidebar-link block py-2 px-4 transition-colors">Configuração Expedição</a></li>
+        <li><a href="relatorios.html" class="sidebar-link block py-2 px-4 transition-colors">Relatórios</a></li>
+        <li><a href="expedicao-historico.html" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a></li>
       </ul>
     </li>
     <li>
@@ -286,8 +298,54 @@
           </svg>
         </button>
       </div>
-      <ul id="menuGestaoContas" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
+      <ul id="menuGestaoContas" class="submenu pl-8 space-y-1 overflow-hidden transition-all duração-300" style="max-height:0;">
         <li><a href="pdf-x-excel.html" class="sidebar-link block py-2 px-4 transition-colors">PDF X Excel</a></li>
+        <li><a href="gestao-contas.html" class="sidebar-link block py-2 px-4 transition-colors">Configurações</a></li>
+      </ul>
+    </li>
+    <li>
+      <div class="sidebar-item flex items-center justify-between">
+        <a href="problemas.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-acompanhamento" data-perfil="usuario,gestor,mentor,responsavel,gestor financeiro">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m0 3.75h.008v.008H12v-.008ZM21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
+          </svg>
+          <span class="link-text">Acompanhamento</span>
+        </a>
+        <button class="submenu-toggle p-2" onclick="toggleMenu('menuAcompanhamento', this)">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
+          </svg>
+        </button>
+      </div>
+      <ul id="menuAcompanhamento" class="submenu pl-8 space-y-1 overflow-hidden transition-all duração-300" style="max-height:0;">
+        <li><a href="problemas.html" class="sidebar-link block py-2 px-4 transition-colors">Problemas</a></li>
+        <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=previsao" class="sidebar-link block py-2 px-4 transition-colors">Previsão</a></li>
+        <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar" class="sidebar-link block py-2 px-4 transition-colors">Conferir Sobras</a></li>
+        <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=sobras" class="sidebar-link block py-2 px-4 transition-colors">Sobras</a></li>
+        <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a></li>
+      </ul>
+    </li>
+    <li>
+      <div class="sidebar-item flex items-center justify-between">
+        <a href="Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=produtos" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-outros" data-perfil="usuario,gestor,mentor">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/>
+          </svg>
+          <span class="link-text">Outros</span>
+        </a>
+        <button class="submenu-toggle p-2" onclick="toggleMenu('menuOutros', this)">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
+          </svg>
+        </button>
+      </div>
+      <ul id="menuOutros" class="submenu pl-8 space-y-1 overflow-hidden transition-all duração-300" style="max-height:0;">
+        <li><a href="Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=produtos" class="sidebar-link block py-2 px-4 transition-colors">Produtos</a></li>
+        <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=metas" class="sidebar-link block py-2 px-4 transition-colors">Cadastro de Sobra</a></li>
+        <li><a href="pedidos-bling.html" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Bling</a></li>
+        <li><a href="pedidos-tiny.html" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Tiny</a></li>
+        <li><a href="pedidos-shopee.html" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Shopee</a></li>
+        <li><a href="https://matheus-35023.web.app" class="sidebar-link block py-2 px-4 transition-colors" target="_blank">Tiny</a></li>
       </ul>
     </li>
     <li>
@@ -305,27 +363,20 @@
           </svg>
         </button>
       </div>
-      <ul id="menuConfiguracoes" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-        <li><a href="Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=produtos" class="sidebar-link block py-2 px-4 transition-colors">Produtos</a></li>
-        <li><a href="Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link block py-2 px-4 transition-colors">Dashboard</a></li>
-        <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=graficos" class="sidebar-link block py-2 px-4 transition-colors">Gráficos</a></li>
-        <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=metas" class="sidebar-link block py-2 px-4 transition-colors">Cadastro de Sobra</a></li>
-        <li><a href="pedidos-bling.html" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Bling</a></li>
-        <li><a href="pedidos-shopee.html" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Shopee</a></li>
-        <li><a href="https://matheus-35023.web.app" class="sidebar-link block py-2 px-4 transition-colors" target="_blank">Tiny</a></li>
-        <li><a href="Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=configuracoes" class="sidebar-link block py-2 px-4 transition-colors">Configurações</a></li>
+      <ul id="menuConfiguracoes" class="submenu pl-8 space-y-1 overflow-hidden transition-all duração-300" style="max-height:0;">
         <li><a href="painel-usuarios.html" class="sidebar-link block py-2 px-4 transition-colors">Painel de Usuários</a></li>
         <li><a href="configuracao-perfil.html" class="sidebar-link block py-2 px-4 transition-colors">Configuração de Perfil</a></li>
         <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a></li>
         <li><a href="email-expedicao.html" class="sidebar-link block py-2 px-4 transition-colors">E-mail de Expedição</a></li>
+        <li><a href="manual.html" target="_blank" class="sidebar-link block py-2 px-4 transition-colors">Manual</a></li>
       </ul>
     </li>
     <li>
-      <a href="manual.html" target="_blank" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-manual" data-perfil="usuario,gestor,mentor">
+      <a href="comunicacao.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-comunicacao" data-perfil="cliente,usuario,gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/>
+          <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m21.75 0-9.423 6.615a2.25 2.25 0 0 1-2.654 0L1.5 6.75" />
         </svg>
-        <span class="link-text">Manual</span>
+        <span class="link-text">Comunicação</span>
       </a>
     </li>
     <li>


### PR DESCRIPTION
## Summary
- Reordena itens do menu lateral para usuários
- Separa seções como Etiquetas, Acompanhamento e Outros
- Simplifica submenu de Expedição e agrupa opções de configuração

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c01d70ca1c832ab957be4413499460