### PR TITLE
Unify label storage in etiquetasimpressas

### DIFF
--- a/expedicao.html
+++ b/expedicao.html
@@ -508,23 +508,34 @@
       start.setHours(17, 0, 0, 0);
       try {
         const q = db
-          .collectionGroup('skuimpressos')
-          .where('createdAt', '>=', start)
-          .where('createdAt', '<=', end);
+          .collectionGroup('etiquetasimpressas')
+          .where('data', '>=', start)
+          .where('data', '<=', end);
         const snap = await q.get();
         const seen = new Set();
         const rows = [];
-        snap.forEach(doc => {
+        const docs = [];
+        snap.forEach(doc => docs.push(doc));
+        const uids = Array.from(new Set(docs.map(d => d.ref.parent.parent.id)));
+        const emailMap = {};
+        await Promise.all(
+          uids.map(async uid => {
+            const udoc = await db.collection('uid').doc(uid).get();
+            emailMap[uid] = udoc.data()?.email || '';
+          })
+        );
+        docs.forEach(doc => {
           const data = doc.data();
-          const createdAt = data.createdAt?.toDate?.();
+          const createdAt = data.data?.toDate?.();
           if (!createdAt) return;
-          const key = `${data.userUid}_${data.sku}_${createdAt.getTime()}`;
+          const uid = doc.ref.parent.parent.id;
+          const key = `${uid}_${data.sku}_${createdAt.getTime()}`;
           if (seen.has(key)) return;
           seen.add(key);
           rows.push({
             sku: data.sku || '',
             quantidade: data.quantidade || 0,
-            usuario: data.userEmail || ''
+            usuario: emailMap[uid] || ''
           });
         });
         rows.forEach(r => {
@@ -806,12 +817,10 @@
           sku: item.sku,
           quantidade: item.quantidade,
           loja: loja || '',
-          userUid: currentUser.uid,
-          userEmail: currentUser.email,
-          createdAt: firebase.firestore.FieldValue.serverTimestamp()
+          data: firebase.firestore.FieldValue.serverTimestamp()
         };
-        batch.set(userDoc.collection('skuimpressos').doc(), data);
-        if (respDoc) batch.set(respDoc.collection('skuimpressos').doc(), data);
+        batch.set(userDoc.collection('etiquetasimpressas').doc(), data);
+        if (respDoc) batch.set(respDoc.collection('etiquetasimpressas').doc(), data);
       });
       await batch.commit();
     }
@@ -863,9 +872,9 @@
       const uid = currentUser.uid;
       const userDoc = db.collection('uid').doc(uid);
       const snap = await userDoc
-        .collection('skuimpressos')
-        .where('createdAt', '>=', firebase.firestore.Timestamp.fromDate(inicio))
-        .where('createdAt', '<', firebase.firestore.Timestamp.fromDate(fim))
+        .collection('etiquetasimpressas')
+        .where('data', '>=', firebase.firestore.Timestamp.fromDate(inicio))
+        .where('data', '<', firebase.firestore.Timestamp.fromDate(fim))
         .get();
       const resumo = {};
       snap.forEach(d => {
@@ -899,14 +908,25 @@
 
     async function gerarRelatorioDiaPorUsuario(inicio, fim, diaDados) {
       const snap = await db
-        .collectionGroup('skuimpressos')
-        .where('createdAt', '>=', firebase.firestore.Timestamp.fromDate(inicio))
-        .where('createdAt', '<', firebase.firestore.Timestamp.fromDate(fim))
+        .collectionGroup('etiquetasimpressas')
+        .where('data', '>=', firebase.firestore.Timestamp.fromDate(inicio))
+        .where('data', '<', firebase.firestore.Timestamp.fromDate(fim))
         .get();
+      const docs = [];
+      snap.forEach(d => docs.push(d));
+      const uids = Array.from(new Set(docs.map(d => d.ref.parent.parent.id)));
+      const emailMap = {};
+      await Promise.all(
+        uids.map(async uid => {
+          const udoc = await db.collection('uid').doc(uid).get();
+          emailMap[uid] = udoc.data()?.email || 'Desconhecido';
+        })
+      );
       const resumo = {};
-      snap.forEach(d => {
+      docs.forEach(d => {
         const data = d.data();
-        const usuario = data.userEmail || 'Desconhecido';
+        const uid = d.ref.parent.parent.id;
+        const usuario = emailMap[uid] || 'Desconhecido';
         const loja = data.loja || 'sem-loja';
         const sku = data.sku || 'sem-sku';
         const qtd = data.quantidade || 0;

--- a/relatorios.js
+++ b/relatorios.js
@@ -73,9 +73,9 @@ export async function exportarSkuImpressos() {
   fim.setMonth(fim.getMonth() + 1);
 
   const q = query(
-    collection(db, `uid/${uid}/skuimpressos`),
-    where('createdAt', '>=', Timestamp.fromDate(inicio)),
-    where('createdAt', '<', Timestamp.fromDate(fim))
+    collection(db, `uid/${uid}/etiquetasimpressas`),
+    where('data', '>=', Timestamp.fromDate(inicio)),
+    where('data', '<', Timestamp.fromDate(fim))
   );
   const snap = await getDocs(q);
   const linhas = [];
@@ -84,10 +84,10 @@ export async function exportarSkuImpressos() {
     const sku = dados.sku || 'sem-sku';
     const quantidade = Number(dados.quantidade) || 0;
     const loja = dados.loja || '';
-    const data = dados.createdAt && dados.createdAt.toDate
-      ? dados.createdAt.toDate().toLocaleDateString('pt-BR')
+    const dataStr = dados.data && dados.data.toDate
+      ? dados.data.toDate().toLocaleDateString('pt-BR')
       : '';
-    linhas.push({ SKU: sku, Quantidade: quantidade, Loja: loja, Data: data });
+    linhas.push({ SKU: sku, Quantidade: quantidade, Loja: loja, Data: dataStr });
   });
   const sobras = [];
   const qSobras = query(
@@ -149,9 +149,9 @@ export async function exportarSkuImpressosGestor() {
     const uid = u.id;
     const emailUsuario = u.data().email || 'sem-email';
     const q = query(
-      collection(db, `uid/${uid}/skuimpressos`),
-      where('createdAt', '>=', Timestamp.fromDate(inicio)),
-      where('createdAt', '<', Timestamp.fromDate(fim))
+      collection(db, `uid/${uid}/etiquetasimpressas`),
+      where('data', '>=', Timestamp.fromDate(inicio)),
+      where('data', '<', Timestamp.fromDate(fim))
     );
     promessas.push(
       getDocs(q).then(snap => {
@@ -160,10 +160,10 @@ export async function exportarSkuImpressosGestor() {
           const sku = dados.sku || 'sem-sku';
           const quantidade = dados.quantidade || 0;
           const loja = dados.loja || '';
-          const data = dados.createdAt && dados.createdAt.toDate
-            ? dados.createdAt.toDate().toLocaleDateString('pt-BR')
+          const dataStr = dados.data && dados.data.toDate
+            ? dados.data.toDate().toLocaleDateString('pt-BR')
             : '';
-          linhas.push({ Usuario: emailUsuario, SKU: sku, Quantidade: quantidade, Loja: loja, Data: data });
+          linhas.push({ Usuario: emailUsuario, SKU: sku, Quantidade: quantidade, Loja: loja, Data: dataStr });
         });
       })
     );

--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -436,25 +436,33 @@
   }
   async function savePrintedItems(items, meta){
     console.log('[savePrintedItems] items:', items, 'meta:', meta);
-    // Salva em uid/{uid}/skuimpressos
-    const base = db.collection('uid').doc(currentUser.uid).collection('skuimpressos');
+    const base = db.collection('uid').doc(currentUser.uid).collection('etiquetasimpressas');
     const batch = db.batch();
-    const now = new Date();
-    items.forEach(it=>{
-      const data = { sku: it.sku, quantidade: it.quantidade, loja: meta.loja||null, dataHora: now.toISOString(), numeroSequencial: meta.labelNumber||null, pdfPath: meta.storagePath||null };
-      const doc = base.doc(); batch.set(doc, data, { merge:true });
+    items.forEach(it => {
+      const data = {
+        sku: it.sku,
+        quantidade: it.quantidade,
+        loja: meta.loja || '',
+        data: firebase.firestore.FieldValue.serverTimestamp()
+      };
+      const doc = base.doc();
+      batch.set(doc, data);
     });
     await batch.commit();
     console.log('[savePrintedItems] saved for current user');
 
-    // Se houver responsável, tenta salvar no UID dele também
     if(meta.responsavelUid){
-      const base2 = db.collection('uid').doc(meta.responsavelUid).collection('skuimpressos');
+      const base2 = db.collection('uid').doc(meta.responsavelUid).collection('etiquetasimpressas');
       const batch2 = db.batch();
-      const now2 = new Date();
-      items.forEach(it=>{
-        const data = { sku: it.sku, quantidade: it.quantidade, loja: meta.loja||null, dataHora: now2.toISOString(), numeroSequencial: meta.labelNumber||null, pdfPath: meta.storagePath||null, origemUid: currentUser.uid };
-        const doc = base2.doc(); batch2.set(doc, data, { merge:true });
+      items.forEach(it => {
+        const data = {
+          sku: it.sku,
+          quantidade: it.quantidade,
+          loja: meta.loja || '',
+          data: firebase.firestore.FieldValue.serverTimestamp()
+        };
+        const doc = base2.doc();
+        batch2.set(doc, data);
       });
       await batch2.commit();
       console.log('[savePrintedItems] saved for responsavel', meta.responsavelUid);

--- a/zpl-import.html
+++ b/zpl-import.html
@@ -204,13 +204,11 @@
                     sku: item.sku,
                     quantidade: item.quantidade,
                     loja: item.loja || '',
-                    userUid: currentUser.uid,
-                    userEmail: currentUser.email,
-                    createdAt: firebase.firestore.FieldValue.serverTimestamp()
+                    data: firebase.firestore.FieldValue.serverTimestamp()
                 };
-                batch.set(userDoc.collection('skuimpressos').doc(), data);
+                batch.set(userDoc.collection('etiquetasimpressas').doc(), data);
                 if (respDoc) {
-                    batch.set(respDoc.collection('skuimpressos').doc(), data);
+                    batch.set(respDoc.collection('etiquetasimpressas').doc(), data);
                 }
             });
             await batch.commit();


### PR DESCRIPTION
## Summary
- Save ZPL import items to `etiquetasimpressas` with server timestamps
- Update checklist and reports to read from `etiquetasimpressas`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c16d5de17c832a84704bdf97ef3e26