### PR TITLE
Add shared navbar with sales, marketing and pricing menus

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -3478,6 +3478,7 @@ window.aplicarFiltroLogistica = aplicarFiltroLogistica;
 window.toggleExportMenu = toggleExportMenu;
 
 </script>
+<script>window.CUSTOM_NAVBAR_PATH='/partials/navbar-vmp.html';</script>
 <script src="shared.js"></script>
 <!-- Outras bibliotecas (como XLSX) -->
 <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>

--- a/Gerenciamento de ANUNCIOS E DESEMPENHO.html
+++ b/Gerenciamento de ANUNCIOS E DESEMPENHO.html
@@ -71,6 +71,7 @@
   <script type="module" src="secure-firestore.js"></script>
 <script type="module" src="crypto.js"></script>
 
+  <script>window.CUSTOM_NAVBAR_PATH='/partials/navbar-vmp.html';</script>
   <script src="shared.js"></script>
 <script type="module">
   import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';

--- a/SISTEMA DE CUSTEIO DE PRODUÇÃO E PRODUTOS.html
+++ b/SISTEMA DE CUSTEIO DE PRODUÇÃO E PRODUTOS.html
@@ -23,7 +23,7 @@
   <div id="sidebar-container"></div>
  <!-- Botão de menu mobile -->
   <button class="mobile-menu-btn" onclick="toggleSidebar()" aria-label="Abrir menu" aria-expanded="false">☰</button>
-  <div id="navbar-container"></div>
+<div id="navbar-container"></div>
 
   <script>
   
@@ -516,6 +516,7 @@
   <script type="module" src="custeio.js"></script>
 
 
+<script>window.CUSTOM_NAVBAR_PATH='/partials/navbar-vmp.html';</script>
 <script src="shared.js"></script>
 
 </body>

--- a/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
+++ b/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
@@ -2205,7 +2205,8 @@ document.getElementById('filterHistoryType')?.addEventListener('change', loadHis
     }, 300000); // 5 minutos
   </script>
       <script type="module" src="bling.js"></script>
