### PR TITLE
fix: use modular firestore for checklist

### DIFF
--- a/expedicao.html
+++ b/expedicao.html
@@ -132,6 +132,7 @@
     }
     const db = firebase.firestore();
     const storage = firebase.storage();
+    const dbMod = db._delegate || db; // Firestore instance for modular APIs
     pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js';
     let currentUser = null;
     let currentFilter = 'all';
@@ -624,7 +625,7 @@
             const col = db.collection(`usuarios/${uid}/pedidostiny`);
             const snap = await col.get();
             for (const doc of snap.docs) {
-              let pedido = await loadSecureDoc(db, `usuarios/${uid}/pedidostiny`, doc.id, pass);
+              let pedido = await loadSecureDoc(dbMod, `usuarios/${uid}/pedidostiny`, doc.id, pass);
               if (!pedido) {
                 const raw = doc.data();
                 if (raw && !raw.encrypted && !raw.encryptedData) pedido = raw;


### PR DESCRIPTION
## Summary
- ensure checklist loader uses modular Firestore to prevent collection() errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c18301f74c832ab8877bf7876d577b