### PR TITLE
Registrar pedidos reais criptografados e exibir na expedição

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -122,7 +122,8 @@
   </div>
 
 <script type="module">
-    import { firebaseConfig } from './firebase-config.js';
+    import { firebaseConfig, getPassphrase } from './firebase-config.js';
+    import { saveSecureDoc } from './secure-firestore.js';
   // =============================================
     // CONFIGURAÇÃO INICIAL E VARIÁVEIS GLOBAIS
     // =============================================
@@ -146,7 +147,7 @@ let graficoBarras, graficoPizza, graficoPrevisao;
 let previsaoDados = {};
 let initialTab = null;
 const API_URL = 'https://us-central1-matheus-35023.cloudfunctions.net/proxyDeepSeek';
-   const tabIds = ['importar','metas','graficos','historico','faturamento','registroFaturamento','controleVendas','sobras','previsao','acompanhamento','acompanhamentoGestor'];
+   const tabIds = ['importar','metas','graficos','historico','faturamento','registroFaturamento','pedidosReais','controleVendas','sobras','previsao','acompanhamento','acompanhamentoGestor'];
       const tabsLoaded = Promise.all(
         tabIds.map(t =>
           fetch(`sobras-tabs/${t}.html`)
@@ -1479,6 +1480,18 @@ document.getElementById("dadosSobrasIA").value = sobras.map(s => {
             }
           }
 
+          const expEmails = dadosUsuario.gestoresExpedicaoEmails || dadosUsuario.responsavelExpedicaoEmail || [];
+          let responsavelExpedicaoUid = null;
+          const expEmail = Array.isArray(expEmails) ? expEmails[0] : expEmails;
+          if (expEmail) {
+            const expSnap = await db.collection('usuarios').where('email', '==', expEmail).limit(1).get();
+            if (!expSnap.empty) {
+              const expDoc = expSnap.docs[0];
+              const expData = expDoc.data() || {};
+              responsavelExpedicaoUid = expData.uid || expDoc.id;
+            }
+          }
+
 const dataInput = document.getElementById("dataFaturamento");
           const lojaInput = document.getElementById("lojaFaturamento");
           const dataReferencia = dataInput?.value;
@@ -1508,26 +1521,41 @@ const dataInput = document.getElementById("dataFaturamento");
             let bruto = 0, taxas = 0, qtdVendas = 0;
             const skusVendidos = {};
             const pedidosErrados = [];
+            const pedidosReais = [];
 
             rows.forEach((row) => {
             const status = (row["Status do pedido"] || "").toLowerCase();
-            if (status.includes("cancelado") || status.includes("não pago")) return;
-
-            const subtotal = parseFloat(row["Subtotal do produto"]) || 0;
-            const reembolso = parseFloat(row["Reembolso Shopee"]) || 0;
-            const cupom = parseFloat(row["Cupom do vendedor"]) || 0;
-            const comissao = parseFloat(row["Taxa de comissão"]) || 0;
-            const servico = parseFloat(row["Taxa de serviço"]) || 0;
-
-            const liquidoLinha = subtotal + reembolso - cupom - comissao - servico;
-
-            bruto += subtotal + reembolso;
-            taxas += cupom + comissao + servico;
-            qtdVendas++;
-
               const headers = Object.keys(row);
               const headerSKU = headers.find(h => h.trim() === "Número de referência SKU"); // pega o nome exato
               const sku = headerSKU ? row[headerSKU] : null;
+
+              const subtotal = parseFloat(row["Subtotal do produto"]) || 0;
+              const reembolso = parseFloat(row["Reembolso Shopee"]) || 0;
+              const cupom = parseFloat(row["Cupom do vendedor"]) || 0;
+              const comissao = parseFloat(row["Taxa de comissão"]) || 0;
+              const servico = parseFloat(row["Taxa de serviço"]) || 0;
+              const taxasPedido = cupom + comissao + servico;
+              const liquidoLinha = subtotal + reembolso - taxasPedido;
+
+              const pedidoReal = {
+                status: status,
+                sku: sku,
+                loja: loja,
+                data: dataReferencia,
+                subtotal: subtotal,
+                taxas: taxasPedido,
+                liquido: liquidoLinha,
+                uid: usuarioLogado.uid
+              };
+              if (reembolso) pedidoReal.reembolso = reembolso;
+              pedidosReais.push(pedidoReal);
+
+            if (status.includes("cancelado") || status.includes("não pago")) return;
+
+            bruto += subtotal + reembolso;
+            taxas += taxasPedido;
+            qtdVendas++;
+
               if (!sku) return;
 
               if (!skusVendidos[sku]) skusVendidos[sku] = { total: 0, valorLiquido: 0 };
@@ -1558,6 +1586,37 @@ const dataInput = document.getElementById("dataFaturamento");
                 });
               }
             });
