### PR TITLE
Add pedidostiny daily checklist with export

### DIFF
--- a/expedicao.html
+++ b/expedicao.html
@@ -103,7 +103,13 @@
       <div class="overflow-y-auto max-h-96">
         <table class="min-w-full text-sm">
           <thead>
-            <tr><th class="p-2 border">SKU</th><th class="p-2 border">Quantidade</th><th class="p-2 border">Usuário</th></tr>
+            <tr>
+              <th class="p-2 border">ID</th>
+              <th class="p-2 border">Loja</th>
+              <th class="p-2 border">SKU</th>
+              <th class="p-2 border">Data</th>
+              <th class="p-2 border">Usuário</th>
+            </tr>
           </thead>
           <tbody id="checklistBody"></tbody>
         </table>
@@ -125,6 +131,7 @@
  <script type="module">
     import { firebaseConfig, getPassphrase } from './firebase-config.js';
     import { decryptString } from './crypto.js';
+    import { loadSecureDocFromSnap } from './secure-firestore.js';
 
     if (!firebase.apps.length) {
       firebase.initializeApp(firebaseConfig);
@@ -150,6 +157,21 @@
     let attentionOnly = false;
     const equipeUsuarios = new Map();
     let checklistRows = [];
+
+    function parseDate(str) {
+      if (!str) return new Date('');
+      if (typeof str === 'object' && typeof str.toDate === 'function') return str.toDate();
+      if (str instanceof Date) return str;
+      const parts = String(str).split(/[\\/\-]/);
+      if (parts.length === 3) {
+        if (String(str).includes('-') && parts[0].length === 4) {
+          return new Date(str);
+        }
+        const [d, m, y] = parts;
+        return new Date(`${y}-${m}-${d}`);
+      }
+      return new Date(str);
+    }
 
     function escolherGestorEmail(emails) {
       return new Promise(resolve => {
@@ -533,7 +555,7 @@
       checklistBody.innerHTML = '';
       checklistRows = [];
       const now = new Date();
-      const end = new Date(now.toISOString().split('T')[0] + 'T13:00:00');
+      const end = new Date(now.toISOString().split('T')[0] + 'T13:30:00');
       const start = new Date(end);
       start.setDate(start.getDate() - 1);
       start.setHours(17, 0, 0, 0);
@@ -562,70 +584,54 @@
           return userCache.get(uid);
         }
 
-        const acumulados = new Map();
-        async function adicionar(uid, sku, qtd, data) {
-          if (!allowedUsers.includes(uid)) return;
-          const nome = await getNome(uid);
-          const chave = `${uid}_${sku}`;
-          let item = acumulados.get(chave);
-          if (!item) {
-            item = { sku, quantidade: 0, usuario: nome };
+        for (const uid of allowedUsers) {
+          const pass = getPassphrase() || `chave-${uid}`;
+          const snap = await db.collection(`usuarios/${uid}/pedidostiny`).get();
+          for (const doc of snap.docs) {
+            let pedido = await loadSecureDocFromSnap(doc, pass);
+            if (!pedido) continue;
+            const dataStr = pedido.data || pedido.dataPedido || pedido.date || '';
+            const dataPedido = parseDate(dataStr);
+            if (isNaN(dataPedido) || dataPedido < start || dataPedido > end) continue;
+            const id = pedido.idPedido || pedido.idpedido || doc.id;
+            const loja = pedido.loja || pedido.store || '';
+            const sku = pedido.sku || (Array.isArray(pedido.itens) ? pedido.itens.map(i => i.sku).join(', ') : '');
+            const usuario = await getNome(uid);
+            checklistRows.push({ id, loja, sku, data: dataPedido, usuario });
           }
-          item.quantidade += qtd;
-          acumulados.set(chave, item);
-          checklistRows.push({ data, usuario: nome, sku, quantidade: qtd });
         }
 
-        const q1 = db
-          .collectionGroup('skuimpressos')
-          .where('createdAt', '>=', start)
-          .where('createdAt', '<=', end);
-        const snap1 = await q1.get();
-        for (const doc of snap1.docs) {
-          const data = doc.data();
-          const createdAt = data.createdAt?.toDate?.();
-          if (!createdAt) continue;
-          await adicionar(data.userUid, data.sku || '', data.quantidade || 0, createdAt);
+        if (!checklistRows.length) {
+          checklistBody.innerHTML = '<tr><td class="p-2 text-center text-gray-500" colspan="5">Nenhum registro</td></tr>';
+          return;
         }
 
-        const q2 = db
-          .collectionGroup('etiquetasimpressas')
-          .where('data', '>=', start)
-          .where('data', '<=', end);
-        const snap2 = await q2.get();
-        for (const doc of snap2.docs) {
-          const data = doc.data();
-          const createdAt = data.data?.toDate?.();
-          if (!createdAt) continue;
-          const uid = doc.ref.parent.parent?.id;
-          if (!uid) continue;
-          await adicionar(uid, data.sku || '', data.quantidade || 0, createdAt);
-        }
-
-        const rows = Array.from(acumulados.values());
-        rows.forEach(r => {
+        checklistRows.sort((a, b) => a.data - b.data);
+        checklistRows.forEach(r => {
           const tr = document.createElement('tr');
-          tr.innerHTML = `<td class="p-2 border">${r.sku}</td><td class="p-2 border">${r.quantidade}</td><td class="p-2 border">${r.usuario}</td>`;
+          tr.innerHTML = `<td class="p-2 border">${r.id}</td>` +
+                         `<td class="p-2 border">${r.loja}</td>` +
+                         `<td class="p-2 border">${r.sku}</td>` +
+                         `<td class="p-2 border">${r.data.toLocaleString('pt-BR')}</td>` +
+                         `<td class="p-2 border">${r.usuario}</td>`;
           checklistBody.appendChild(tr);
         });
-        if (!rows.length) {
-          checklistBody.innerHTML = '<tr><td class="p-2 text-center text-gray-500" colspan="3">Nenhum registro</td></tr>';
-        }
       } catch (e) {
         console.error('Erro ao carregar checklist:', e);
-        checklistBody.innerHTML = '<tr><td class="p-2 text-center text-red-500" colspan="3">Erro ao carregar</td></tr>';
+        checklistBody.innerHTML = '<tr><td class="p-2 text-center text-red-500" colspan="5">Erro ao carregar</td></tr>';
       }
     }
 
     function exportarChecklist() {
       if (!checklistRows.length) return;
       const wsData = checklistRows.map(r => ({
-        Data: r.data.toISOString().split('T')[0],
-        Usuario: r.usuario,
+        ID: r.id,
+        Loja: r.loja,
         SKU: r.sku,
-        Quantidade: r.quantidade
+        Data: r.data.toLocaleString('pt-BR'),
+        Usuario: r.usuario
       }));
-      const ws = XLSX.utils.json_to_sheet(wsData, { header: ['Data', 'Usuario', 'SKU', 'Quantidade'] });
+      const ws = XLSX.utils.json_to_sheet(wsData, { header: ['ID', 'Loja', 'SKU', 'Data', 'Usuario'] });
       const wb = XLSX.utils.book_new();
       XLSX.utils.book_append_sheet(wb, ws, 'Checklist');
       XLSX.writeFile(wb, 'checklist_expedicao.xlsx');


### PR DESCRIPTION
## Summary
- list pedidostiny orders between 17:00 yesterday and 13:30 today with id, store, SKU, date and user
- enable export of the daily checklist to Excel with these fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c180bc3f0c832ab69f023433c3693f