### PR TITLE
Melhora no design dos cards de precificação

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1481,32 +1481,46 @@ body.dark-mode .table tr:nth-child(2n) {
   background: rgba(255,255,255,.03);
 }
 .scenario-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
   background: var(--background);
-  border-radius: 0.5rem;
-  padding: 15px;
-  margin-top: 10px;
-  border-left: 4px solid
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  margin-top: 0.5rem;
 }
-.scenario-ideal {
-  border-left-color: var(--success);
-  background-color: rgba(76,175,80,.05)
-}
-.scenario-medium {
-  border-left-color: #ffc107;
-  background-color: rgba(255,193,7,.05)
-}
-.scenario-promo {
-  border-left-color: var(--error);
-  background-color: rgba(244,67,54,.05)
+.scenario-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 9999px;
 }
 .scenario-title {
+  flex: 1;
   font-weight: 600;
-  margin-bottom: 5px;
-  font-size: 14px
+  font-size: 0.875rem;
 }
 .scenario-value {
-  font-size: 1.2rem;
-  font-weight: 700
+  font-size: 1rem;
+  font-weight: 700;
+}
+.scenario-ideal {
+  background-color: rgba(76,175,80,0.1);
+}
+.scenario-ideal .scenario-dot {
+  background-color: var(--success);
+}
+.scenario-medium {
+  background-color: rgba(255,193,7,0.1);
+}
+.scenario-medium .scenario-dot {
+  background-color: #ffc107;
+}
+.scenario-promo {
+  background-color: rgba(244,67,54,0.1);
+}
+.scenario-promo .scenario-dot {
+  background-color: var(--error);
 }
 .platform-tag {
   display: inline-block;

--- a/precificacao-tabs/precificacao.html
+++ b/precificacao-tabs/precificacao.html
@@ -43,6 +43,7 @@
         <div class="card">
           <h2 class="text-xl font-bold mb-4 text-red-600"><i class="fas fa-store mr-2"></i> Mercado Livre</h2>
           <div id="mlCampos">
+            <h3 class="text-sm font-semibold text-gray-700 mb-2">Taxas</h3>
             <div class="input-group">
               <label>Taxas da Plataforma (%)</label>
               <div class="flex gap-2">
@@ -63,7 +64,8 @@
                 <input type="number" step="0.01" placeholder="Outro" id="ml_fixo_custom" class="flex-1 p-2">
               </div>
             </div>
-            
+
+            <h3 class="text-sm font-semibold text-gray-700 mt-4 mb-2">Custos</h3>
             <input placeholder="Frete (R$)" data-campo="Frete (R$)" class="p-2">
             <input placeholder="Taxa de Transação (%)" data-campo="Taxa de Transação (%)" class="p-2">
             <input placeholder="Taxa de Transferência (%)" data-campo="Taxa de Transferência (%)" class="p-2">
@@ -71,25 +73,28 @@
             <input placeholder="Custos Variáveis (R$)" data-campo="Custos Variáveis (R$)" class="p-2">
             <input placeholder="Imposto (%)" data-campo="Imposto (%)" class="p-2">
             <input placeholder="Comissão do Vendedor (%)" data-campo="Comissão do Vendedor (%)" class="p-2">
-            
+
             <div class="input-group mt-4">
               <label>Preço Mínimo (R$)</label>
               <input id="preco_ml" disabled class="p-3 bg-gray-100 font-bold text-lg">
             </div>
-            
-             <div class="scenario-card scenario-promo">
-              <div class="scenario-title">Sem Lucro (0%)</div>
-              <div class="scenario-value" id="preco_ml_promo">R$ 0,00</div>
+
+            <div class="scenario-card scenario-promo">
+              <span class="scenario-dot"></span>
+              <span class="scenario-title">Sem Lucro</span>
+              <span class="scenario-value" id="preco_ml_promo">R$ 0,00</span>
             </div>
-            
+
             <div class="scenario-card scenario-medium">
-              <div class="scenario-title">Lucro 5%</div>
-              <div class="scenario-value" id="preco_ml_medio">R$ 0,00</div>
+              <span class="scenario-dot"></span>
+              <span class="scenario-title">Lucro 5%</span>
+              <span class="scenario-value" id="preco_ml_medio">R$ 0,00</span>
             </div>
-            
+
             <div class="scenario-card scenario-ideal">
-              <div class="scenario-title">Lucro 10%</div>
-              <div class="scenario-value" id="preco_ml_ideal">R$ 0,00</div>
+              <span class="scenario-dot"></span>
+              <span class="scenario-title">Lucro 10%</span>
+              <span class="scenario-value" id="preco_ml_ideal">R$ 0,00</span>
             </div>
           </div>
           <button class="btn-primary w-full mt-4" onclick="calcular('ml')">
@@ -101,6 +106,7 @@
         <div class="card">
           <h2 class="text-xl font-bold mb-4 text-blue-600"><i class="fas fa-store mr-2"></i> Shopee</h2>
           <div id="shopeeCampos">
+            <h3 class="text-sm font-semibold text-gray-700 mb-2">Taxas</h3>
             <div class="input-group">
               <label>Taxas da Plataforma (%)</label>
               <div class="flex gap-2">
@@ -128,7 +134,8 @@
                 <input type="number" step="0.01" placeholder="Outro" id="shopee_fixo_custom" class="flex-1 p-2">
               </div>
             </div>
-            
+
+            <h3 class="text-sm font-semibold text-gray-700 mt-4 mb-2">Custos</h3>
             <input placeholder="Frete (R$)" data-campo="Frete (R$)" class="p-2">
             <input placeholder="Taxa de Transação (%)" data-campo="Taxa de Transação (%)" class="p-2">
             <input placeholder="Taxa de Transferência (%)" data-campo="Taxa de Transferência (%)" class="p-2">
@@ -136,25 +143,28 @@
             <input placeholder="Custos Variáveis (R$)" data-campo="Custos Variáveis (R$)" class="p-2">
             <input placeholder="Imposto (%)" data-campo="Imposto (%)" class="p-2">
             <input placeholder="Comissão do Vendedor (%)" data-campo="Comissão do Vendedor (%)" class="p-2">
-            
+
             <div class="input-group mt-4">
               <label>Preço Mínimo (R$)</label>
               <input id="preco_shopee" disabled class="p-3 bg-gray-100 font-bold text-lg">
             </div>
-            
-             <div class="scenario-card scenario-promo">
-              <div class="scenario-title">Sem Lucro (0%)</div>
-              <div class="scenario-value" id="preco_shopee_promo">R$ 0,00</div>
+
+            <div class="scenario-card scenario-promo">
+              <span class="scenario-dot"></span>
+              <span class="scenario-title">Sem Lucro</span>
+              <span class="scenario-value" id="preco_shopee_promo">R$ 0,00</span>
             </div>
-            
+
             <div class="scenario-card scenario-medium">
-              <div class="scenario-title">Lucro 5%</div>
-              <div class="scenario-value" id="preco_shopee_medio">R$ 0,00</div>
+              <span class="scenario-dot"></span>
+              <span class="scenario-title">Lucro 5%</span>
+              <span class="scenario-value" id="preco_shopee_medio">R$ 0,00</span>
             </div>
-            
-           <div class="scenario-card scenario-ideal">
-              <div class="scenario-title">Lucro 10%</div>
-              <div class="scenario-value" id="preco_shopee_ideal">R$ 0,00</div>
+
+            <div class="scenario-card scenario-ideal">
+              <span class="scenario-dot"></span>
+              <span class="scenario-title">Lucro 10%</span>
+              <span class="scenario-value" id="preco_shopee_ideal">R$ 0,00</span>
             </div>
           </div>
           <button class="btn-primary w-full mt-4" onclick="calcular('shopee')">
@@ -166,6 +176,7 @@
         <div class="card">
           <h2 class="text-xl font-bold mb-4 text-green-600"><i class="fas fa-store mr-2"></i> Magalu</h2>
           <div id="magaluCampos">
+            <h3 class="text-sm font-semibold text-gray-700 mb-2">Taxas</h3>
             <div class="input-group">
               <label>Taxas da Plataforma (%)</label>
               <div class="flex gap-2">
@@ -177,7 +188,7 @@
                 <input type="number" step="0.01" placeholder="Outro" id="magalu_taxa_custom" class="flex-1 p-2">
               </div>
             </div>
-            
+
             <div class="input-group">
               <label>Custo Fixo Plataforma (R$)</label>
               <div class="flex gap-2">
@@ -187,7 +198,8 @@
                 <input type="number" step="0.01" placeholder="Outro" id="magalu_fixo_custom" class="flex-1 p-2">
               </div>
             </div>
-            
+
+            <h3 class="text-sm font-semibold text-gray-700 mt-4 mb-2">Custos</h3>
             <input placeholder="Frete (R$)" data-campo="Frete (R$)" class="p-2">
             <input placeholder="Taxa de Transação (%)" data-campo="Taxa de Transação (%)" class="p-2">
             <input placeholder="Taxa de Transferência (%)" data-campo="Taxa de Transferência (%)" class="p-2">
@@ -195,25 +207,28 @@
             <input placeholder="Custos Variáveis (R$)" data-campo="Custos Variáveis (R$)" class="p-2">
             <input placeholder="Imposto (%)" data-campo="Imposto (%)" class="p-2">
             <input placeholder="Comissão do Vendedor (%)" data-campo="Comissão do Vendedor (%)" class="p-2">
-            
+
             <div class="input-group mt-4">
               <label>Preço Mínimo (R$)</label>
               <input id="preco_magalu" disabled class="p-3 bg-gray-100 font-bold text-lg">
             </div>
-            
-           <div class="scenario-card scenario-promo">
-              <div class="scenario-title">Sem Lucro (0%)</div>
-              <div class="scenario-value" id="preco_magalu_promo">R$ 0,00</div>
+
+            <div class="scenario-card scenario-promo">
+              <span class="scenario-dot"></span>
+              <span class="scenario-title">Sem Lucro</span>
+              <span class="scenario-value" id="preco_magalu_promo">R$ 0,00</span>
             </div>
-            
+
             <div class="scenario-card scenario-medium">
-<div class="scenario-title">Lucro 5%</div>
-              <div class="scenario-value" id="preco_magalu_medio">R$ 0,00</div>
+              <span class="scenario-dot"></span>
+              <span class="scenario-title">Lucro 5%</span>
+              <span class="scenario-value" id="preco_magalu_medio">R$ 0,00</span>
             </div>
-            
+
             <div class="scenario-card scenario-ideal">
-              <div class="scenario-title">Lucro 10%</div>
-              <div class="scenario-value" id="preco_magalu_ideal">R$ 0,00</div>
+              <span class="scenario-dot"></span>
+              <span class="scenario-title">Lucro 10%</span>
+              <span class="scenario-value" id="preco_magalu_ideal">R$ 0,00</span>
             </div>
           </div>
           <button class="btn-primary w-full mt-4" onclick="calcular('magalu')">
@@ -225,6 +240,7 @@
         <div class="card">
           <h2 class="text-xl font-bold mb-4 text-purple-600"><i class="fas fa-store mr-2"></i> SHEIN</h2>
           <div id="sheinCampos">
+            <h3 class="text-sm font-semibold text-gray-700 mb-2">Taxas</h3>
             <div class="input-group">
               <label>Taxas da Plataforma (%)</label>
               <div class="flex gap-2">
@@ -234,7 +250,7 @@
                 <input type="number" step="0.01" placeholder="Outro" id="shein_taxa_custom" class="flex-1 p-2">
               </div>
             </div>
-            
+
             <div class="input-group">
               <label>Custo Fixo Plataforma (R$)</label>
               <div class="flex gap-2">
@@ -244,7 +260,8 @@
                 <input type="number" step="0.01" placeholder="Outro" id="shein_fixo_custom" class="flex-1 p-2">
               </div>
             </div>
-            
+
+            <h3 class="text-sm font-semibold text-gray-700 mt-4 mb-2">Custos</h3>
             <input placeholder="Frete (R$)" data-campo="Frete (R$)" class="p-2">
             <input placeholder="Taxa de Transação (%)" data-campo="Taxa de Transação (%)" class="p-2">
             <input placeholder="Taxa de Transferência (%)" data-campo="Taxa de Transferência (%)" class="p-2">
@@ -252,25 +269,28 @@
             <input placeholder="Custos Variáveis (R$)" data-campo="Custos Variáveis (R$)" class="p-2">
             <input placeholder="Imposto (%)" data-campo="Imposto (%)" class="p-2">
             <input placeholder="Comissão do Vendedor (%)" data-campo="Comissão do Vendedor (%)" class="p-2">
-            
+
             <div class="input-group mt-4">
               <label>Preço Mínimo (R$)</label>
               <input id="preco_shein" disabled class="p-3 bg-gray-100 font-bold text-lg">
             </div>
-            
+
             <div class="scenario-card scenario-promo">
-              <div class="scenario-title">Sem Lucro (0%)</div>
-              <div class="scenario-value" id="preco_shein_promo">R$ 0,00</div>
+              <span class="scenario-dot"></span>
+              <span class="scenario-title">Sem Lucro</span>
+              <span class="scenario-value" id="preco_shein_promo">R$ 0,00</span>
             </div>
-            
+
             <div class="scenario-card scenario-medium">
-             <div class="scenario-title">Lucro 5%</div>
-              <div class="scenario-value" id="preco_shein_medio">R$ 0,00</div>
+              <span class="scenario-dot"></span>
+              <span class="scenario-title">Lucro 5%</span>
+              <span class="scenario-value" id="preco_shein_medio">R$ 0,00</span>
             </div>
-            
-           <div class="scenario-card scenario-ideal">
-              <div class="scenario-title">Lucro 10%</div>
-              <div class="scenario-value" id="preco_shein_ideal">R$ 0,00</div>
+
+            <div class="scenario-card scenario-ideal">
+              <span class="scenario-dot"></span>
+              <span class="scenario-title">Lucro 10%</span>
+              <span class="scenario-value" id="preco_shein_ideal">R$ 0,00</span>
             </div>
           </div>
           <button class="btn-primary w-full mt-4" onclick="calcular('shein')">


### PR DESCRIPTION
## Resumo
- Adiciona seções de **Taxas** e **Custos** em cada card de precificação
- Estiliza resultados com novos `scenario-card` coloridos e indicadores

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c058fd704c832aa2167317f3793766