### PR TITLE
Unify layout loader and navbar styling

### DIFF
--- a/comunicacao.html
+++ b/comunicacao.html
@@ -11,8 +11,7 @@
   <link rel="stylesheet" href="css/components.css">
 </head>
 <body class="bg-gray-100 text-gray-800">
-  <button class="mobile-menu-btn" aria-label="Abrir menu" aria-expanded="false">☰</button>
-  <div id="sidebar-container" class="-translate-x-full"></div>
+  <div id="sidebar-container"></div>
   <div id="navbar-container"></div>
 
   <main class="main-content p-4 space-y-4">
@@ -68,9 +67,9 @@
   </div>
 </template>
 
-  <script type="module" src="firebase-config.js"></script>
-  <script type="module" src="comunicacao.js"></script>
   <script>window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';</script>
   <script src="shared.js"></script>
+  <script type="module" src="firebase-config.js"></script>
+  <script type="module" src="comunicacao.js"></script>
 </body>
 </html>

--- a/financeiro-inicio.html
+++ b/financeiro-inicio.html
@@ -11,8 +11,7 @@
   <link rel="stylesheet" href="css/components.css" />
 </head>
 <body class="bg-gray-100 text-gray-800">
-  <button class="mobile-menu-btn" aria-label="Abrir menu" aria-expanded="false">☰</button>
-  <div id="sidebar-container" class="-translate-x-full"></div>
+  <div id="sidebar-container"></div>
   <div id="navbar-container"></div>
   <main class="main-content p-4 space-y-4">
     <h1 class="text-2xl font-bold">Área Financeira</h1>

--- a/financeiro.html
+++ b/financeiro.html
@@ -14,8 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="bg-gray-100 text-gray-800">
-  <button class="mobile-menu-btn" aria-label="Abrir menu" aria-expanded="false">☰</button>
-  <div id="sidebar-container" class="-translate-x-full"></div>
+  <div id="sidebar-container"></div>
   <div id="navbar-container"></div>
   <main class="main-content p-4 space-y-4">
     <div class="card p-4 flex flex-wrap items-center gap-4">
@@ -102,9 +101,9 @@
     </div>
     <div class="card-body space-y-2" id="faturamentoFeed"></div>
   </div>
-  <script type="module" src="firebase-config.js"></script>
-  <script type="module" src="financeiro.js"></script>
   <script>window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';</script>
   <script src="shared.js"></script>
+  <script type="module" src="firebase-config.js"></script>
+  <script type="module" src="financeiro.js"></script>
   </body>
 </html>

--- a/mentoria.html
+++ b/mentoria.html
@@ -14,30 +14,11 @@
   <!-- Seus estilos -->
   <link rel="stylesheet" href="css/styles.css?v=20240826">
   <link rel="stylesheet" href="css/components.css">
-
-  <!-- Layout padrão para TODAS as páginas -->
-  <style>
-    :root { --sbw: 256px; } /* largura do sidebar */
-    @media (min-width:1024px){ .main-content { margin-left: var(--sbw); } } /* empurra o conteúdo no desktop */
-    .mobile-menu-btn{ position:fixed; left:12px; top:12px; z-index:50; }
-  </style>
 </head>
 <body class="bg-gray-100 text-gray-800">
 
-  <!-- Botão mobile -->
-  <button class="mobile-menu-btn lg:hidden bg-white rounded-md px-3 py-2 shadow"
-          onclick="toggleSidebar()" aria-label="Abrir menu" aria-expanded="false">☰</button>
-
-  <!-- SIDEBAR fixo no desktop / offcanvas no mobile -->
-  <aside id="sidebar-container"
-         class="fixed inset-y-0 left-0 w-64 max-w-[80vw] bg-purple-700 text-white overflow-auto z-40
-                transition-transform duration-200 ease-out
-                -translate-x-full lg:translate-x-0 shadow-lg">
-    <!-- parcial é injetado aqui -->
-  </aside>
-
-  <!-- NAVBAR -->
-  <div id="navbar-container" class="lg:pl-64"></div>
+  <div id="sidebar-container"></div>
+  <div id="navbar-container"></div>
 
   <!-- CONTEÚDO -->
   <main class="main-content p-4 space-y-4">

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,11 +1,11 @@
-<div class="navbar h-16 px-4 md:px-6 flex items-center justify-between bg-white border-b border-neutral-200/70 shadow-sm sticky top-0 z-30">
+<div class="navbar h-16 px-4 md:px-6 flex items-center justify-between">
   <div class="flex items-center gap-4">
     <button class="mobile-menu-btn hamburger menu-item" aria-label="Abrir menu" aria-expanded="false">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
         <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5" />
       </svg>
     </button>
