### PR TITLE
feat: use native ZPL text for checklists

### DIFF
--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -97,13 +97,12 @@
 
   </div>
 
-  <!-- Libs: PDF, Firebase (compat), Tesseract -->
+  <!-- Libs: PDF e Firebase (compat) -->
   <script src="https://unpkg.com/pdf-lib@1.4.0"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-storage-compat.js"></script>
-  <script src="https://unpkg.com/tesseract.js@v6.0.0/dist/tesseract.min.js"></script>
   <script type="module">
   import { firebaseConfig } from './firebase-config.js';
   // ===== Utilitários UI =====
@@ -310,44 +309,7 @@
     }
     return await res.blob();
   }
-  function binarizeBlob(blob, threshold=200){
-    return new Promise((resolve,reject)=>{
-      const img = new Image();
-      img.onload = ()=>{
-        const c=document.createElement('canvas'); c.width=img.naturalWidth; c.height=img.naturalHeight;
-        const ctx=c.getContext('2d'); ctx.drawImage(img,0,0);
-        const id=ctx.getImageData(0,0,c.width,c.height); const d=id.data;
-        for(let i=0;i<d.length;i+=4){ const lum=0.2126*d[i]+0.7152*d[i+1]+0.0722*d[i+2]; const v=lum<threshold?0:255; d[i]=d[i+1]=d[i+2]=v; }
-        ctx.putImageData(id,0,0); c.toBlob(resolve,'image/png');
-      };
-      img.onerror=reject; img.src=URL.createObjectURL(blob);
-    });
-  }
-  // --- Tesseract Worker Singleton ---
-  let _tessWorker = null;
-  async function getTessWorker(){
-    if (_tessWorker) return _tessWorker;
-    _tessWorker = await Tesseract.createWorker('eng', Tesseract.OEM.LSTM_ONLY, {
-      // logger: m => console.log(m), // opcional
-      // workerPath: '/tess/worker.min.js',
-      // corePath: '/tess/tesseract-core.wasm.js',
-      // langPath: '/tess/lang-data'
-    });
-    // createWorker já carrega e inicializa o idioma informado
-    return _tessWorker;
-  }
-  async function terminateTess(){
-    if(_tessWorker){
-      await _tessWorker.terminate();
-      _tessWorker = null;
-    }
-  }
-
-  async function ocrBlobToText(blob){
-    const worker = await getTessWorker();
-    const { data:{ text } } = await worker.recognize(blob);
-    return text||'';
-  }
+  // OCR helpers removidos - checklist deve vir em texto ^FD
   function parseItemsFromText(text){
     console.log('[parseItemsFromText] raw text:', text);
     const items=[]; const lines=(text||'').split(/\r?\n/).map(l=>l.trim()).filter(Boolean);
@@ -528,13 +490,9 @@
         const loja = detectLojaFromZpl(labelZpl);
         console.log('[btnProcessar] loja', loja);
 
-        // Extrair itens (primeiro tentando ^FD, depois OCR)
-        let text = extractFDText(checklistZpl);
-        if(!text || text.length<3){
-          const chkBlob = await renderZplToPngBlob(zplPrefix + checklistZpl, dpmm, widthIn, heightIn);
-          const bin = await binarizeBlob(chkBlob, 200);
-          text = await ocrBlobToText(bin);
-        }
+        // Extrair itens do checklist via comandos ^FD
+        const text = extractFDText(checklistZpl);
+        if(!text || text.length<3){ throw new Error(`Checklist #${idx} não contém texto ^FD válido.`); }
         console.log('[btnProcessar] checklist text:', text);
         let items = parseItemsFromText(text);
         console.log('[btnProcessar] parsed items:', items);


### PR DESCRIPTION
## Summary
- drop Tesseract OCR dependency for checklist import
- require checklist data via ^FD commands and build ZPL list directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c02f843194832aa38ce19d23c1e792