### PR TITLE
Fix real orders page not loading orders

### DIFF
--- a/expedicao-pedidosreais.html
+++ b/expedicao-pedidosreais.html
@@ -135,27 +135,24 @@
     async function carregarPedidos(user) {
       try {
         const { decryptString } = await import('./crypto.js');
-        const pedidosRef = db.collection('uid').doc(user.uid).collection('pedidosreais');
-        const datasSnap = await pedidosRef.get();
-          todosPedidos = [];
-          const pass = getPassphrase() || user.uid;
-          for (const dataDoc of datasSnap.docs) {
-            const listaSnap = await dataDoc.ref.collection('lista').get();
-            for (const doc of listaSnap.docs) {
-              let d = doc.data();
-              if (d.encrypted) {
-                try {
-                  const txt = await decryptString(d.encrypted, pass);
-                  d = JSON.parse(txt);
-                } catch (e) {
-                  console.error('Erro ao descriptografar pedido', e);
-                  continue;
-                }
-              }
-              d.pedidoId = d.pedidoId || doc.id;
-              todosPedidos.push(d);
+        const pass = getPassphrase() || user.uid;
+        todosPedidos = [];
+        const listaSnap = await db.collectionGroup('lista').where('uid', '==', user.uid).get();
+        for (const doc of listaSnap.docs) {
+          if (!doc.ref.path.includes('/pedidosreais/')) continue;
+          let d = doc.data();
+          if (d.encrypted) {
+            try {
+              const txt = await decryptString(d.encrypted, pass);
+              d = JSON.parse(txt);
+            } catch (e) {
+              console.error('Erro ao descriptografar pedido', e);
+              continue;
             }
           }
+          d.pedidoId = d.pedidoId || doc.id;
+          todosPedidos.push(d);
+        }
         todosPedidos.sort((a, b) => {
           const da = parseDate(a.data);
           const db = parseDate(b.data);


### PR DESCRIPTION
## Summary
- load real orders directly from collection group
- ensure decryption runs with correct passphrase and filter by pedidosreais path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c22334e180832a906702e46f1a80a9