### PR TITLE
Add filter mode option to price list

### DIFF
--- a/precificacao-tabs/lista-precos.html
+++ b/precificacao-tabs/lista-precos.html
@@ -6,6 +6,11 @@
     </span>
   </h2>  <div class="flex flex-wrap items-end gap-4 mb-4">
     <input id="filtroBusca" type="text" placeholder="Filtrar por SKU, nome ou loja" class="border p-2 rounded flex-1" />
+    <select id="tipoFiltro" class="border p-2 rounded">
+      <option value="contains">Contém</option>
+      <option value="starts">Começa com</option>
+      <option value="exact">Exato</option>
+    </select>
     <div class="flex">
       <button id="btnCardView" class="px-3 py-2 bg-gray-200 rounded-l">Cards</button>
       <button id="btnListView" class="px-3 py-2 bg-gray-200 rounded-r">Lista</button>

--- a/precificacao-tabs/lista-precos.js
+++ b/precificacao-tabs/lista-precos.js
@@ -59,13 +59,21 @@ async function carregarProdutos() {
 }
 
 function aplicarFiltros() {
-    const termo = document.getElementById('filtroBusca')?.value.toLowerCase() || '';
+  const termo = document.getElementById('filtroBusca')?.value.toLowerCase() || '';
+  const tipo = document.getElementById('tipoFiltro')?.value || 'contains';
 
   const filtrados = produtos.filter(p => {
     const texto = `${p.produto || ''} ${(p.sku || '')}`.toLowerCase();
-        return !termo || texto.includes(termo);
-
+    if (!termo) return true;
+    if (tipo === 'exact') {
+      return texto === termo;
+    }
+    if (tipo === 'starts') {
+      return texto.startsWith(termo);
+    }
+    return texto.includes(termo);
   });
+
   renderLista(filtrados);
 }
 
@@ -423,9 +431,10 @@ function importarExcelLista() {
 }
 function setupListeners() {
   document.getElementById('filtroBusca')?.addEventListener('input', aplicarFiltros);
+  document.getElementById('tipoFiltro')?.addEventListener('change', aplicarFiltros);
   document.getElementById('btnCardView')?.addEventListener('click', () => { viewMode = 'cards'; aplicarFiltros(); });
   document.getElementById('btnListView')?.addEventListener('click', () => { viewMode = 'list'; aplicarFiltros(); });
-    document.getElementById('selectAll')?.addEventListener('change', e => selecionarTodos(e.target.checked));
+  document.getElementById('selectAll')?.addEventListener('change', e => selecionarTodos(e.target.checked));
 }
 
 function initTooltips() {


### PR DESCRIPTION
## Summary
- allow choosing filter mode (contém, começa com, exato) in Lista de Preços
- update filtering logic to respect selected mode and attach listener

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0539505e4832a9d02ee92db9221ab