### PR TITLE
Render checklist items as native ZPL text

### DIFF
--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -386,15 +386,13 @@
     const originalContent = sanitizeZpl(originalLabelZpl);
     let y = startY; let list='';
     for(const it of items){
-      list += `^FO50,${y}^ABN,${fontH},${fontW}^FDSKU: ${it.sku}^FS`;
-      y += fontH + 6;
-      list += `^FO50,${y}^ABN,${fontH},${fontW}^FDQtd: ${it.quantidade}^FS`;
+      list += `^FO50,${y}^A0N,${fontH},${fontW}^FDSKU: ${it.sku} Qtd: ${it.quantidade}^FS`;
       y += step;
     }
     const extraDots = Math.max(0, y - inchesToDots(heightIn, dpmm) + 80);
     const totalDots = inchesToDots(heightIn, dpmm) + extraDots;
     const numberY = totalDots - 48;
-    const numberTag = labelNumber? `^FO50,${numberY}^ABN,22,22^FD${labelNumber}^FS` : '';
+    const numberTag = labelNumber? `^FO50,${numberY}^A0N,22,22^FD${labelNumber}^FS` : '';
     return `^XA^LL${totalDots}^LH0,0${originalContent}${list}${numberTag}^XZ`;
   }
 

--- a/zpl-import.html
+++ b/zpl-import.html
@@ -638,28 +638,27 @@ async function generateImageFromZpl(zplCode, dpmm, width, height) {
         function generateCombinedZPL(labelBlock, data, labelNumber) {
             let originalContent = labelBlock.replace(/\^XA|\^XZ/g, ''); 
             originalContent = originalContent.replace(/\^A0N,20,20/g, '^ABN,22,22'); 
-            const newContentStartX = 50; 
-            const newContentStartY = 1200; 
-            const fontH = 22; 
-            const fontW = 22; 
-            const lineStep = 30; 
+            const newContentStartX = 50;
+            const newContentStartY = 1200;
+            const fontH = 22;
+            const fontW = 22;
+            const lineStep = 34;
 
-            let newContentZPL = ''; 
-            if (data && data.length > 0) { 
-                data.forEach((item, index) => { 
-                    const y = newContentStartY + (index * (lineStep + fontH)); 
-                    const skuText = `^FO${newContentStartX},${y}^ABN,${fontH},${fontW}^FD SKU: ${item.sku} ^FS`; 
-                    const qtdText = `^FO${newContentStartX},${y + fontH + 5}^ABN,${fontH},${fontW}^FD Qtd: ${item.quantidade} ^FS`; 
-                    newContentZPL += `${skuText}${qtdText}`; 
-                }); 
-            } 
-            
-            const dpmm = 8; 
-            const originalHeightIn = 5.2; 
+            let newContentZPL = '';
+            if (data && data.length > 0) {
+                data.forEach((item, index) => {
+                    const y = newContentStartY + (index * lineStep);
+                    const line = `^FO${newContentStartX},${y}^A0N,${fontH},${fontW}^FDSKU: ${item.sku} Qtd: ${item.quantidade}^FS`;
+                    newContentZPL += line;
+                });
+            }
+
+            const dpmm = 8;
+            const originalHeightIn = 5.2;
             const totalPageHeightInches = calculateNewTotalHeight(originalHeightIn, data.length, dpmm);
             const totalPageHeightDots = Math.round(totalPageHeightInches * dpmm * 8);
             const numberY = totalPageHeightDots - 420;
-            const numberZpl = `^FO50,${numberY}^ABN,22,22^FD${labelNumber}^FS`;
+            const numberZpl = `^FO50,${numberY}^A0N,22,22^FD${labelNumber}^FS`;
 
             return `^XA^LL${totalPageHeightDots}^LH0,0${originalContent}${newContentZPL}${numberZpl}^XZ`;
         }


### PR DESCRIPTION
## Summary
- List checklist SKUs and quantities with `^A0N`/`^FD` commands in ZPL outputs
- Simplify label templates to avoid rasterized checklists and keep label numbers in native text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c02a1764e4832aaa07c574a8327100