### PR TITLE
fix: decrypt real orders

### DIFF
--- a/expedicao-pedidosreais.html
+++ b/expedicao-pedidosreais.html
@@ -134,23 +134,39 @@
 
     async function carregarPedidos(user) {
       try {
-        const pass = getPassphrase() || user.uid;
         const { decryptString } = await import('./crypto.js');
-        const snap = await db.collection('uid').doc(user.uid).collection('pedidosreais').orderBy('data', 'desc').get();
+        const snap = await db.collection('uid').doc(user.uid).collection('pedidosreais').get();
         todosPedidos = [];
+        const candidates = [getPassphrase(), user?.email, `chave-${user.uid}`, user.uid];
         for (const doc of snap.docs) {
           let d = doc.data();
           if (d.encrypted) {
+            let txt;
+            for (const p of candidates) {
+              if (!p) continue;
+              try {
+                txt = await decryptString(d.encrypted, p);
+                if (txt) break;
+              } catch (_) {}
+            }
+            if (!txt) {
+              console.error('Erro ao descriptografar pedido');
+              continue;
+            }
             try {
-              const txt = await decryptString(d.encrypted, pass);
               d = JSON.parse(txt);
             } catch (e) {
-              console.error('Erro ao descriptografar pedido', e);
+              console.error('JSON inválido no pedido', e);
               continue;
             }
           }
           todosPedidos.push(d);
         }
+        todosPedidos.sort((a, b) => {
+          const da = parseDate(a.data);
+          const db = parseDate(b.data);
+          return db - da;
+        });
       } catch (e) {
         console.error('Erro ao carregar pedidos:', e);
       }


### PR DESCRIPTION
## Summary
- handle multiple passphrases when decrypting real orders
- sort real orders after decryption

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c21a9e421c832aba3d40ba20431a1e