### PR TITLE
fix: update Tesseract worker init

### DIFF
--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -322,15 +322,13 @@
   let _tessWorker = null;
   async function getTessWorker(){
     if (_tessWorker) return _tessWorker;
-    _tessWorker = await Tesseract.createWorker({
+    _tessWorker = await Tesseract.createWorker('eng', Tesseract.OEM.LSTM_ONLY, {
       // logger: m => console.log(m), // opcional
       // workerPath: '/tess/worker.min.js',
       // corePath: '/tess/tesseract-core.wasm.js',
       // langPath: '/tess/lang-data'
     });
-    await _tessWorker.load();
-    await _tessWorker.loadLanguage('eng');
-    await _tessWorker.initialize('eng');
+    // createWorker já carrega e inicializa o idioma informado
     return _tessWorker;
   }
   async function terminateTess(){


### PR DESCRIPTION
## Summary
- initialize Tesseract worker using v6 API to prevent runtime error when processing labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c01ed70994832a9e10daa22589f71c