### PR TITLE
Unifica salvamento de etiquetas em 'etiquetasimpressas'

### DIFF
--- a/expedicao.html
+++ b/expedicao.html
@@ -523,18 +523,18 @@
           allowedUsers = [...allowedUsers, ...usuarios];
         }
         const q = db
-          .collectionGroup('skuimpressos')
-          .where('createdAt', '>=', start)
-          .where('createdAt', '<=', end);
+          .collectionGroup('etiquetasimpressas')
+          .where('data', '>=', start)
+          .where('data', '<=', end);
         const snap = await q.get();
         const seen = new Set();
         const rows = [];
         snap.forEach(doc => {
           const data = doc.data();
-          const createdAt = data.createdAt?.toDate?.();
+          const createdAt = data.data?.toDate?.();
           if (!createdAt) return;
-          if (!allowedUsers.includes(data.userUid)) return;
-          const key = `${data.userUid}_${data.sku}_${createdAt.getTime()}`;
+          if (data.userUid && !allowedUsers.includes(data.userUid)) return;
+          const key = `${data.userUid || ''}_${data.sku}_${createdAt.getTime()}`;
           if (seen.has(key)) return;
           seen.add(key);
           rows.push({
@@ -824,10 +824,10 @@
           loja: loja || '',
           userUid: currentUser.uid,
           userEmail: currentUser.email,
-          createdAt: firebase.firestore.FieldValue.serverTimestamp()
+          data: firebase.firestore.FieldValue.serverTimestamp()
         };
-        batch.set(userDoc.collection('skuimpressos').doc(), data);
-        if (respDoc) batch.set(respDoc.collection('skuimpressos').doc(), data);
+        batch.set(userDoc.collection('etiquetasimpressas').doc(), data);
+        if (respDoc) batch.set(respDoc.collection('etiquetasimpressas').doc(), data);
       });
       await batch.commit();
     }
@@ -879,9 +879,9 @@
       const uid = currentUser.uid;
       const userDoc = db.collection('uid').doc(uid);
       const snap = await userDoc
