### PR TITLE
Fix mobile sidebar initialization on Finance page

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -474,6 +474,8 @@ function setupMobileSidebar() {
 document.addEventListener('navbarLoaded', setupMobileSidebar);
 document.addEventListener('sidebarLoaded', setupMobileSidebar);
 document.addEventListener('DOMContentLoaded', setupMobileSidebar);
+// Ensure mobile sidebar listeners are applied even if partials load before these events are registered
+setupMobileSidebar();
 
 let userMenuClickRegistered = false;
 document.addEventListener('navbarLoaded', () => {


### PR DESCRIPTION
## Summary
- Initialize mobile sidebar listeners immediately to avoid race conditions when partials load before event handlers register

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1577c791c832abcb60fd835d06679