### PR TITLE
Registrar pedidos reais com cópias criptografadas

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -1479,6 +1479,20 @@ document.getElementById("dadosSobrasIA").value = sobras.map(s => {
             }
           }
 
+          const gestorEmail = Array.isArray(dadosUsuario.gestoresExpedicaoEmails)
+            ? dadosUsuario.gestoresExpedicaoEmails[0]
+            : dadosUsuario.responsavelExpedicaoEmail || null;
+          let baseExp = null;
+          if (gestorEmail) {
+            const expSnap = await db.collection('usuarios').where('email', '==', gestorEmail).limit(1).get();
+            if (!expSnap.empty) {
+              const expDoc = expSnap.docs[0];
+              const expData = expDoc.data() || {};
+              const gestorUid = expData.uid || expDoc.id;
+              baseExp = db.collection('uid').doc(gestorUid).collection('uid').doc(usuarioLogado.uid);
+            }
+          }
+
 const dataInput = document.getElementById("dataFaturamento");
           const lojaInput = document.getElementById("lojaFaturamento");
           const dataReferencia = dataInput?.value;
@@ -1636,8 +1650,47 @@ const dataInput = document.getElementById("dataFaturamento");
                 .set({ encrypted: encSku, uid: usuarioLogado.uid });
             }
           }
-
+          
           const pass = getPassphrase() || usuarioLogado.uid;
