### PR TITLE
Prevent layout listener duplication

### DIFF
--- a/public/shared.js
+++ b/public/shared.js
@@ -384,10 +384,14 @@ async function ensureLayout(){
   }
 }
 
-// roda em várias fases para cobrir login/redirect/back-forward-cache
-['DOMContentLoaded','load','pageshow','focus'].forEach(evt=>{
-  window.addEventListener(evt, ensureLayout, { once: false });
-});
+// roda em momentos essenciais para evitar recargas desnecessárias
+// evita acumular listeners em execuções repetidas do script
+if (!window._layoutListenersBound) {
+  ['DOMContentLoaded', 'pageshow'].forEach(evt => {
+    window.addEventListener(evt, ensureLayout, { once: true });
+  });
+  window._layoutListenersBound = true;
+}
 
 // se algum script remover os containers, recolocamos
 const mo = new MutationObserver(() => {

--- a/shared.js
+++ b/shared.js
@@ -385,9 +385,13 @@ async function ensureLayout(){
 }
 
 // roda em momentos essenciais para evitar recargas desnecessárias
-['DOMContentLoaded','pageshow'].forEach(evt=>{
-  window.addEventListener(evt, ensureLayout, { once: false });
-});
+// evita acumular listeners em execuções repetidas do script
+if (!window._layoutListenersBound) {
+  ['DOMContentLoaded', 'pageshow'].forEach(evt => {
+    window.addEventListener(evt, ensureLayout, { once: true });
+  });
+  window._layoutListenersBound = true;
+}
 
 // se algum script remover os containers, recolocamos
 const mo = new MutationObserver(() => {


### PR DESCRIPTION
## Summary
- Add guard to avoid binding layout listeners multiple times
- Limit layout reload triggers to DOMContentLoaded and pageshow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0695fdcf4832a9255b73873755998