### PR TITLE
Include previous evening labels in expedition total

### DIFF
--- a/expedicao.html
+++ b/expedicao.html
@@ -439,10 +439,14 @@
       const totalEl = document.getElementById('dailyTotal');
       if (!totalEl || !currentUser) return;
       const snap = await db.collection('pdfDocs').get();
+
+      // Intervalo: 17h do dia anterior até 13h do dia atual
       const now = new Date();
-      const startOfDay = new Date(now.toISOString().split('T')[0] + 'T00:00:00');
-      const cutoff = new Date(startOfDay);
-      cutoff.setHours(13, 0, 0, 0);
+      const end = new Date(now.toISOString().split('T')[0] + 'T13:00:00');
+      const start = new Date(end);
+      start.setDate(start.getDate() - 1);
+      start.setHours(17, 0, 0, 0);
+
       let total = 0;
       for (const doc of snap.docs) {
         const data = doc.data();
@@ -452,7 +456,11 @@
         if (!allowed || !data.createdAt) continue;
         const createdAt = data.createdAt.toDate ? data.createdAt.toDate() : null;
         if (!createdAt) continue;
-        if (createdAt <= cutoff && data.status !== 'concluido') {
+        if (
+          createdAt >= start &&
+          createdAt <= end &&
+          data.status !== 'concluido'
+        ) {
           total++;
         }
       }


### PR DESCRIPTION
## Summary
- count labels created from 17:00 previous day to 13:00 current day for daily expedition total

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1675048f8832aa95b7415b825d69d