### PR TITLE
Remove mobile navbar

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1755,21 +1755,17 @@ input:checked + .toggle-slider:before {
       width: 95%;
       margin: 10px auto;
     }
+    :root {
+      --navbar-height: 0;
+    }
     .navbar {
-      left: 0;
-      padding: 0 1rem;
-    }
-    .navbar .menu-item {
       display: none;
-    }
-    .navbar .hamburger {
-      display: block;
     }
     .main-content {
       margin-left: 0;
       padding-left: 1rem;
       padding-right: 1rem;
-      padding-top: var(--navbar-height);
+      padding-top: 0;
     }
   }
 


### PR DESCRIPTION
## Summary
- Hide navbar on mobile by setting `--navbar-height` to 0
- Remove top padding for content when navbar is hidden

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0d946a360832ab389e5b4ce911c3d