### PR TITLE
Align navbar layout across pages

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1304,6 +1304,18 @@ body.dark-mode .data-table th {
   align-items: center;
   gap: 20px;
 }
+.navbar-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.navbar-title {
+  font-weight: 600;
+  font-size: 1.125rem;
+}
+@media (min-width:768px) {
+  .navbar-title { font-size: 1.25rem; }
+}
 .navbar .menu-item {
   color: #fff;
   display: inline-flex;

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,24 +1,13 @@
-<div class="navbar h-16 px-4 md:px-6 flex items-center justify-between">
-  <div class="flex items-center gap-4">
+<div class="navbar">
+  <div class="navbar-left">
     <button class="mobile-menu-btn hamburger menu-item" aria-label="Abrir menu" aria-expanded="false">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
         <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5" />
       </svg>
     </button>
-    <h1 class="text-lg md:text-xl font-semibold">Dashboard</h1>
-    <div class="hidden md:block ml-4">
-      <label class="relative block">
-        <span class="sr-only">Buscar</span>
-        <span class="absolute inset-y-0 left-0 flex items-center pl-2 pointer-events-none">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4 text-neutral-400">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 15.75 21 21m-3-9a6 6 0 1 0-12 0 6 6 0 0 0 12 0Z" />
-          </svg>
-        </span>
-        <input type="text" placeholder="Buscar" class="pl-8 pr-3 py-2 text-sm border border-neutral-300 rounded-lg focus:outline-none focus:ring-1 focus:ring-orange-500" />
-      </label>
-    </div>
+    <h1 class="navbar-title">Dashboard</h1>
   </div>
-  <div class="flex items-center gap-1">
+  <div class="navbar-right">
     <a href="cadastro-interesse.html" class="menu-item" title="Cadastre-se">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
         <path stroke-linecap="round" stroke-linejoin="round" d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3M12.75 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3.001 19.234c-.001-.037-.001-.074-.001-.111 0-3.52 2.854-6.375 6.375-6.375S15.75 15.604 15.75 19.125v.003a12.318 12.318 0 0 1-6.375 1.872A12.32 12.32 0 0 1 3.001 19.234Z"/>


### PR DESCRIPTION
## Summary
- Simplify shared navbar markup and remove unused search field
- Add navbar-left and navbar-title styles for consistent look without Tailwind

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0a8aee5f4832a8b86a38404e49700