### PR TITLE
feat: show expected shipping date in real orders

### DIFF
--- a/expedicao-pedidosreais.html
+++ b/expedicao-pedidosreais.html
@@ -61,6 +61,7 @@
             <th class="p-2">Pedido</th>
             <th class="p-2">Data</th>
             <th class="p-2">Pagamento</th>
+            <th class="p-2">Prev. envio</th>
             <th class="p-2">Loja</th>
             <th class="p-2">SKU</th>
             <th class="p-2">Status</th>
@@ -101,7 +102,7 @@
       tbody.innerHTML = '';
       if (!lista.length) {
         const tr = document.createElement('tr');
-        tr.innerHTML = '<td class="p-2 text-center text-gray-500" colspan="10">Sem registros.</td>';
+        tr.innerHTML = '<td class="p-2 text-center text-gray-500" colspan="11">Sem registros.</td>';
         tbody.appendChild(tr);
         return;
       }
@@ -113,6 +114,7 @@
           <td class="p-2">${d.pedidoId || ''}</td>
           <td class="p-2">${d.data || ''}</td>
           <td class="p-2">${d.horaPagamento || ''}</td>
+          <td class="p-2">${d.dataPrevistaEnvio || ''}</td>
           <td class="p-2">${d.loja || ''}</td>
           <td class="p-2">${d.sku || ''}</td>
           <td class="p-2">${d.status || ''}</td>
@@ -235,11 +237,12 @@
 
     function exportarCSV(lista) {
       if (!lista.length) return;
-      const headers = ['Pedido','Data','Pagamento','Loja','SKU','Status','Subtotal','Taxas','Líquido','Reembolso'];
+      const headers = ['Pedido','Data','Pagamento','Prev. envio','Loja','SKU','Status','Subtotal','Taxas','Líquido','Reembolso'];
       const rows = lista.map(d => [
         d.pedidoId || '',
         d.data || '',
         d.horaPagamento || '',
+        d.dataPrevistaEnvio || '',
         d.loja || '',
         d.sku || '',
         d.status || '',


### PR DESCRIPTION
## Summary
- display `Prev. envio` column in real orders table
- include expected shipment date in exported CSV

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2c7305b00832a99c0fe6bd4b6450d