### PR TITLE
Sum labels for daily shipping total

### DIFF
--- a/expedicao.html
+++ b/expedicao.html
@@ -461,7 +461,8 @@
           createdAt <= end &&
           data.status !== 'concluido'
         ) {
-          total++;
+          const labelsCount = Number(data.total ?? data.totalLabels);
+          total += isNaN(labelsCount) ? 1 : labelsCount;
         }
       }
       totalEl.textContent = `Pedidos a enviar hoje: ${total}`;


### PR DESCRIPTION
## Summary
- adjust daily order counter to sum labels per document using stored totals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c16a9741b0832aaf68e454ee094326