### PR TITLE
Handle missing alert elements

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -331,22 +331,30 @@ const API_URL = 'https://us-central1-matheus-35023.cloudfunctions.net/proxyDeepS
     
     function mostrarSucesso(mensagem) {
       const alerta = document.getElementById('alertSuccess');
-      alerta.querySelector('.alert-content').textContent = mensagem;
-      alerta.style.display = 'flex';
-      
-      setTimeout(() => {
-        alerta.style.display = 'none';
-      }, 5000);
+      const conteudo = alerta?.querySelector('.alert-content');
+      if (alerta && conteudo) {
+        conteudo.textContent = mensagem;
+        alerta.style.display = 'flex';
+        setTimeout(() => {
+          alerta.style.display = 'none';
+        }, 5000);
+      } else {
+        Swal.fire('Sucesso', mensagem, 'success');
+      }
     }
 
     function mostrarErro(mensagem) {
       const alerta = document.getElementById('alertError');
-      alerta.querySelector('.alert-content').textContent = mensagem;
-      alerta.style.display = 'flex';
-      
-      setTimeout(() => {
-        alerta.style.display = 'none';
-      }, 5000);
+      const conteudo = alerta?.querySelector('.alert-content');
+      if (alerta && conteudo) {
+        conteudo.textContent = mensagem;
+        alerta.style.display = 'flex';
+        setTimeout(() => {
+          alerta.style.display = 'none';
+        }, 5000);
+      } else {
+        Swal.fire('Erro', mensagem, 'error');
+      }
     }
 
     function toggleLoading(botao, texto) {


### PR DESCRIPTION
## Summary
- Avoid querySelector null errors by checking for alert elements before use
- Use SweetAlert fallback when custom alerts are absent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c210b80af8832aa6ff52fdf908eaf5