### PR TITLE
Ensure layout loads after DOM ready

### DIFF
--- a/public/shared.js
+++ b/public/shared.js
@@ -387,9 +387,12 @@ async function ensureLayout(){
 // roda em momentos essenciais para evitar recargas desnecessárias
 // evita acumular listeners em execuções repetidas do script
 if (!window._layoutListenersBound) {
-  ['DOMContentLoaded', 'pageshow'].forEach(evt => {
-    window.addEventListener(evt, ensureLayout, { once: true });
-  });
+  if (document.readyState === 'loading') {
+    window.addEventListener('DOMContentLoaded', ensureLayout, { once: true });
+  } else {
+    ensureLayout();
+  }
+  window.addEventListener('pageshow', ensureLayout, { once: true });
   window._layoutListenersBound = true;
 }
 

--- a/shared.js
+++ b/shared.js
@@ -387,9 +387,12 @@ async function ensureLayout(){
 // roda em momentos essenciais para evitar recargas desnecessárias
 // evita acumular listeners em execuções repetidas do script
 if (!window._layoutListenersBound) {
-  ['DOMContentLoaded', 'pageshow'].forEach(evt => {
-    window.addEventListener(evt, ensureLayout, { once: true });
-  });
+  if (document.readyState === 'loading') {
+    window.addEventListener('DOMContentLoaded', ensureLayout, { once: true });
+  } else {
+    ensureLayout();
+  }
+  window.addEventListener('pageshow', ensureLayout, { once: true });
   window._layoutListenersBound = true;
 }
 


### PR DESCRIPTION
## Summary
- guarantee sidebar/navbar partials load even if script runs after DOM is ready, preventing mobile sidebar from staying closed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c154e5b588832aaef6e019b4ca2eba