### PR TITLE
Agrupa pedidos por data e exibe ID em pedidos reais

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -1681,14 +1681,28 @@ const dataInput = document.getElementById("dataFaturamento");
               reembolso: reembolsoPedido
             };
             const encPedido = await encryptString(JSON.stringify(pedidoPayload), pass);
-            await pedidosRef.add({ encrypted: encPedido, uid: usuarioLogado.uid });
+            await pedidosRef
+              .doc(dataReferencia)
+              .collection('lista')
+              .doc(pedidoId)
+              .set({ encrypted: encPedido, uid: usuarioLogado.uid });
             if (baseResp && respEmail) {
               const encPedidoResp = await encryptString(JSON.stringify(pedidoPayload), respEmail);
-              await baseResp.collection('pedidosreais').add({ encrypted: encPedidoResp, uid: usuarioLogado.uid });
+              await baseResp
+                .collection('pedidosreais')
+                .doc(dataReferencia)
+                .collection('lista')
+                .doc(pedidoId)
+                .set({ encrypted: encPedidoResp, uid: usuarioLogado.uid });
             }
             if (baseExp && gestorEmail) {
               const encPedidoExp = await encryptString(JSON.stringify(pedidoPayload), gestorEmail);
-              await baseExp.collection('pedidosreais').add({ encrypted: encPedidoExp, uid: usuarioLogado.uid });
+              await baseExp
+                .collection('pedidosreais')
+                .doc(dataReferencia)
+                .collection('lista')
+                .doc(pedidoId)
+                .set({ encrypted: encPedidoExp, uid: usuarioLogado.uid });
             }
           }
 

--- a/expedicao-pedidosreais.html
+++ b/expedicao-pedidosreais.html
@@ -135,32 +135,37 @@
     async function carregarPedidos(user) {
       try {
         const { decryptString } = await import('./crypto.js');
-        const snap = await db.collection('uid').doc(user.uid).collection('pedidosreais').get();
+        const pedidosRef = db.collection('uid').doc(user.uid).collection('pedidosreais');
+        const datasSnap = await pedidosRef.get();
         todosPedidos = [];
         const candidates = [getPassphrase(), user?.email, `chave-${user.uid}`, user.uid];
-        for (const doc of snap.docs) {
-          let d = doc.data();
-          if (d.encrypted) {
-            let txt;
-            for (const p of candidates) {
-              if (!p) continue;
+        for (const dataDoc of datasSnap.docs) {
+          const listaSnap = await dataDoc.ref.collection('lista').get();
+          for (const doc of listaSnap.docs) {
+            let d = doc.data();
+            if (d.encrypted) {
+              let txt;
+              for (const p of candidates) {
+                if (!p) continue;
+                try {
+                  txt = await decryptString(d.encrypted, p);
+                  if (txt) break;
+                } catch (_) {}
+              }
+              if (!txt) {
+                console.error('Erro ao descriptografar pedido');
+                continue;
+              }
               try {
-                txt = await decryptString(d.encrypted, p);
-                if (txt) break;
-              } catch (_) {}
+                d = JSON.parse(txt);
+              } catch (e) {
+                console.error('JSON inválido no pedido', e);
+                continue;
+              }
             }
-            if (!txt) {
-              console.error('Erro ao descriptografar pedido');
-              continue;
-            }
-            try {
-              d = JSON.parse(txt);
-            } catch (e) {
-              console.error('JSON inválido no pedido', e);
-              continue;
-            }
+            d.pedidoId = d.pedidoId || doc.id;
+            todosPedidos.push(d);
           }
-          todosPedidos.push(d);
         }
         todosPedidos.sort((a, b) => {
           const da = parseDate(a.data);


### PR DESCRIPTION
## Summary
- Agrupa pedidos reais por data ao salvar no Firestore e usa o ID do pedido como documento
- Ajusta a página de pedidos reais para ler todas as datas e mostrar o ID do pedido

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c21c7c8378832a94f5dcc7e2fa300f