+
+          const pedidosRef = db.collection('uid').doc(usuarioLogado.uid).collection('pedidosreais');
+          for (const row of rows) {
+            const statusPedido = row['Status do pedido'] || '';
+            const headersPedido = Object.keys(row);
+            const headerSku = headersPedido.find(h => h.trim() === 'Número de referência SKU');
+            const skuPedido = headerSku ? row[headerSku] : null;
+            const headerPedidoId = headersPedido.find(h => h.toLowerCase().includes('pedido') && h.toLowerCase().includes('id'));
+            const pedidoId = headerPedidoId ? row[headerPedidoId] : null;
+            const subtotalPedido = parseFloat(row['Subtotal do produto']) || 0;
+            const reembolsoPedido = parseFloat(row['Reembolso Shopee']) || 0;
+            const cupomPedido = parseFloat(row['Cupom do vendedor']) || 0;
+            const comissaoPedido = parseFloat(row['Taxa de comissão']) || 0;
+            const servicoPedido = parseFloat(row['Taxa de serviço']) || 0;
+            const taxasPedido = cupomPedido + comissaoPedido + servicoPedido;
+            const liquidoPedido = subtotalPedido + reembolsoPedido - taxasPedido;
+            if (!pedidoId) continue;
+            const pedidoPayload = {
+              pedidoId,
+              status: statusPedido,
+              sku: skuPedido,
+              loja,
+              data: dataReferencia,
+              subtotal: subtotalPedido,
+              taxas: taxasPedido,
+              liquido: liquidoPedido,
+              reembolso: reembolsoPedido
+            };
+            const encPedido = await encryptString(JSON.stringify(pedidoPayload), pass);
+            await pedidosRef.add({ encrypted: encPedido, uid: usuarioLogado.uid });
+            if (baseResp && respEmail) {
+              const encPedidoResp = await encryptString(JSON.stringify(pedidoPayload), respEmail);
+              await baseResp.collection('pedidosreais').add({ encrypted: encPedidoResp, uid: usuarioLogado.uid });
+            }
+            if (baseExp && gestorEmail) {
+              const encPedidoExp = await encryptString(JSON.stringify(pedidoPayload), gestorEmail);
+              await baseExp.collection('pedidosreais').add({ encrypted: encPedidoExp, uid: usuarioLogado.uid });
+            }
+          }
 
           const lojaPayload = {
             valorBruto: bruto,

--- a/expedicao-pedidosreais.html
+++ b/expedicao-pedidosreais.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Pedidos Reais</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css?v=20240826">
+  <link rel="stylesheet" href="css/mobile.css">
+  <link rel="stylesheet" href="css/components.css">
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
+</head>
+<body class="bg-gray-100">
+  <div id="sidebar-container"></div>
+  <div id="navbar-container"></div>
+  <div class="main-content p-4">
+    <h1 class="text-2xl font-bold mb-4">Pedidos Reais</h1>
+    <div class="bg-white rounded shadow overflow-x-auto">
+      <table class="min-w-full">
+        <thead>
+          <tr class="bg-gray-200 text-left">
+            <th class="p-2">Pedido</th>
+            <th class="p-2">Data</th>
+            <th class="p-2">Loja</th>
+            <th class="p-2">SKU</th>
+            <th class="p-2">Status</th>
+            <th class="p-2">Subtotal</th>
+            <th class="p-2">Taxas</th>
+            <th class="p-2">Líquido</th>
+            <th class="p-2">Reembolso</th>
+          </tr>
+        </thead>
+        <tbody id="pedidosTable"></tbody>
+      </table>
+    </div>
+  </div>
+
+  <script type="module">
+    import { firebaseConfig, getPassphrase } from './firebase-config.js';
+
+    if (!firebase.apps.length) {
+      firebase.initializeApp(firebaseConfig);
+    }
+    const db = firebase.firestore();
+
+    firebase.auth().onAuthStateChanged(async user => {
+      if (!user) {
+        window.location.href = 'index.html?login=1';
+        return;
+      }
+      carregarPedidos(user);
+    });
+
+    async function carregarPedidos(user) {
+      const tbody = document.getElementById('pedidosTable');
+      tbody.innerHTML = '';
+      try {
+        const pass = getPassphrase() || user.uid;
+        const { decryptString } = await import('./crypto.js');
+        const snap = await db.collection('uid').doc(user.uid).collection('pedidosreais').orderBy('data', 'desc').get();
+        if (snap.empty) {
+          const tr = document.createElement('tr');
+          tr.innerHTML = '<td class="p-2 text-center text-gray-500" colspan="9">Sem registros.</td>';
+          tbody.appendChild(tr);
+          return;
+        }
+        for (const doc of snap.docs) {
+          let d = doc.data();
+          if (d.encrypted) {
+            try {
+              const txt = await decryptString(d.encrypted, pass);
+              d = JSON.parse(txt);
+            } catch (e) {
+              console.error('Erro ao descriptografar pedido', e);
+              continue;
+            }
+          }
+          const fmt = n => `R$ ${Number(n || 0).toLocaleString('pt-BR', { minimumFractionDigits: 2 })}`;
+          const tr = document.createElement('tr');
+          tr.className = 'border-b';
+          tr.innerHTML = `
+            <td class="p-2">${d.pedidoId || ''}</td>
+            <td class="p-2">${d.data || ''}</td>
+            <td class="p-2">${d.loja || ''}</td>
+            <td class="p-2">${d.sku || ''}</td>
+            <td class="p-2">${d.status || ''}</td>
+            <td class="p-2">${fmt(d.subtotal)}</td>
+            <td class="p-2">${fmt(d.taxas)}</td>
+            <td class="p-2">${fmt(d.liquido)}</td>
+            <td class="p-2">${fmt(d.reembolso)}</td>
+          `;
+          tbody.appendChild(tr);
+        }
+      } catch (e) {
+        console.error('Erro ao carregar pedidos:', e);
+        const tr = document.createElement('tr');
+        tr.innerHTML = '<td class="p-2 text-center text-red-500" colspan="9">Erro ao carregar pedidos</td>';
+        tbody.appendChild(tr);
+      }
+    }
+  </script>
+</body>
+</html>
+

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -283,6 +283,7 @@
         <li><a href="relatorios.html" class="sidebar-link block py-2 px-4 transition-colors">Relatórios</a></li>
         <li><a href="coletas.html" class="sidebar-link block py-2 px-4 transition-colors">Coletas</a></li>
         <li><a href="expedicao-historico.html" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a></li>
+        <li><a href="expedicao-pedidosreais.html" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Reais</a></li>
       </ul>
     </li>
     <li>


### PR DESCRIPTION
## Summary
- Salva todos os pedidos importados em uma nova coleção `pedidosreais`, incluindo subtotais, taxas, líquido e reembolsos, além de gerar cópias criptografadas para gestor de expedição e responsável financeiro
- Cria página **Pedidos Reais** na área de expedição para visualizar os pedidos registrados
- Adiciona link de acesso à nova página no menu de expedição

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2154f496c832aaaf23c9c6c609b42