- <script src="shared.js"></script>
+<script>window.CUSTOM_NAVBAR_PATH='/partials/navbar-vmp.html';</script>
+<script src="shared.js"></script>
 <script>
    document.querySelectorAll('.tooltip').forEach(el => {
      const text = el.getAttribute('data-tooltip');

--- a/acompanhamento-promocoes.html
+++ b/acompanhamento-promocoes.html
@@ -105,6 +105,7 @@
   </div>
 
   <script type="module" src="firebase-config.js"></script>
+  <script>window.CUSTOM_NAVBAR_PATH='/partials/navbar-vmp.html';</script>
   <script src="shared.js"></script>
   <script src="acompanhamento-promocoes.js"></script>
   <!-- Modal de Edição -->

--- a/acompanhamento-vendas.html
+++ b/acompanhamento-vendas.html
@@ -43,6 +43,7 @@
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="acompanhamento-vendas.js"></script>
   <script>window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';</script>
+  <script>window.CUSTOM_NAVBAR_PATH='/partials/navbar-vmp.html';</script>
   <script src="shared.js"></script>
 </body>
 </html>

--- a/ads-lista.html
+++ b/ads-lista.html
@@ -49,6 +49,7 @@
   <!-- Scripts -->
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="ads-lista.js"></script>
+  <script>window.CUSTOM_NAVBAR_PATH='/partials/navbar-vmp.html';</script>
   <script src="shared.js"></script>
 </body>
 </html>

--- a/ads.html
+++ b/ads.html
@@ -55,5 +55,6 @@
     window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';
     window.CUSTOM_NAVBAR_PATH  = '/partials/navbar.html';
   </script>
+  <script>window.CUSTOM_NAVBAR_PATH='/partials/navbar-vmp.html';</script>
   <script src="shared.js"></script>
 </body>

--- a/anuncios-tabs/analise.html
+++ b/anuncios-tabs/analise.html
@@ -62,6 +62,7 @@
   </div>
   <script type="module" src="../firebase-config.js"></script>
   <script type="module" src="../gerenciamento.js"></script>
+   <script>window.CUSTOM_NAVBAR_PATH='/partials/navbar-vmp.html';</script>
    <script src="../shared.js"></script>
 </body>
 </html>

--- a/anuncios-tabs/anuncios.html
+++ b/anuncios-tabs/anuncios.html
@@ -118,6 +118,7 @@
  <script type="module" src="../secure-firestore.js"></script>
 <script type="module" src="../crypto.js"></script>
   <script type="module" src="../gerenciamento.js"></script>
+  <script>window.CUSTOM_NAVBAR_PATH='/partials/navbar-vmp.html';</script>
   <script src="../shared.js"></script>
 </body>
 </html>

--- a/anuncios-tabs/cadastro.html
+++ b/anuncios-tabs/cadastro.html
@@ -149,6 +149,7 @@
   </div>
   <script type="module" src="../firebase-config.js"></script>
   <script type="module" src="../gerenciamento.js"></script>
+  <script>window.CUSTOM_NAVBAR_PATH='/partials/navbar-vmp.html';</script>
   <script src="../shared.js"></script>
    <script>
     document.querySelectorAll('.tooltip').forEach(el => {

--- a/anuncios-tabs/criar-ia.html
+++ b/anuncios-tabs/criar-ia.html
@@ -112,6 +112,7 @@
   </div>
   <script type="module" src="../firebase-config.js"></script>
   <script type="module" src="../criar-anuncio-ia.js"></script>
+  <script>window.CUSTOM_NAVBAR_PATH='/partials/navbar-vmp.html';</script>
   <script src="../shared.js"></script>
 </body>
 </html>

--- a/anuncios-tabs/evolucao.html
+++ b/anuncios-tabs/evolucao.html
@@ -52,6 +52,7 @@
   </div>
   <script type="module" src="../firebase-config.js"></script>
   <script type="module" src="../gerenciamento.js"></script>
+  <script>window.CUSTOM_NAVBAR_PATH='/partials/navbar-vmp.html';</script>
   <script src="../shared.js"></script>
 </body>
 </html>

--- a/partials/navbar-vmp.html
+++ b/partials/navbar-vmp.html
@@ -1,0 +1,95 @@
+<div class="navbar">
+  <div class="navbar-left">
+    <button class="mobile-menu-btn hamburger menu-item" aria-label="Abrir menu" aria-expanded="false">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5" />
+      </svg>
+    </button>
+    <ul class="flex items-center gap-4">
+      <li><a href="index.html" class="hover:text-gray-200">Início</a></li>
+      <li><a href="dashboard-geral.html" class="hover:text-gray-200">Dashboard Geral</a></li>
+      <li class="relative">
+        <button class="submenu-toggle flex items-center gap-1 hover:text-gray-200" onclick="toggleMenu('menuVendas', this)">
+          Vendas
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+          </svg>
+        </button>
+        <ul id="menuVendas" class="submenu absolute left-0 mt-2 bg-neutral-800 rounded shadow-lg z-10 w-56">
+          <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento" class="submenu-link">Registrar Faturamento</a></li>
+          <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=registroFaturamento" class="submenu-link">Acompanhamento Faturamento</a></li>
+          <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=metas" class="submenu-link">Acompanhamento Metas</a></li>
+          <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamento" class="submenu-link">Acompanhamento Mensal</a></li>
+          <li><a href="saques.html" class="submenu-link">Saques</a></li>
+        </ul>
+      </li>
+      <li class="relative">
+        <button class="submenu-toggle flex items-center gap-1 hover:text-gray-200" onclick="toggleMenu('menuPrecificacao', this)">
+          Precificação
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+          </svg>
+        </button>
+        <ul id="menuPrecificacao" class="submenu absolute left-0 mt-2 bg-neutral-800 rounded shadow-lg z-10 w-56">
+          <li><a href="Sistema%20de%20Precificação%20COM%20IMPORTAÇÃO%20DE%20PLANILHA%20DE%20PROMOÇÕES%20SHOPEE.html?tab=precificacao" class="submenu-link">Precificação</a></li>
+          <li><a href="Sistema%20de%20Precificação%20COM%20IMPORTAÇÃO%20DE%20PLANILHA%20DE%20PROMOÇÕES%20SHOPEE.html?tab=lista-precos" class="submenu-link">Lista Preços</a></li>
+          <li><a href="Sistema%20de%20Precificação%20COM%20IMPORTAÇÃO%20DE%20PLANILHA%20DE%20PROMOÇÕES%20SHOPEE.html?tab=produtos" class="submenu-link">Cadastro de Produtos</a></li>
+          <li><a href="Sistema%20de%20Precificação%20COM%20IMPORTAÇÃO%20DE%20PLANILHA%20DE%20PROMOÇÕES%20SHOPEE.html?tab=historico" class="submenu-link">Histórico</a></li>
+        </ul>
+      </li>
+      <li class="relative">
+        <button class="submenu-toggle flex items-center gap-1 hover:text-gray-200" onclick="toggleMenu('menuMarketing', this)">
+          Marketing
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+          </svg>
+        </button>
+        <ul id="menuMarketing" class="submenu absolute left-0 mt-2 bg-neutral-800 rounded shadow-lg z-10 w-56">
+          <li><a href="promocoes-shopee.html" class="submenu-link">Promoções Shopee</a></li>
+          <li><a href="ads.html" class="submenu-link">Shopee Ads</a></li>
+          <li><a href="Gerenciamento%20de%20ANUNCIOS%20E%20DESEMPENHO.html" class="submenu-link">Anúncios Autos</a></li>
+          <li><a href="acompanhamento-promocoes.html" class="submenu-link">Acompanhamento Promoções</a></li>
+          <li><a href="ads-lista.html" class="submenu-link">Histórico</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <div class="navbar-right">
+    <a href="cadastro-interesse.html" class="menu-item" title="Cadastre-se">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3M12.75 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3.001 19.234c-.001-.037-.001-.074-.001-.111 0-3.52 2.854-6.375 6.375-6.375S15.75 15.604 15.75 19.125v.003a12.318 12.318 0 0 1-6.375 1.872A12.32 12.32 0 0 1 3.001 19.234Z"/>
+      </svg>
+    </a>
+    <button id="loginBtn" class="menu-item" title="Login">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.118a8.999 8.999 0 0 1 15 0"/>
+      </svg>
+    </button>
+    <div id="notificationWrapper" class="relative">
+      <button id="notificationBtn" class="menu-item relative" title="Notificações">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082A23.86 23.86 0 0 0 20.312 15.772 8.966 8.966 0 0 1 18 9.75V9a6 6 0 1 0-12 0v.75a8.966 8.966 0 0 1-2.312 6.021A23.86 23.86 0 0 0 9.143 17.082M14.857 17.082A24.255 24.255 0 0 1 12 17.25c-1.035 0-2.06-.068-3.057-.199M14.857 17.082c.092.29.143.599.143.918a3 3 0 1 1-6 0c0-.319.051-.628.143-.918"/>
+        </svg>
+        <span id="notificationBadge" data-count="0" class="hidden absolute -top-1 -right-1 bg-brand text-white rounded-full w-5 h-5 flex items-center justify-center text-xs"></span>
+      </button>
+      <div id="notificationList" class="hidden absolute right-0 mt-2 w-64 bg-white text-gray-700 rounded shadow-lg z-20"></div>
+    </div>
+    <button id="startTourBtn" class="menu-item hidden" title="Introdução">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519a3.75 3.75 0 1 1 4.243 6.212c-.203.178-.43.325-.67.441-.555.26-.903.816-.903 1.43V16.5m0 2.25h.008v.008H12v-.008Z"/>
+      </svg>
+    </button>
+    <div class="relative">
+      <button id="userMenuBtn" class="menu-item rounded-full overflow-hidden" title="Usuário">
+        <img id="userPhoto" src="" alt="Avatar" class="hidden h-10 w-10 object-cover">
+        <span id="userInitials" class="h-10 w-10 rounded-full bg-neutral-200 flex items-center justify-center text-sm font-medium text-neutral-600">U</span>
+      </button>
+      <div id="userMenu" class="hidden absolute right-0 mt-2 w-40 bg-white rounded-md shadow-md py-2">
+        <div id="currentUser" class="px-4 py-2 text-sm text-neutral-700">Usuário</div>
+        <div class="border-t my-1"></div>
+        <a href="perfil-mentorado.html" class="block px-4 py-2 text-sm text-neutral-700 hover:bg-neutral-100">Perfil</a>
+        <button id="logoutBtn" class="block w-full text-left px-4 py-2 text-sm text-neutral-700 hover:bg-neutral-100">Sair</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/promocoes-shopee.html
+++ b/promocoes-shopee.html
@@ -561,6 +561,7 @@ const searchSku = (sku || parentSku || '').toUpperCase();
   }
 </script>
 
+  <script>window.CUSTOM_NAVBAR_PATH='/partials/navbar-vmp.html';</script>
   <script src="shared.js"></script>
 </body>
 </html>

--- a/saques.html
+++ b/saques.html
@@ -126,6 +126,7 @@
     <script type="module" src="firebase-config.js"></script>
     <script type="module" src="saques.js"></script>
   <script>window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';</script>
+  <script>window.CUSTOM_NAVBAR_PATH='/partials/navbar-vmp.html';</script>
   <script src="shared.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add reusable top navbar partial with menus for Vendas, Precificação and Marketing
- Load new navbar across sales, marketing and pricing pages via `CUSTOM_NAVBAR_PATH`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2bb907b7c832aad297e9ee050b80a