### PR TITLE
fix: keep navbar menu items in a single row

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1238,8 +1238,10 @@ body.dark-mode .data-table th {
   align-items: center;
   justify-content: center;
   height: 2.5rem;
-  width: 2.5rem;
+  min-width: 2.5rem;
+  padding: 0 0.75rem;
   border-radius: 0.5rem;
+  white-space: nowrap;
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 .navbar .menu-item:hover {


### PR DESCRIPTION
## Summary
- allow navbar menu items to auto-size so they don't stack vertically

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2c645300c832a974ea7f8b79ef76d