-        .collection('skuimpressos')
-        .where('createdAt', '>=', firebase.firestore.Timestamp.fromDate(inicio))
-        .where('createdAt', '<', firebase.firestore.Timestamp.fromDate(fim))
+        .collection('etiquetasimpressas')
+        .where('data', '>=', firebase.firestore.Timestamp.fromDate(inicio))
+        .where('data', '<', firebase.firestore.Timestamp.fromDate(fim))
         .get();
       const resumo = {};
       snap.forEach(d => {
@@ -915,9 +915,9 @@
 
     async function gerarRelatorioDiaPorUsuario(inicio, fim, diaDados) {
       const snap = await db
-        .collectionGroup('skuimpressos')
-        .where('createdAt', '>=', firebase.firestore.Timestamp.fromDate(inicio))
-        .where('createdAt', '<', firebase.firestore.Timestamp.fromDate(fim))
+        .collectionGroup('etiquetasimpressas')
+        .where('data', '>=', firebase.firestore.Timestamp.fromDate(inicio))
+        .where('data', '<', firebase.firestore.Timestamp.fromDate(fim))
         .get();
       const resumo = {};
       snap.forEach(d => {

--- a/relatorios.js
+++ b/relatorios.js
@@ -73,9 +73,9 @@ export async function exportarSkuImpressos() {
   fim.setMonth(fim.getMonth() + 1);
 
   const q = query(
-    collection(db, `uid/${uid}/skuimpressos`),
-    where('createdAt', '>=', Timestamp.fromDate(inicio)),
-    where('createdAt', '<', Timestamp.fromDate(fim))
+    collection(db, `uid/${uid}/etiquetasimpressas`),
+    where('data', '>=', Timestamp.fromDate(inicio)),
+    where('data', '<', Timestamp.fromDate(fim))
   );
   const snap = await getDocs(q);
   const linhas = [];
@@ -84,8 +84,8 @@ export async function exportarSkuImpressos() {
     const sku = dados.sku || 'sem-sku';
     const quantidade = Number(dados.quantidade) || 0;
     const loja = dados.loja || '';
-    const data = dados.createdAt && dados.createdAt.toDate
-      ? dados.createdAt.toDate().toLocaleDateString('pt-BR')
+    const data = dados.data && dados.data.toDate
+      ? dados.data.toDate().toLocaleDateString('pt-BR')
       : '';
     linhas.push({ SKU: sku, Quantidade: quantidade, Loja: loja, Data: data });
   });
@@ -149,9 +149,9 @@ export async function exportarSkuImpressosGestor() {
     const uid = u.id;
     const emailUsuario = u.data().email || 'sem-email';
     const q = query(
-      collection(db, `uid/${uid}/skuimpressos`),
-      where('createdAt', '>=', Timestamp.fromDate(inicio)),
-      where('createdAt', '<', Timestamp.fromDate(fim))
+      collection(db, `uid/${uid}/etiquetasimpressas`),
+      where('data', '>=', Timestamp.fromDate(inicio)),
+      where('data', '<', Timestamp.fromDate(fim))
     );
     promessas.push(
       getDocs(q).then(snap => {
@@ -160,8 +160,8 @@ export async function exportarSkuImpressosGestor() {
           const sku = dados.sku || 'sem-sku';
           const quantidade = dados.quantidade || 0;
           const loja = dados.loja || '';
-          const data = dados.createdAt && dados.createdAt.toDate
-            ? dados.createdAt.toDate().toLocaleDateString('pt-BR')
+          const data = dados.data && dados.data.toDate
+            ? dados.data.toDate().toLocaleDateString('pt-BR')
             : '';
           linhas.push({ Usuario: emailUsuario, SKU: sku, Quantidade: quantidade, Loja: loja, Data: data });
         });

--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -436,29 +436,23 @@
   }
   async function savePrintedItems(items, meta){
     console.log('[savePrintedItems] items:', items, 'meta:', meta);
-    // Salva em uid/{uid}/skuimpressos
-    const base = db.collection('uid').doc(currentUser.uid).collection('skuimpressos');
     const batch = db.batch();
-    const now = new Date();
+    const userDoc = db.collection('uid').doc(currentUser.uid);
+    const respDoc = meta.responsavelUid ? db.collection('uid').doc(meta.responsavelUid) : null;
     items.forEach(it=>{
-      const data = { sku: it.sku, quantidade: it.quantidade, loja: meta.loja||null, dataHora: now.toISOString(), numeroSequencial: meta.labelNumber||null, pdfPath: meta.storagePath||null };
-      const doc = base.doc(); batch.set(doc, data, { merge:true });
+      const data = {
+        sku: it.sku,
+        quantidade: it.quantidade,
+        loja: meta.loja || '',
+        userUid: currentUser.uid,
+        userEmail: currentUser.email,
+        data: firebase.firestore.FieldValue.serverTimestamp()
+      };
+      batch.set(userDoc.collection('etiquetasimpressas').doc(), data);
+      if (respDoc) batch.set(respDoc.collection('etiquetasimpressas').doc(), data);
     });
     await batch.commit();
     console.log('[savePrintedItems] saved for current user');
-
-    // Se houver responsável, tenta salvar no UID dele também
-    if(meta.responsavelUid){
-      const base2 = db.collection('uid').doc(meta.responsavelUid).collection('skuimpressos');
-      const batch2 = db.batch();
-      const now2 = new Date();
-      items.forEach(it=>{
-        const data = { sku: it.sku, quantidade: it.quantidade, loja: meta.loja||null, dataHora: now2.toISOString(), numeroSequencial: meta.labelNumber||null, pdfPath: meta.storagePath||null, origemUid: currentUser.uid };
-        const doc = base2.doc(); batch2.set(doc, data, { merge:true });
-      });
-      await batch2.commit();
-      console.log('[savePrintedItems] saved for responsavel', meta.responsavelUid);
-    }
   }
 
   async function savePdfRecord(url, storagePath, name, responsavelUid, foraHorario){

--- a/zpl-import.html
+++ b/zpl-import.html
@@ -206,11 +206,11 @@
                     loja: item.loja || '',
                     userUid: currentUser.uid,
                     userEmail: currentUser.email,
-                    createdAt: firebase.firestore.FieldValue.serverTimestamp()
+                    data: firebase.firestore.FieldValue.serverTimestamp()
                 };
-                batch.set(userDoc.collection('skuimpressos').doc(), data);
+                batch.set(userDoc.collection('etiquetasimpressas').doc(), data);
                 if (respDoc) {
-                    batch.set(respDoc.collection('skuimpressos').doc(), data);
+                    batch.set(respDoc.collection('etiquetasimpressas').doc(), data);
                 }
             });
             await batch.commit();


### PR DESCRIPTION
## Summary
- Ajusta ZPL Import para salvar etiquetas na coleção `etiquetasimpressas` com campo de data unificado
- Atualiza relatórios e ferramentas de expedição para ler/gravar da nova coleção

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c17246db94832aa778712fd713717e