### PR TITLE
feat: support multiple tax calculations

### DIFF
--- a/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
+++ b/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
@@ -926,15 +926,20 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
 
       if (plataforma === 'shopee' && document.getElementById('shopee_duas_taxas')?.checked) {
         sistema.produtoEditando = null;
-        calcularComTaxa(plataforma, custo, produto, sku, 20, true);
-        calcularComTaxa(plataforma, custo, produto, sku, 14, true);
+        const calc20 = calcularComTaxa(plataforma, custo, produto, sku, 20, false, true);
+        const calc14 = calcularComTaxa(plataforma, custo, produto, sku, 14, false, true);
+        document.getElementById(`preco_${plataforma}`).value = calc20.precoMinimo;
+        document.getElementById(`preco_${plataforma}_ideal`).textContent = `R$ ${calc20.precoIdeal}`;
+        document.getElementById(`preco_${plataforma}_medio`).textContent = `R$ ${calc20.precoMedio}`;
+        document.getElementById(`preco_${plataforma}_promo`).textContent = `R$ ${calc20.precoPromo}`;
+        salvarProdutoMultiplasTaxas(produto, sku, plataforma.toUpperCase(), custo, [calc20, calc14]);
         return;
       }
 
       calcularComTaxa(plataforma, custo, produto, sku);
     }
 
-    function calcularComTaxa(plataforma, custo, produto, sku, taxaOverride, forceNew = false) {
+    function calcularComTaxa(plataforma, custo, produto, sku, taxaOverride, forceNew = false, returnOnly = false) {
       let totalPercentual = 0;
       let totalFixo = 0;
       const taxasDetalhadas = {};
@@ -980,13 +985,24 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
 
       // Calcular preço mínimo (sem lucro)
       const precoMinimo = ((custo + totalFixo) / (1 - totalPercentual / 100)).toFixed(2);
-      document.getElementById(`preco_${plataforma}`).value = precoMinimo;
-
-      // Calcular cenários de lucro
       const precoPromo = precoMinimo; // 0% de lucro
       const precoMedio = (precoMinimo * 1.05).toFixed(2); // 5% de lucro
       const precoIdeal = (precoMinimo * 1.10).toFixed(2); // 10% de lucro
 
+      const resultado = {
+        taxaPercentual: taxa,
+        precoMinimo: parseFloat(precoMinimo),
+        precoIdeal: parseFloat(precoIdeal),
+        precoMedio: parseFloat(precoMedio),
+        precoPromo: parseFloat(precoPromo),
+        taxas: taxasDetalhadas
+      };
+
+      if (returnOnly) {
+        return resultado;
+      }
+
+      document.getElementById(`preco_${plataforma}`).value = precoMinimo;
       document.getElementById(`preco_${plataforma}_ideal`).textContent = `R$ ${precoIdeal}`;
       document.getElementById(`preco_${plataforma}_medio`).textContent = `R$ ${precoMedio}`;
       document.getElementById(`preco_${plataforma}_promo`).textContent = `R$ ${precoPromo}`;
@@ -998,6 +1014,58 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
         sistema.produtoEditando = null;
       } else {
         salvarProduto(produto, sku, plataformaNome, precoMinimo, precoIdeal, precoMedio, precoPromo, custo, taxasDetalhadas, forceNew);
+      }
+
+      return resultado;
+    }
+
+    async function salvarProdutoMultiplasTaxas(produto, sku, plataforma, custo, resultados) {
+      const user = auth.currentUser;
+      if (!user) {
+        showToast("Usuário não autenticado!", "error");
+        return;
+      }
+
+      const calculos = {};
+      resultados.forEach(r => {
+        calculos[`${r.taxaPercentual}%`] = {
+          precoMinimo: r.precoMinimo,
+          precoIdeal: r.precoIdeal,
+          precoMedio: r.precoMedio,
+          precoPromo: r.precoPromo
+        };
+      });
+
+      const base = resultados[0];
+      const novoProduto = {
+        produto,
+        sku,
+        plataforma,
+        custo,
+        precoMinimo: base.precoMinimo,
+        precoIdeal: base.precoIdeal,
+        precoMedio: base.precoMedio,
+        precoPromo: base.precoPromo,
+        taxas: base.taxas,
+        calculosTaxas: calculos,
+        userId: user.uid,
+        createdAt: new Date().toISOString()
+      };
+
+      try {
+        const docRef = await db
+          .collection('uid')
+          .doc(user.uid)
+          .collection('produtos')
+          .add(novoProduto);
+        sistema.produtos.unshift({ ...novoProduto, id: docRef.id });
+        atualizarLista();
+
+        showToast("Produto criado com sucesso!", "success");
+        addHistoryEntry('product_add', `Produto \"${produto}\" cadastrado para ${plataforma}`);
+      } catch (error) {
+        console.error("Erro ao salvar produto:", error);
+        showToast("Erro ao salvar produto!", "error");
       }
     }
 

--- a/precificacao-tabs/lista-precos.js
+++ b/precificacao-tabs/lista-precos.js
@@ -93,8 +93,16 @@ function renderLista(lista) {
             </div>
           </div>
           <div class="text-right">
-            <div class="text-gray-500 text-sm">Preço mínimo</div>
-            <div class="text-lg font-semibold text-green-600">R$ ${parseFloat(data.precoMinimo).toFixed(2)}</div>
+            ${data.calculosTaxas ? Object.entries(data.calculosTaxas).map(([taxa, valores]) => `
+              <div class="mb-2">
+                <div class="text-gray-500 text-sm">${taxa} - Preço mínimo</div>
+                <div class="text-lg font-semibold text-green-600">R$ ${parseFloat(valores.precoMinimo).toFixed(2)}</div>
+                <div class="text-xs text-gray-500">Promo: R$ ${parseFloat(valores.precoPromo).toFixed(2)} | Médio: R$ ${parseFloat(valores.precoMedio).toFixed(2)} | Ideal: R$ ${parseFloat(valores.precoIdeal).toFixed(2)}</div>
+              </div>
+            `).join('') : `
+              <div class="text-gray-500 text-sm">Preço mínimo</div>
+              <div class="text-lg font-semibold text-green-600">R$ ${parseFloat(data.precoMinimo).toFixed(2)}</div>
+            `}
           </div>
         </div>
         <div class="mt-4 pt-4 border-t border-gray-100 flex justify-between">


### PR DESCRIPTION
## Summary
- store dual Shopee tax calculations together and link prices to their rates
- render all stored price calculations on each product card in the price list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0534a5594832aa8ffe709674e03b8