### PR TITLE
Fix Firestore collection call in faturamento import

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -1736,7 +1736,7 @@ const dataInput = document.getElementById("dataFaturamento");
             uid: usuarioLogado.uid
         };
           const encResumo = await encryptString(JSON.stringify(resumoPayload), pass);
-await db
+          await firebase.firestore()
             .collection('uid')
             .doc(usuarioLogado.uid)
             .collection('faturamento')


### PR DESCRIPTION
## Summary
- ensure faturamento import uses firebase.firestore() when saving resumo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c211d1df84832a879f98a956208656