### PR TITLE
Fix retrieval of encrypted real orders

### DIFF
--- a/expedicao-pedidosreais.html
+++ b/expedicao-pedidosreais.html
@@ -136,7 +136,7 @@
       try {
         const pass = getPassphrase() || user.uid;
         const { decryptString } = await import('./crypto.js');
-        const snap = await db.collection('uid').doc(user.uid).collection('pedidosreais').orderBy('data', 'desc').get();
+        const snap = await db.collection('uid').doc(user.uid).collection('pedidosreais').get();
         todosPedidos = [];
         for (const doc of snap.docs) {
           let d = doc.data();
@@ -151,6 +151,11 @@
           }
           todosPedidos.push(d);
         }
+        todosPedidos.sort((a, b) => {
+          const da = parseDate(a.data);
+          const db = parseDate(b.data);
+          return db - da;
+        });
       } catch (e) {
         console.error('Erro ao carregar pedidos:', e);
       }


### PR DESCRIPTION
## Summary
- Fetch real orders without ordering by encrypted fields and sort after decryption so stored orders display correctly.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c21a9e421c832aba3d40ba20431a1e