### PR TITLE
Fix mobile finance sidebar toggle

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -382,6 +382,10 @@ async function ensureLayout(){
   if (typeof window.initDarkMode === 'function') {
     window.initDarkMode();
   }
+  // Ensure mobile sidebar buttons are wired after partials load
+  if (typeof setupMobileSidebar === 'function') {
+    setupMobileSidebar();
+  }
 }
 
 // roda em momentos essenciais para evitar recargas desnecessárias


### PR DESCRIPTION
## Summary
- Initialize mobile sidebar after layout partials are loaded to ensure toggle works on Financeiro page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c15dc0cfb8832abe25b27ce48ee142