### PR TITLE
fix: ensure sidebar opens on mobile finance page

### DIFF
--- a/financeiro.js
+++ b/financeiro.js
@@ -60,12 +60,11 @@ function setupFiltros(usuarios) {
   userSel.value = 'todos';
   mesSel.value = formatMes(new Date());
 
-  // Evita que cliques nesses filtros acionem links subjacentes
-  userSel.addEventListener('click', e => e.stopPropagation());
-  mesSel.addEventListener('click', e => e.stopPropagation());
+  // A interação com os filtros não precisa mais bloquear a propagação
+  // de cliques. Isso evita conflitos com o botão que abre o sidebar
+  // em dispositivos móveis.
   document.getElementById('usuarioIcon')?.addEventListener('click', e => {
     e.preventDefault();
-    e.stopPropagation();
     if (typeof userSel.showPicker === 'function') {
       userSel.showPicker();
     } else {
@@ -74,7 +73,6 @@ function setupFiltros(usuarios) {
   });
   document.getElementById('mesIcon')?.addEventListener('click', e => {
     e.preventDefault();
-    e.stopPropagation();
     if (typeof mesSel.showPicker === 'function') {
       mesSel.showPicker();
     } else {

--- a/shared.js
+++ b/shared.js
@@ -433,7 +433,9 @@ function setupMobileSidebar() {
 
   btns.forEach(btn => {
     if (btn.dataset.sidebarReady) return;
-    btn.addEventListener('click', toggleSidebar, { once: false });
+    // Impede que outros listeners de clique capturem o evento
+    // antes de abrir o menu lateral em telas menores.
+    btn.addEventListener('click', e => { e.stopPropagation(); toggleSidebar(); }, { once: false });
     btn.dataset.sidebarReady = 'true';
   });
   if (!overlay.dataset.sidebarReady) {


### PR DESCRIPTION
## Summary
- prevent finance filter clicks from stopping sidebar toggle
- safeguard mobile menu button so other handlers can't block sidebar opening

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c15f7ebbe0832a873c6a4db27b6cc4