### PR TITLE
Fix sidebar layout on problems page

### DIFF
--- a/problemas.html
+++ b/problemas.html
@@ -13,7 +13,8 @@
 <body class="min-h-screen bg-gradient-to-b from-slate-50 to-white text-slate-700">
   <div id="sidebar-container"></div>
   <div id="navbar-container"></div>
-  <div class="main-content max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
+  <div class="main-content px-4 sm:px-6 lg:px-8 py-6">
+    <div class="max-w-7xl mx-auto space-y-6">
     <header>
       <h1 class="text-2xl font-semibold text-slate-700">Problemas</h1>
       <p class="mt-1 text-sm text-slate-500">Registre e acompanhe reembolsos e peças faltantes</p>
@@ -168,6 +169,7 @@
           <tbody id="pecasTableBody" class="divide-y divide-slate-100"></tbody>
         </table>
       </div>
+    </div>
     </div>
   </div>
   <script type="module" src="firebase-config.js"></script>


### PR DESCRIPTION
## Summary
- prevent sidebar from overlapping content on problemas page by restructuring main content wrapper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c026298dc0832a9e4b8a4dc648a8a0