### PR TITLE
fix: use ESM build of tesseract for OCR

### DIFF
--- a/createWorker.js
+++ b/createWorker.js
@@ -1,5 +1,5 @@
-// Importa a versão correta do Tesseract que fornece o método `createWorker`
-import { createWorker } from 'https://cdn.jsdelivr.net/npm/tesseract.js@5.0.4/dist/tesseract.min.js';
+// Importa a build ESM do Tesseract que expõe `createWorker`
+import { createWorker } from 'https://cdn.jsdelivr.net/npm/tesseract.js@5.0.4/dist/tesseract.esm.min.js';
 
 export async function createOcrWorker() {
   const worker = await createWorker({ logger: m => console.log('[OCR]', m) });


### PR DESCRIPTION
## Summary
- import Tesseract's ESM build so `createWorker` is available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0630bbc68832a8ab0f38a06519e93