### PR TITLE
Melhora layout mobile da aba Atualizações

### DIFF
--- a/atualizacoes.html
+++ b/atualizacoes.html
@@ -21,7 +21,7 @@
         Últimos 7 dias <i class="fa fa-chevron-down text-xs"></i>
       </button>
     </div>
-    <div id="resumoTotais" class="grid grid-cols-2 lg:grid-cols-4 gap-4"></div>
+    <div id="resumoTotais" class="grid grid-cols-2 gap-2 sm:grid-cols-4 sm:gap-4"></div>
     <div id="historicoFaturamentoCard" class="card p-4 hidden">
       <h2 class="font-medium mb-2">Histórico de Faturamento (Último dia)</h2>
       <div id="historicoFaturamento" class="flex flex-nowrap gap-4 overflow-x-auto"></div>

--- a/atualizacoes.js
+++ b/atualizacoes.js
@@ -255,7 +255,10 @@ async function carregarTotais() {
   cards.forEach(c => {
     const div = document.createElement('div');
     div.className = 'card text-center';
-    div.innerHTML = `<div class="text-sm text-gray-500">${c.label}</div><div class="text-lg font-semibold">${c.valor}</div>`;
+    div.innerHTML = `
+      <div class="label text-xs sm:text-sm text-gray-500">${c.label}</div>
+      <div class="value text-base sm:text-lg font-semibold">${c.valor}</div>
+    `;
     container.appendChild(div);
   });
 }

--- a/css/components.css
+++ b/css/components.css
@@ -167,6 +167,12 @@
   }
 }
 
+@media (max-width: 640px) {
+  #resumoTotais .card {
+    padding: 0.5rem;
+  }
+}
+
 .floating-btn {
   position: fixed;
   bottom: 1.5rem;


### PR DESCRIPTION
## Summary
- Ajusta grid de `resumoTotais` para duas colunas com menor espaçamento em telas pequenas
- Usa classes responsivas para reduzir texto dos cards de totais no mobile
- Aplica padding reduzido aos cards de totais em telas menores

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0db9ab9fc832ab7dd7ed8fcab9d24