### PR TITLE
Group real orders by date and expose order IDs

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -1653,7 +1653,29 @@ const dataInput = document.getElementById("dataFaturamento");
           
           const pass = getPassphrase() || usuarioLogado.uid;
 
-          const pedidosRef = db.collection('uid').doc(usuarioLogado.uid).collection('pedidosreais');
+          const pedidosDataRef = db
+            .collection('uid')
+            .doc(usuarioLogado.uid)
+            .collection('pedidosreais')
+            .doc(dataReferencia);
+          await pedidosDataRef.set({ data: dataReferencia, uid: usuarioLogado.uid }, { merge: true });
+          const pedidosRef = pedidosDataRef.collection('lista');
+          let pedidosRespRef = null;
+          if (baseResp && respEmail) {
+            pedidosRespRef = baseResp
+              .collection('pedidosreais')
+              .doc(dataReferencia);
+            await pedidosRespRef.set({ data: dataReferencia, uid: usuarioLogado.uid }, { merge: true });
+            pedidosRespRef = pedidosRespRef.collection('lista');
+          }
+          let pedidosExpRef = null;
+          if (baseExp && gestorEmail) {
+            pedidosExpRef = baseExp
+              .collection('pedidosreais')
+              .doc(dataReferencia);
+            await pedidosExpRef.set({ data: dataReferencia, uid: usuarioLogado.uid }, { merge: true });
+            pedidosExpRef = pedidosExpRef.collection('lista');
+          }
           for (const row of rows) {
             const statusPedido = row['Status do pedido'] || '';
             const headersPedido = Object.keys(row);
@@ -1681,14 +1703,14 @@ const dataInput = document.getElementById("dataFaturamento");
               reembolso: reembolsoPedido
             };
             const encPedido = await encryptString(JSON.stringify(pedidoPayload), pass);
-            await pedidosRef.add({ encrypted: encPedido, uid: usuarioLogado.uid });
-            if (baseResp && respEmail) {
+            await pedidosRef.doc(String(pedidoId)).set({ encrypted: encPedido, uid: usuarioLogado.uid });
+            if (pedidosRespRef) {
               const encPedidoResp = await encryptString(JSON.stringify(pedidoPayload), respEmail);
-              await baseResp.collection('pedidosreais').add({ encrypted: encPedidoResp, uid: usuarioLogado.uid });
+              await pedidosRespRef.doc(String(pedidoId)).set({ encrypted: encPedidoResp, uid: usuarioLogado.uid });
             }
-            if (baseExp && gestorEmail) {
+            if (pedidosExpRef) {
               const encPedidoExp = await encryptString(JSON.stringify(pedidoPayload), gestorEmail);
-              await baseExp.collection('pedidosreais').add({ encrypted: encPedidoExp, uid: usuarioLogado.uid });
+              await pedidosExpRef.doc(String(pedidoId)).set({ encrypted: encPedidoExp, uid: usuarioLogado.uid });
             }
           }
 

--- a/expedicao-pedidosreais.html
+++ b/expedicao-pedidosreais.html
@@ -135,32 +135,36 @@
     async function carregarPedidos(user) {
       try {
         const { decryptString } = await import('./crypto.js');
-        const snap = await db.collection('uid').doc(user.uid).collection('pedidosreais').get();
+        const rootSnap = await db.collection('uid').doc(user.uid).collection('pedidosreais').get();
         todosPedidos = [];
         const candidates = [getPassphrase(), user?.email, `chave-${user.uid}`, user.uid];
-        for (const doc of snap.docs) {
-          let d = doc.data();
-          if (d.encrypted) {
-            let txt;
-            for (const p of candidates) {
-              if (!p) continue;
+        for (const dataDoc of rootSnap.docs) {
+          const listaSnap = await dataDoc.ref.collection('lista').get();
+          for (const doc of listaSnap.docs) {
+            let d = doc.data();
+            if (d.encrypted) {
+              let txt;
+              for (const p of candidates) {
+                if (!p) continue;
+                try {
+                  txt = await decryptString(d.encrypted, p);
+                  if (txt) break;
+                } catch (_) {}
+              }
+              if (!txt) {
+                console.error('Erro ao descriptografar pedido');
+                continue;
+              }
               try {
-                txt = await decryptString(d.encrypted, p);
-                if (txt) break;
-              } catch (_) {}
+                d = JSON.parse(txt);
+              } catch (e) {
+                console.error('JSON inválido no pedido', e);
+                continue;
+              }
             }
-            if (!txt) {
-              console.error('Erro ao descriptografar pedido');
-              continue;
-            }
-            try {
-              d = JSON.parse(txt);
-            } catch (e) {
-              console.error('JSON inválido no pedido', e);
-              continue;
-            }
+            if (!d.pedidoId) d.pedidoId = doc.id;
+            todosPedidos.push(d);
           }
-          todosPedidos.push(d);
         }
         todosPedidos.sort((a, b) => {
           const da = parseDate(a.data);


### PR DESCRIPTION
## Summary
- Store real orders under date-based documents with order ID as document key
- Fetch and render all orders across dates in real orders view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c21c7c8378832a94f5dcc7e2fa300f