+
+            if (pedidosReais.length) {
+              const systemPassphrase = getPassphrase();
+              const basePath = `uid/${usuarioLogado.uid}/pedidosreais`;
+              for (const pedido of pedidosReais) {
+                const id = db.collection('uid').doc(usuarioLogado.uid).collection('pedidosreais').doc().id;
+                // Salva na coleção do usuário com a chave padrão do sistema
+                await saveSecureDoc(db, basePath, id, { ...pedido, uid: usuarioLogado.uid }, systemPassphrase);
+                if (responsavelExpedicaoUid && responsavelExpedicaoUid !== usuarioLogado.uid) {
+                  // Cópia para o gestor de expedição, criptografada com o UID dele
+                  await saveSecureDoc(
+                    db,
+                    `uid/${responsavelExpedicaoUid}/uid/${usuarioLogado.uid}/pedidosreais`,
+                    id,
+                    { ...pedido, uid: usuarioLogado.uid },
+                    responsavelExpedicaoUid
+                  );
+                }
+                const respFinUid = window.responsavelFinanceiro?.uid;
+                if (respFinUid && respFinUid !== usuarioLogado.uid && respFinUid !== responsavelExpedicaoUid) {
+                  // Cópia para o responsável financeiro, criptografada com o UID dele
+                  await saveSecureDoc(
+                    db,
+                    `uid/${respFinUid}/uid/${usuarioLogado.uid}/pedidosreais`,
+                    id,
+                    { ...pedido, uid: usuarioLogado.uid },
+                    respFinUid
+                  );
+                }
+              }
+            }
 
             if (pedidosErrados.length) {
               const errRef = db

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -163,6 +163,7 @@
       <ul id="menuVendas" class="submenu space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
         <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento" class="sidebar-link block py-2 px-4 transition-colors">Registrar Faturamento</a></li>
         <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=registroFaturamento" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Faturamento</a></li>
+        <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=pedidosReais" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Reais</a></li>
         <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=controleVendas" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Vendas</a></li>
         <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamento" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Mensal</a></li>
       </ul>

--- a/sobras-tabs/pedidosReais.html
+++ b/sobras-tabs/pedidosReais.html
@@ -1,0 +1,55 @@
+<div class="card">
+  <div class="card-header">
+    <h3 class="text-lg font-semibold">Pedidos Reais</h3>
+  </div>
+  <div class="overflow-x-auto">
+    <table class="min-w-full text-sm">
+      <thead>
+        <tr>
+          <th class="p-2 border">Status</th>
+          <th class="p-2 border">SKU</th>
+          <th class="p-2 border">Loja</th>
+          <th class="p-2 border">Data</th>
+          <th class="p-2 border">Subtotal</th>
+          <th class="p-2 border">Taxas</th>
+          <th class="p-2 border">Líquido</th>
+          <th class="p-2 border">Reembolso</th>
+        </tr>
+      </thead>
+      <tbody id="pedidosReaisBody"></tbody>
+    </table>
+  </div>
+</div>
+
+<script type="module">
+  import { firebaseConfig, getPassphrase } from '../firebase-config.js';
+  import { loadSecureDocFromSnap } from '../secure-firestore.js';
+  if (!firebase.apps.length) {
+    firebase.initializeApp(firebaseConfig);
+  }
+  const db = firebase.firestore();
+  const passphrase = getPassphrase();
+  const tbody = document.getElementById('pedidosReaisBody');
+  const uid = window.usuarioLogado?.uid;
+  if (uid && passphrase) {
+    db.collection('uid').doc(uid).collection('pedidosreais').onSnapshot(async snap => {
+      tbody.innerHTML = '';
+      for (const doc of snap.docs) {
+        const data = await loadSecureDocFromSnap(doc, passphrase);
+        if (!data) continue;
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td class="p-2 border">${data.status || ''}</td>
+          <td class="p-2 border">${data.sku || ''}</td>
+          <td class="p-2 border">${data.loja || ''}</td>
+          <td class="p-2 border">${data.data || ''}</td>
+          <td class="p-2 border">${(data.subtotal || 0).toFixed(2)}</td>
+          <td class="p-2 border">${(data.taxas || 0).toFixed(2)}</td>
+          <td class="p-2 border">${(data.liquido || 0).toFixed(2)}</td>
+          <td class="p-2 border">${data.reembolso ? data.reembolso.toFixed(2) : '-'}</td>
+        `;
+        tbody.appendChild(tr);
+      }
+    });
+  }
+</script>


### PR DESCRIPTION
## Summary
- Salva pedidos reais criptografados na coleção do usuário com chave padrão
- Criptografa cópias para gestor de expedição e responsável financeiro usando o UID de cada um

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c207d3eb20832a9dbaf74d3b267d8c