### PR TITLE
Corrige comparação de pedidos na aba Coletas

### DIFF
--- a/coletas.html
+++ b/coletas.html
@@ -157,16 +157,22 @@
       const tinyCol = db.collection('usuarios').doc(currentUser.uid).collection('pedidostiny');
       for (const o of orders) {
         try {
+          // procura pelo pedido usando a chave interna "idPedido"
+          let qSnap = await tinyCol.where('idPedido', '==', o.numeroPedido).limit(1).get();
+          // fallback para alguns registros que utilizam "numeroPedido"
+          if (qSnap.empty) {
+            qSnap = await tinyCol.where('numeroPedido', '==', o.numeroPedido).limit(1).get();
+          }
+          if (!qSnap.empty) {
+            const foundRef = tinyCol.doc(qSnap.docs[0].id);
+            await foundRef.set({ coletado: true }, { merge: true });
+            continue;
+          }
+          // por fim, tenta atualizar um documento cujo ID seja o número do pedido
           const docRef = tinyCol.doc(o.numeroPedido);
           const docSnap = await docRef.get();
           if (docSnap.exists) {
             await docRef.set({ coletado: true }, { merge: true });
-            continue;
-          }
-          const qSnap = await tinyCol.where('idPedido', '==', o.numeroPedido).limit(1).get();
-          if (!qSnap.empty) {
-            const foundRef = tinyCol.doc(qSnap.docs[0].id);
-            await foundRef.set({ coletado: true }, { merge: true });
           }
         } catch (err) {
           console.error('Erro ao marcar pedido coletado no Tiny:', o.numeroPedido, err);


### PR DESCRIPTION
## Summary
- Ajusta a busca de pedidos do Tiny pelo campo interno `idPedido`
- Adiciona fallback para `numeroPedido` e ID do documento ao marcar pedidos coletados

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1c0eb1090832ab49741edcff5fb54