-    <h1 class="text-lg md:text-xl font-semibold text-gray-900">Dashboard</h1>
+    <h1 class="text-lg md:text-xl font-semibold">Dashboard</h1>
     <div class="hidden md:block ml-4">
       <label class="relative block">
         <span class="sr-only">Buscar</span>

--- a/public/shared.js
+++ b/public/shared.js
@@ -4,64 +4,50 @@
     var scripts = document.getElementsByTagName('script');
     return scripts[scripts.length - 1];
   })();
-  
-  // Corrigido para apontar para a raiz do repositório
   var BASE_PATH = '';
   if (currentScript && currentScript.src) {
-    // Remove 'public/' do caminho para acessar os partials na raiz
-    var scriptPath = currentScript.src;
-    if (scriptPath.includes('/public/')) {
-      BASE_PATH = scriptPath.split('/public/')[0] + '/';
-    } else {
-      BASE_PATH = scriptPath.split('/').slice(0, -1).join('/') + '/';
-    }
+    BASE_PATH = currentScript.src.split('/').slice(0, -1).join('/') + '/';
   }
-  
-  console.log('BASE_PATH configurado:', BASE_PATH);
 
-  // Flags globais para evitar carregamento duplicado
-  if (!window.sharedComponentsState) {
-    window.sharedComponentsState = {
-      tailwindLoaded: false,
-      sidebarLoaded: false,
-      navbarLoaded: false,
-      authModalsLoaded: false,
-      darkModeInitialized: false
-    };
+  // Support repositories that serve pages from a subdirectory (e.g. GitHub Pages "public" folder)
+  // ROOT_PATH points to the repo root while BASE_PATH remains the current script folder
+  var ROOT_PATH = BASE_PATH.replace(/public\/$/, '');
+  window.ROOT_PATH = ROOT_PATH;
+
+  function fetchWithFallback(urls, idx) {
+    idx = idx || 0;
+    if (idx >= urls.length) return Promise.reject(new Error('Not found'));
+    return fetch(urls[idx]).then(function(res) {
+      if (!res.ok) throw new Error('Not found');
+      return res.text();
+    }).catch(function() {
+      return fetchWithFallback(urls, idx + 1);
+    });
   }
 
   function loadTailwind() {
     return new Promise(function(resolve, reject) {
-      if (window.sharedComponentsState.tailwindLoaded || document.querySelector('link[href*="tailwind"]')) { 
-        resolve(); 
-        return; 
-      }
-      
+      if (document.querySelector('link[href*="tailwind"]')) { resolve(); return; }
       var link = document.createElement('link');
       link.rel = 'stylesheet';
       link.href = 'https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css';
-      link.onload = function() {
-        window.sharedComponentsState.tailwindLoaded = true;
-        resolve();
-      };
+      link.onload = resolve;
       link.onerror = reject;
       document.head.appendChild(link);
     });
   }
   
-  // Toggle submenu visibility with smooth slide animation
-  window.toggleMenu = function(menuId) {
+  // Toggle submenu visibility using max-height for smooth transitions
+  window.toggleMenu = function(menuId, btn) {
     var el = document.getElementById(menuId);
     if (!el) return;
-    if (el.classList.contains('max-h-0')) {
-      el.classList.remove('max-h-0');
-      el.classList.add('max-h-screen');
-    } else {
-      el.classList.add('max-h-0');
-      el.classList.remove('max-h-screen');
+    var isOpen = el.style.maxHeight && el.style.maxHeight !== '0px';
+    el.style.maxHeight = isOpen ? '0px' : el.scrollHeight + 'px';
+    if (btn) {
+      btn.classList.toggle('open', !isOpen);
     }
   };
-  
+
   // Toggle visibility of the Importar Produtos card on the precificação page
   window.toggleImportCard = function() {
     var card = document.getElementById('importarProdutosCard');
@@ -74,7 +60,6 @@
       btn.textContent = 'Esconder Importar Produtos';
     }
   };
-  
   // Load Intro.js library if not already loaded
   function loadIntroJs() {
     return new Promise(function(resolve, reject) {
@@ -93,117 +78,105 @@
       document.head.appendChild(script);
     });
   }
-
-  // Load sidebar HTML into placeholder
+// Load sidebar HTML into placeholder
   window.loadSidebar = function(containerId, sidebarPath) {
-    if (window.sharedComponentsState.sidebarLoaded) {
-      console.log('Sidebar já carregado, ignorando...');
-      return Promise.resolve();
-    }
-    
     containerId = containerId || 'sidebar-container';
     sidebarPath = sidebarPath || 'partials/sidebar.html';
-    
-    console.log('Carregando sidebar...');
-    console.log('Caminho do sidebar:', BASE_PATH + sidebarPath);
-    
-    return fetch(BASE_PATH + sidebarPath)
-      .then(function(res) { 
-        if (!res.ok) {
-          throw new Error(`HTTP ${res.status}: ${res.statusText}`);
-        }
-        return res.text(); 
-      })
+
+    var paths = [];
+    if (/^https?:\/\//.test(sidebarPath)) {
+      paths = [sidebarPath];
+    } else if (sidebarPath.startsWith('/')) {
+      var rel = sidebarPath.replace(/^\//, '');
+      paths = [
+        ROOT_PATH + rel,
+        BASE_PATH + rel,
+        sidebarPath
+      ];
+    } else {
+      paths = [
+        ROOT_PATH + sidebarPath,
+        BASE_PATH + sidebarPath,
+        ROOT_PATH + 'partials/sidebar.html',
+        BASE_PATH + 'partials/sidebar.html',
+        '/partials/sidebar.html'
+      ];
+    }
+
+    return fetchWithFallback(paths)
       .then(function(html) {
         var container = document.getElementById(containerId);
         if (container) {
           container.innerHTML = html;
-          window.sharedComponentsState.sidebarLoaded = true;
-          console.log('Sidebar carregado com sucesso');
           var event = new CustomEvent('sidebarLoaded', { detail: { containerId: containerId } });
           document.dispatchEvent(event);
         }
       })
-      .catch(function(error) {
-        console.error('Erro ao carregar sidebar:', error);
+      .catch(function(err) {
+        console.error('Erro ao carregar sidebar:', err);
       });
   };
-
-  // Load navbar HTML into placeholder
-  window.loadNavbar = function(containerId) {
-    if (window.sharedComponentsState.navbarLoaded) {
-      console.log('Navbar já carregado, ignorando...');
-      return Promise.resolve();
-    }
-    
+// Load navbar HTML into placeholder
+  window.loadNavbar = function(containerId, navbarPath) {
     containerId = containerId || 'navbar-container';
-    
-    console.log('Carregando navbar...');
-    console.log('Caminho do navbar:', BASE_PATH + 'partials/navbar.html');
-    
-    return fetch(BASE_PATH + 'partials/navbar.html')
-      .then(function(res) { 
-        if (!res.ok) {
-          throw new Error(`HTTP ${res.status}: ${res.statusText}`);
-        }
-        return res.text(); 
-      })
+    navbarPath = navbarPath || 'partials/navbar.html';
+
+    var paths = [];
+    if (/^https?:\/\//.test(navbarPath)) {
+      paths = [navbarPath];
+    } else if (navbarPath.startsWith('/')) {
+      var rel = navbarPath.replace(/^\//, '');
+      paths = [
+        ROOT_PATH + rel,
+        BASE_PATH + rel,
+        navbarPath
+      ];
+    } else {
+      paths = [
+        ROOT_PATH + navbarPath,
+        BASE_PATH + navbarPath,
+        ROOT_PATH + 'partials/navbar.html',
+        BASE_PATH + 'partials/navbar.html',
+        '/partials/navbar.html'
+      ];
+    }
+
+    return fetchWithFallback(paths)
       .then(function(html) {
         var container = document.getElementById(containerId);
         if (container) {
           container.innerHTML = html;
-          window.sharedComponentsState.navbarLoaded = true;
-          console.log('Navbar carregado com sucesso');
           var event = new CustomEvent('navbarLoaded', { detail: { containerId: containerId } });
           document.dispatchEvent(event);
         }
-      })
-      .catch(function(error) {
-        console.error('Erro ao carregar navbar:', error);
       });
   };
   
   // Load authentication modals into placeholder
   window.loadAuthModals = function(containerId) {
-    if (window.sharedComponentsState.authModalsLoaded) {
-      console.log('Modais de auth já carregados, ignorando...');
-      return Promise.resolve();
-    }
-    
     containerId = containerId || 'auth-modals-container';
-    
-    console.log('Carregando modais de autenticação...');
-    
-    return fetch(BASE_PATH + 'partials/auth-modals.html')
-      .then(function(res) { return res.text(); })
+    var paths = [
+      ROOT_PATH + 'partials/auth-modals.html',
+      BASE_PATH + 'partials/auth-modals.html',
+      '/partials/auth-modals.html'
+    ];
+    return fetchWithFallback(paths)
       .then(function(html) {
         var container = document.getElementById(containerId);
         if (container) {
           container.innerHTML = html;
-          window.sharedComponentsState.authModalsLoaded = true;
-          console.log('Modais de autenticação carregados com sucesso');
         }
-      })
-      .catch(function(error) {
-        console.error('Erro ao carregar modais de auth:', error);
       });
   };
-
   // Initialize dark mode handling
-  window.initDarkMode = function(toggleId, darkClass) {
-    if (window.sharedComponentsState.darkModeInitialized) {
-      console.log('Dark mode já inicializado, ignorando...');
-      return;
-    }
-    
-    toggleId = toggleId || 'darkModeToggle';
-    darkClass = darkClass || 'dark';
+    window.initDarkMode = function(toggleId, darkClass) {
+      toggleId = toggleId || 'darkModeToggle';
+      darkClass = darkClass || 'dark-mode';
 
     var toggle = document.getElementById(toggleId);
     var savedTheme = localStorage.getItem('theme');
-    var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
 
-    if (savedTheme === 'dark' || (!savedTheme && prefersDark)) {
+    if (savedTheme === 'dark') {
       document.body.classList.add(darkClass);
       if (toggle) toggle.checked = true;
     }
@@ -219,12 +192,8 @@
         }
       });
     }
-    
-    window.sharedComponentsState.darkModeInitialized = true;
-    console.log('Dark mode inicializado');
   };
-
-  // Check elements for text color matching background color
+// Check elements for text color matching background color
   window.checkColorContrast = function() {
     var all = document.querySelectorAll('*');
     all.forEach(function(el) {
@@ -241,7 +210,7 @@
   window.startSidebarTour = function(force) {
     if (typeof introJs === 'undefined') return;
     if (!force && localStorage.getItem('sidebarTourSeen') === 'true') return;
-    var intro = introJs();
+    var intro = introJs.tour();
     intro.setOptions({
       steps: [
         { element: '#menu-inicio', intro: 'Voltar para a página inicial.' },
@@ -263,100 +232,411 @@
       .start();
   };
 
-  document.addEventListener('DOMContentLoaded', function () {
-    console.log('DOM carregado, iniciando carregamento de componentes...');
-    
-    // ✅ PRIMEIRO: Carrega os modais de login para evitar redirecionamento
-    // Isso é crítico para resolver o problema de "piscar"
-    console.log('Carregando modais de autenticação primeiro...');
-    window.loadAuthModals().then(() => {
-      console.log('Modais carregados, agora carregando outros componentes...');
-      
-      // SEGUNDO: Carrega outros componentes
-      loadTailwind().then(function () {
-        console.log('Tailwind carregado, carregando sidebar e navbar...');
-        
-        // Carrega sidebar e navbar em paralelo
-        Promise.all([
-          window.loadSidebar(null, window.CUSTOM_SIDEBAR_PATH),
-          window.loadNavbar()
-        ]).then(function () {
-          console.log('Sidebar e navbar carregados, inicializando dark mode...');
-          window.initDarkMode();
-          
-          // TERCEIRO: Sinaliza que tudo está pronto
-          console.log('Todos os componentes carregados com sucesso!');
-          window.dispatchEvent(new CustomEvent('allComponentsLoaded'));
-        });
-      });
-    }).catch(error => {
-      console.error('Erro ao carregar modais:', error);
-    });
-
-    window.checkColorContrast();
-  });
-
-  // Controle de sidebar para mobile
-  function toggleSidebar() {
-    var container = document.getElementById('sidebar-container');
-    if (!container) return;
-    var overlay = document.getElementById('sidebar-overlay');
-    if (!overlay) {
-      overlay = document.createElement('div');
-      overlay.id = 'sidebar-overlay';
-      document.body.appendChild(overlay);
-      overlay.addEventListener('click', toggleSidebar);
-    }
-    var isOpen = container.classList.toggle('open');
-    overlay.classList.toggle('show', isOpen);
-    document.body.style.overflow = isOpen ? 'hidden' : '';
-  }
-  window.toggleSidebar = toggleSidebar;
-
-  function setupMobileSidebar() {
-    var container = document.getElementById('sidebar-container');
-    var btn = document.querySelector('.mobile-menu-btn');
-    if (btn && !btn.dataset.sidebarReady) {
-      btn.addEventListener('click', toggleSidebar);
-      btn.dataset.sidebarReady = 'true';
-    }
-    if (container) {
-      container.querySelectorAll('a').forEach(function(a){
-        a.addEventListener('click', function(){
-          if (window.innerWidth <= 768) toggleSidebar();
-        });
-      });
-      if (window.innerWidth > 768) {
-        container.classList.add('open');
-      }
-    }
-  }
-
-  document.addEventListener('navbarLoaded', setupMobileSidebar);
-  document.addEventListener('sidebarLoaded', function () {
-    setupMobileSidebar();
-    loadIntroJs().then(function () {
-      var btn = document.getElementById('startSidebarTourBtn');
-      if (btn) {
-        btn.addEventListener('click', function () { window.startSidebarTour(true); });
-      }
-      window.startSidebarTour(false);
-    });
-  });
-
-  window.addEventListener('resize', function () {
-    var container = document.getElementById('sidebar-container');
-    var overlay = document.getElementById('sidebar-overlay');
-    if (!container || !overlay) return;
-    if (window.innerWidth > 768) {
-      container.classList.add('open');
-      overlay.classList.remove('show');
-      document.body.style.overflow = '';
+function initShared() {
+  function start() {
+    if (window.ensureLayout) {
+      // ensureLayout will initialize dark mode after loading partials
+      window.ensureLayout();
     } else {
-      container.classList.remove('open');
-      overlay.classList.remove('show');
-      document.body.style.overflow = '';
+      window.initDarkMode();
     }
+  }
+
+  loadTailwind().then(start).catch(function () {
+    start();
   });
+
+  // ✅ Só carrega os modais de login se estiver na index.html
+  const pathname = window.location.pathname.toLowerCase();
+  const filename = pathname.substring(pathname.lastIndexOf('/') + 1);
+  if (filename === '' || filename === 'index.html') {
+    window.loadAuthModals();
+  }
+
+  window.checkColorContrast();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initShared);
+} else {
+  initShared();
+}
+
+document.addEventListener('sidebarLoaded', function () {
+  document.body.classList.add('has-sidebar');
+  document.querySelectorAll('#sidebar .submenu').forEach(function(el){
+    el.style.maxHeight = '0px';
+  });
+  loadIntroJs().then(function () {
+    var btn = document.getElementById('startSidebarTourBtn');
+    if (btn) {
+      btn.addEventListener('click', function () { window.startSidebarTour(true); });
+    }
+    window.startSidebarTour(false);
+  });
+});
 
 })();
+
+/** === LAYOUT PERSISTENTE DO SIDEBAR/NAV === **/
+window.CUSTOM_SIDEBAR_PATH = window.CUSTOM_SIDEBAR_PATH || 'partials/sidebar.html';
+window.CUSTOM_NAVBAR_PATH  = window.CUSTOM_NAVBAR_PATH  || 'partials/navbar.html';
+const PARTIALS_VERSION = '2025-08-25-02'; // mude quando atualizar parciais
+
+function toggleSidebar(){
+  const sb = document.getElementById('sidebar-container');
+  if (!sb) return;
+
+  let overlay = document.getElementById('sidebar-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'sidebar-overlay';
+    document.body.appendChild(overlay);
+    overlay.addEventListener('click', toggleSidebar);
+  }
+
+  const btn = document.querySelector('.mobile-menu-btn');
+  const isOpen = sb.classList.toggle('open');
+  overlay.classList.toggle('show', isOpen);
+  document.body.style.overflow = isOpen ? 'hidden' : '';
+  if (btn) btn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+}
+
+async function loadPartial(selector, path){
+  // cria o container se não existir (algumas telas substituem o body)
+  let el = document.querySelector(selector);
+  const id = selector.replace('#', '');
+  if (!el) {
+    el = document.createElement(selector.startsWith('#') ? 'div' : 'aside');
+    el.id = id;
+    if (id === 'sidebar-container') {
+      el.className = 'fixed inset-y-0 left-0 w-64 max-w-[80vw] overflow-auto z-40 transition-transform duration-200 ease-out shadow-lg';
+      document.body.prepend(el);
+      // garante margem do conteúdo no desktop
+      document.querySelector('.main-content')?.classList.add('lg:ml-64');
+    } else {
+      // navbar acima do main
+      document.body.insertBefore(el, document.querySelector('main') || null);
+    }
+  } else {
+    if (id === 'sidebar-container') {
+      el.classList.add('fixed','inset-y-0','left-0','w-64','max-w-[80vw]','overflow-auto','z-40','transition-transform','duration-200','ease-out','shadow-lg');
+      document.querySelector('.main-content')?.classList.add('lg:ml-64');
+    }
+  }
+
+  // sempre força rede p/ evitar cache velho do SW
+  const base = window.ROOT_PATH || `${location.origin}/`;
+  let url;
+  if (/^https?:\/\//.test(path)) {
+    url = path;
+  } else {
+    url = new URL(path.replace(/^\//, ''), base).toString();
+  }
+  url += (url.includes('?') ? '&' : '?') + 'v=' + PARTIALS_VERSION;
+
+  try {
+    const res = await fetch(url, { cache: 'no-store' });
+    if (!res.ok) throw new Error(`HTTP ${res.status} em ${url}`);
+    const html = await res.text();
+    el.innerHTML = html;
+
+    // reexecuta <script> internos do parcial
+    el.querySelectorAll('script').forEach(old=>{
+      const s = document.createElement('script');
+      s.type = old.type || 'text/javascript';
+      if (old.src) {
+        const srcUrl = new URL(old.getAttribute('src'), url).toString();
+        s.src = srcUrl + (srcUrl.includes('?') ? '&' : '?') + 'v=' + PARTIALS_VERSION;
+      } else {
+        s.text = old.textContent || '';
+      }
+      old.replaceWith(s);
+    });
+
+    // dispara eventos para compatibilidade
+    const evtName = selector === '#sidebar-container' ? 'sidebarLoaded' : selector === '#navbar-container' ? 'navbarLoaded' : null;
+    if (evtName) {
+      document.dispatchEvent(new CustomEvent(evtName, { detail: { selector } }));
+    }
+
+    // no desktop, sempre aberto
+    if (selector === '#sidebar-container' && matchMedia('(min-width:1024px)').matches) {
+      el.classList.add('open');
+      // limpa qualquer estado salvo que esconda
+      try { localStorage.removeItem('sidebarClosed'); } catch(e){}
+      document.cookie = 'sidebarClosed=; Max-Age=0; path=/';
+    }
+  } catch (err) {
+    console.error('[partials] falha', path, err);
+    el.innerHTML = `<div class="p-3 bg-red-50 text-red-700 text-sm rounded">Erro ao carregar <code>${path}</code>.</div>`;
+  }
+}
+
+async function ensureLayout(){
+  await Promise.all([
+    loadPartial('#sidebar-container', window.CUSTOM_SIDEBAR_PATH),
+    loadPartial('#navbar-container',  window.CUSTOM_NAVBAR_PATH),
+  ]);
+  // Reapply dark mode listeners after layout reloads
+  if (typeof window.initDarkMode === 'function') {
+    window.initDarkMode();
+  }
+}
+
+// roda em várias fases para cobrir login/redirect/back-forward-cache
+['DOMContentLoaded','load','pageshow','focus'].forEach(evt=>{
+  window.addEventListener(evt, ensureLayout, { once: false });
+});
+
+// se algum script remover os containers, recolocamos
+const mo = new MutationObserver(() => {
+  if (!document.getElementById('sidebar-container')) ensureLayout();
+  if (!document.getElementById('navbar-container'))  ensureLayout();
+});
+mo.observe(document.documentElement, { childList: true, subtree: true });
+
+// ao redimensionar para desktop, garante aberto
+window.addEventListener('resize', ()=>{
+  const sb = document.getElementById('sidebar-container');
+  const overlay = document.getElementById('sidebar-overlay');
+  if (sb && matchMedia('(min-width:1024px)').matches) {
+    sb.classList.add('open');
+    overlay?.classList.remove('show');
+    document.body.style.overflow = '';
+  }
+});
+
+// expõe global
+window.toggleSidebar = window.toggleSidebar || toggleSidebar;
+window.ensureLayout  = ensureLayout;
+
+function setupMobileSidebar() {
+  const container = document.getElementById('sidebar-container');
+  const btns = Array.from(document.querySelectorAll('.mobile-menu-btn'));
+  if (!container || !btns.length) return;
+
+  let overlay = document.getElementById('sidebar-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'sidebar-overlay';
+    document.body.appendChild(overlay);
+  }
+  overlay.classList.remove('show');
+
+  btns.forEach(btn => {
+    if (btn.dataset.sidebarReady) return;
+    btn.addEventListener('click', toggleSidebar, { once: false });
+    btn.dataset.sidebarReady = 'true';
+  });
+  if (!overlay.dataset.sidebarReady) {
+    overlay.addEventListener('click', toggleSidebar);
+    document.addEventListener('click', (e) => {
+      if (window.innerWidth > 768) return;
+      if (!container.contains(e.target) && !btns.some(b => b.contains(e.target))) {
+        container.classList.remove('open');
+        overlay.classList.remove('show');
+        document.body.style.overflow = '';
+        btns.forEach(b => b.setAttribute('aria-expanded', 'false'));
+      }
+    });
+    window.addEventListener('resize', () => {
+      if (window.innerWidth > 768) {
+        container.classList.add('open');
+        overlay.classList.remove('show');
+        document.body.style.overflow = '';
+      } else {
+        container.classList.remove('open');
+        overlay.classList.remove('show');
+        document.body.style.overflow = '';
+      }
+      btns.forEach(b => b.setAttribute('aria-expanded', 'false'));
+    });
+    overlay.dataset.sidebarReady = 'true';
+  }
+
+  container.querySelectorAll('a').forEach(a => a.addEventListener('click', () => {
+    if (window.innerWidth <= 768) toggleSidebar();
+  }));
+
+  if (window.innerWidth > 768) {
+    container.classList.add('open');
+  }
+}
+
+document.addEventListener('navbarLoaded', setupMobileSidebar);
+document.addEventListener('sidebarLoaded', setupMobileSidebar);
+document.addEventListener('DOMContentLoaded', setupMobileSidebar);
+
+document.addEventListener('navbarLoaded', () => {
+  const btn = document.getElementById('userMenuBtn');
+  const menu = document.getElementById('userMenu');
+  if (!btn || !menu) return;
+  btn.addEventListener('click', () => {
+    menu.classList.toggle('hidden');
+  });
+  document.addEventListener('click', (e) => {
+    if (!btn.contains(e.target) && !menu.contains(e.target)) {
+      menu.classList.add('hidden');
+    }
+  });
+});
+
+// Controle de visibilidade do sidebar baseado no perfil do usuário
+document.addEventListener('sidebarLoaded', async () => {
+  const sidebar = document.getElementById('sidebar');
+  if (!sidebar || sidebar.dataset.permsApplied) return;
+  sidebar.dataset.permsApplied = 'true';
+
+  const [
+    { initializeApp, getApps },
+    { getAuth, onAuthStateChanged },
+    { getFirestore, doc, getDoc },
+    { firebaseConfig }
+  ] = await Promise.all([
+    import('https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js'),
+    import('https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js'),
+    import('https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js'),
+    import('./firebase-config.js')
+  ]);
+
+  const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+  const db = getFirestore(app);
+
+  const ADMIN_GESTOR_MENU_IDS = [
+    'menu-gestao',
+    'menu-financeiro',
+    'menu-atualizacoes',
+    'menu-comunicacao',
+    'menu-saques',
+    'menu-acompanhamento-gestor',
+    'menu-acompanhamento-tiny',
+    'menu-acompanhamento-vendas',
+    'menu-mentoria',
+    'menu-perfil-mentorado',
+    'menu-equipes',
+    'menu-produtos',
+    'menu-sku-associado',
+    'menu-produtos-vendidos',
+    'menu-desempenho',
+  ];
+
+  const CLIENTE_HIDDEN_MENU_IDS = ADMIN_GESTOR_MENU_IDS.filter(id => id !== 'menu-comunicacao');
+
+  function showOnly(ids) {
+    document.querySelectorAll('#sidebar .sidebar-link').forEach(a => {
+      const li = a.closest('li') || a.parentElement;
+      if (li) li.style.display = 'none';
+    });
+    ids.forEach(id => {
+      const el = document.getElementById(id);
+      const li = el && (el.closest('li') || el.parentElement);
+      if (li) li.style.display = '';
+    });
+  }
+
+  function hideIds(ids) {
+    ids.forEach(id => {
+      const el = document.getElementById(id);
+      const li = el && (el.closest('li') || el.parentElement);
+      if (li) li.style.display = 'none';
+    });
+  }
+
+  function buildGestorSidebarLayout() {
+    const menu = document.querySelector('#sidebar .sidebar-menu');
+    if (!menu) return;
+
+    const getLi = id => {
+      const el = document.getElementById(id);
+      return el ? el.closest('li') : null;
+    };
+
+    const atualizacoes = getLi('menu-atualizacoes');
+    const financeiro = getLi('menu-financeiro');
+    const saques = getLi('menu-saques');
+    const tiny = getLi('menu-acompanhamento-tiny');
+    const gestao = getLi('menu-gestao');
+    const acompGestor = getLi('menu-acompanhamento-gestor');
+    const acompVendas = getLi('menu-acompanhamento-vendas');
+    const produtosVendidos = getLi('menu-produtos-vendidos');
+    const mentoria = getLi('menu-mentoria');
+    const perfilMentorado = getLi('menu-perfil-mentorado');
+    const produtos = getLi('menu-produtos');
+    const skuAssociado = getLi('menu-sku-associado');
+    const comunicacao = getLi('menu-comunicacao');
+    const equipes = getLi('menu-equipes');
+    const desempenho = getLi('menu-desempenho');
+
+    function createGroup(mainLi, submenuId, items) {
+      if (!mainLi) return null;
+      const a = mainLi.querySelector('a.sidebar-link');
+      if (!a) return null;
+
+      const div = document.createElement('div');
+      div.className = 'sidebar-item flex items-center justify-between';
+      div.appendChild(a);
+
+      const btn = document.createElement('button');
+      btn.className = 'submenu-toggle p-2';
+      btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>';
+      btn.addEventListener('click', () => toggleMenu(submenuId, btn));
+      div.appendChild(btn);
+
+      const ul = document.createElement('ul');
+      ul.id = submenuId;
+      ul.className = 'submenu space-y-1 overflow-hidden transition-all duration-300';
+      ul.style.maxHeight = '0';
+      items.forEach(item => { if (item) ul.appendChild(item); });
+
+      mainLi.innerHTML = '';
+      mainLi.appendChild(div);
+      mainLi.appendChild(ul);
+      return mainLi;
+    }
+
+    const financeiroGroup = createGroup(financeiro, 'menuFinanceiro', [saques, tiny]);
+    const gestaoGroup = createGroup(gestao, 'menuGestao', [acompGestor, acompVendas, produtosVendidos, mentoria, perfilMentorado, produtos, skuAssociado]);
+    const comunicacaoGroup = createGroup(comunicacao, 'menuComunicacao', [equipes]);
+
+    menu.innerHTML = '';
+    [atualizacoes, financeiroGroup, gestaoGroup, comunicacaoGroup, desempenho].forEach(li => {
+      if (li) {
+        li.style.display = '';
+        menu.appendChild(li);
+      }
+    });
+  }
+
+  async function applySidebarPermissions(uid) {
+    try {
+      const snap = await getDoc(doc(db, 'usuarios', uid));
+      const perfil = (snap.exists() && String(snap.data().perfil || '') || '').trim().toLowerCase();
+
+      const isADM = ['adm', 'admin', 'administrador'].includes(perfil);
+      const isGestor = ['gestor', 'mentor', 'responsavel', 'gestor financeiro', 'responsavel financeiro'].includes(perfil);
+      const isCliente = ['cliente', 'user', 'usuario'].includes(perfil);
+
+      if (isADM || isGestor) {
+        showOnly(ADMIN_GESTOR_MENU_IDS);
+        if (isGestor && !["gestor","responsavel financeiro"].includes(perfil)) {
+          hideIds(["menu-sku-associado"]);
+        }
+        buildGestorSidebarLayout();
+      } else if (isCliente) {
+        hideIds(CLIENTE_HIDDEN_MENU_IDS);
+        document.querySelectorAll('#sidebar .sidebar-link').forEach(a => {
+          const li = a.closest('li') || a.parentElement;
+          if (li && !CLIENTE_HIDDEN_MENU_IDS.includes(a.id)) li.style.display = '';
+        });
+      }
+    } catch (e) {
+      console.error('Erro ao aplicar permissões do sidebar:', e);
+    }
+  }
+
+  const auth = getAuth(app);
+  onAuthStateChanged(auth, user => {
+    if (user) applySidebarPermissions(user.uid);
+  });
+});

--- a/shared.js
+++ b/shared.js
@@ -310,7 +310,7 @@ async function loadPartial(selector, path){
     el = document.createElement(selector.startsWith('#') ? 'div' : 'aside');
     el.id = id;
     if (id === 'sidebar-container') {
-      el.className = 'fixed inset-y-0 left-0 w-64 max-w-[80vw] bg-purple-700 text-white overflow-auto z-40 transition-transform duration-200 ease-out shadow-lg';
+      el.className = 'fixed inset-y-0 left-0 w-64 max-w-[80vw] overflow-auto z-40 transition-transform duration-200 ease-out shadow-lg';
       document.body.prepend(el);
       // garante margem do conteúdo no desktop
       document.querySelector('.main-content')?.classList.add('lg:ml-64');
@@ -320,7 +320,7 @@ async function loadPartial(selector, path){
     }
   } else {
     if (id === 'sidebar-container') {
-      el.classList.add('fixed','inset-y-0','left-0','w-64','max-w-[80vw]','bg-purple-700','text-white','overflow-auto','z-40','transition-transform','duration-200','ease-out','shadow-lg');
+      el.classList.add('fixed','inset-y-0','left-0','w-64','max-w-[80vw]','overflow-auto','z-40','transition-transform','duration-200','ease-out','shadow-lg');
       document.querySelector('.main-content')?.classList.add('lg:ml-64');
     }
   }


### PR DESCRIPTION
## Summary
- Replace public/shared.js with the root loader, enabling ensureLayout, overlay handling and cache-busting via PARTIALS_VERSION
- Simplify navbar partial to rely on global .navbar styles
- Standardize sidebar/navbar containers and script order on individual pages

## Testing
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c02ac7b454832a9b2b36a115520b12