### PR TITLE
Captura de horário de pagamento nos pedidos de faturamento

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -1661,6 +1661,8 @@ const dataInput = document.getElementById("dataFaturamento");
             const skuPedido = headerSku ? row[headerSku] : null;
             const headerPedidoId = headersPedido.find(h => h.toLowerCase().includes('pedido') && h.toLowerCase().includes('id'));
             const pedidoId = headerPedidoId ? row[headerPedidoId] : null;
+           const headerPagamento = headersPedido.find(h => h.toLowerCase().includes('hora do pagamento'));
+           const horaPagamento = headerPagamento ? row[headerPagamento] : null;
             const subtotalPedido = parseFloat(row['Subtotal do produto']) || 0;
             const reembolsoPedido = parseFloat(row['Reembolso Shopee']) || 0;
             const cupomPedido = parseFloat(row['Cupom do vendedor']) || 0;
@@ -1675,6 +1677,7 @@ const dataInput = document.getElementById("dataFaturamento");
               sku: skuPedido,
               loja,
               data: dataReferencia,
+              horaPagamento,
               subtotal: subtotalPedido,
               taxas: taxasPedido,
               liquido: liquidoPedido,

--- a/expedicao-pedidosreais.html
+++ b/expedicao-pedidosreais.html
@@ -53,6 +53,7 @@
           <tr class="bg-gray-200 text-left">
             <th class="p-2">Pedido</th>
             <th class="p-2">Data</th>
+            <th class="p-2">Pagamento</th>
             <th class="p-2">Loja</th>
             <th class="p-2">SKU</th>
             <th class="p-2">Status</th>
@@ -92,7 +93,7 @@
       tbody.innerHTML = '';
       if (!lista.length) {
         const tr = document.createElement('tr');
-        tr.innerHTML = '<td class="p-2 text-center text-gray-500" colspan="9">Sem registros.</td>';
+        tr.innerHTML = '<td class="p-2 text-center text-gray-500" colspan="10">Sem registros.</td>';
         tbody.appendChild(tr);
         return;
       }
@@ -103,6 +104,7 @@
         tr.innerHTML = `
           <td class="p-2">${d.pedidoId || ''}</td>
           <td class="p-2">${d.data || ''}</td>
+          <td class="p-2">${d.horaPagamento || ''}</td>
           <td class="p-2">${d.loja || ''}</td>
           <td class="p-2">${d.sku || ''}</td>
           <td class="p-2">${d.status || ''}</td>
@@ -192,10 +194,11 @@
 
     function exportarCSV(lista) {
       if (!lista.length) return;
-      const headers = ['Pedido','Data','Loja','SKU','Status','Subtotal','Taxas','Líquido','Reembolso'];
+      const headers = ['Pedido','Data','Pagamento','Loja','SKU','Status','Subtotal','Taxas','Líquido','Reembolso'];
       const rows = lista.map(d => [
         d.pedidoId || '',
         d.data || '',
+        d.horaPagamento || '',
         d.loja || '',
         d.sku || '',
         d.status || '',


### PR DESCRIPTION
## Resumo
- captura a coluna "Hora do pagamento do pedido" ao importar a planilha de faturamento
- exibe e exporta o horário de pagamento na listagem de pedidos reais

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2ab382128832a921029047777acb6