### PR TITLE
feat: store planned ship date from spreadsheets

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -1697,6 +1697,16 @@ const dataInput = document.getElementById("dataFaturamento");
             const pedidoId = headerPedidoId ? row[headerPedidoId] : null;
            const headerPagamento = headersPedido.find(h => h.toLowerCase().includes('hora do pagamento'));
            const horaPagamento = headerPagamento ? row[headerPagamento] : null;
+           const headerPrevEnvio = headersPedido.find(h => h.toLowerCase().includes('data prevista') && h.toLowerCase().includes('envio'));
+           let dataPrevistaEnvio = headerPrevEnvio ? row[headerPrevEnvio] : null;
+           if (dataPrevistaEnvio) {
+             const dPrev = new Date(dataPrevistaEnvio);
+             if (!isNaN(dPrev)) {
+               dataPrevistaEnvio = dPrev.toISOString().split('T')[0];
+             } else if (typeof dataPrevistaEnvio === 'string') {
+               dataPrevistaEnvio = dataPrevistaEnvio.split(' ')[0];
+             }
+           }
             const subtotalPedido = parseFloat(row['Subtotal do produto']) || 0;
             const reembolsoPedido = parseFloat(row['Reembolso Shopee']) || 0;
             const cupomPedido = parseFloat(row['Cupom do vendedor']) || 0;
@@ -1717,6 +1727,7 @@ const dataInput = document.getElementById("dataFaturamento");
               liquido: liquidoPedido,
               reembolso: reembolsoPedido
             };
+            if (dataPrevistaEnvio) pedidoPayload.dataPrevistaEnvio = dataPrevistaEnvio;
 
             // Atualiza coleção pedidostiny evitando duplicações
             const tinyDocRef = pedidosTinyRef.doc(pedidoId);

--- a/expedicao-pedidosreais.html
+++ b/expedicao-pedidosreais.html
@@ -282,6 +282,8 @@
           const dataHeader = headers.find(h => h.toLowerCase().includes('data') && !h.toLowerCase().includes('hora'));
           let horaPagamento = horaPagHeader ? String(row[horaPagHeader]).trim() : '';
           let data = dataHeader ? row[dataHeader] : '';
+          const dataPrevHeader = headers.find(h => h.toLowerCase().includes('data prevista') && h.toLowerCase().includes('envio'));
+          let dataPrevistaEnvio = dataPrevHeader ? row[dataPrevHeader] : '';
           if (horaPagamento) {
             const d = new Date(horaPagamento);
             if (!data && !isNaN(d)) data = d.toISOString().split('T')[0];
@@ -289,6 +291,14 @@
           if (data) {
             const d = new Date(data);
             if (!isNaN(d)) data = d.toISOString().split('T')[0];
+          }
+          if (dataPrevistaEnvio) {
+            const dPrev = new Date(dataPrevistaEnvio);
+            if (!isNaN(dPrev)) {
+              dataPrevistaEnvio = dPrev.toISOString().split('T')[0];
+            } else if (typeof dataPrevistaEnvio === 'string') {
+              dataPrevistaEnvio = dataPrevistaEnvio.split(' ')[0];
+            }
           }
           const skuHeader = headers.find(h => h.toLowerCase().includes('sku'));
           const statusHeader = headers.find(h => h.toLowerCase().includes('status'));
@@ -306,6 +316,7 @@
             loja: nomeLoja,
             data,
             horaPagamento,
+            dataPrevistaEnvio,
             subtotal,
             taxas,
             liquido,


### PR DESCRIPTION
## Summary
- capture Data prevista de envio when importing faturamento
- save planned ship date during Pedidos Reais spreadsheet import

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2c4ded51c832a9f84e4539e0d5561