### PR TITLE
Add navbar for expedition and label tools

### DIFF
--- a/partials/navbar-expedicao.html
+++ b/partials/navbar-expedicao.html
@@ -1,0 +1,96 @@
+<div class="navbar flex items-center justify-between">
+  <div class="flex items-center space-x-4">
+    <a href="index.html" class="menu-item">Início</a>
+    <a href="dashboard-geral.html" class="menu-item">Dashboard Geral</a>
+    <div class="relative">
+      <button class="menu-item flex items-center" onclick="toggleMenu('menuNavEtiquetas', this)">
+        Etiquetas
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 ml-1">
+          <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+        </svg>
+      </button>
+      <ul id="menuNavEtiquetas" class="absolute left-0 mt-2 bg-white rounded shadow-lg overflow-hidden transition-all" style="max-height:0;">
+        <li><a href="etiquetas-ocr.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Etiquetas PDF</a></li>
+        <li><a href="zpl-import.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Etiquetas ZPL</a></li>
+        <li><a href="zpl-import-ocr.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">ZPL Import csv</a></li>
+      </ul>
+    </div>
+    <div class="relative">
+      <button class="menu-item flex items-center" onclick="toggleMenu('menuNavExpedicao', this)">
+        Expedição
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 ml-1">
+          <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+        </svg>
+      </button>
+      <ul id="menuNavExpedicao" class="absolute left-0 mt-2 bg-white rounded shadow-lg overflow-hidden transition-all" style="max-height:0;">
+        <li><a href="coletas.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Coletas</a></li>
+        <li><a href="expedicao-pedidosreais.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Pedidos Reais</a></li>
+      </ul>
+    </div>
+    <div class="relative">
+      <button class="menu-item flex items-center" onclick="toggleMenu('menuNavConfigExped', this)">
+        Configuração Expedição
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 ml-1">
+          <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+        </svg>
+      </button>
+      <ul id="menuNavConfigExped" class="absolute left-0 mt-2 bg-white rounded shadow-lg overflow-hidden transition-all" style="max-height:0;">
+        <li><a href="configuracao-expedicao.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Atualizações Da Relações</a></li>
+        <li><a href="expedicao-historico.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Histórico</a></li>
+      </ul>
+    </div>
+    <div class="relative">
+      <button class="menu-item flex items-center" onclick="toggleMenu('menuNavConfig', this)">
+        Configurações
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 ml-1">
+          <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+        </svg>
+      </button>
+      <ul id="menuNavConfig" class="absolute left-0 mt-2 bg-white rounded shadow-lg overflow-hidden transition-all" style="max-height:0;">
+        <li><a href="painel-usuarios.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Painel de Usuários</a></li>
+        <li><a href="configuracao-perfil.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Configuração de Perfil</a></li>
+        <li><a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Histórico</a></li>
+        <li><a href="email-expedicao.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">E-mail de Expedição</a></li>
+        <li><a href="manual.html" target="_blank" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Manual</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="navbar-right flex items-center space-x-3">
+    <a href="cadastro-interesse.html" class="menu-item" title="Cadastre-se">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3M12.75 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3.001 19.234c-.001-.037-.001-.074-.001-.111 0-3.52 2.854-6.375 6.375-6.375S15.75 15.604 15.75 19.125v.003a12.318 12.318 0 0 1-6.375 1.872A12.32 12.32 0 0 1 3.001 19.234Z" />
+      </svg>
+    </a>
+    <button id="loginBtn" class="menu-item" title="Login">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.118a8.999 8.999 0 0 1 15 0" />
+      </svg>
+    </button>
+    <div id="notificationWrapper" class="relative">
+      <button id="notificationBtn" class="menu-item relative" title="Notificações">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082A23.86 23.86 0 0 0 20.312 15.772 8.966 8.966 0 0 1 18 9.75V9a6 6 0 1 0-12 0v.75a8.966 8.966 0 0 1-2.312 6.021A23.86 23.86 0 0 0 9.143 17.082M14.857 17.082A24.255 24.255 0 0 1 12 17.25c-1.035 0-2.06-.068-3.057-.199M14.857 17.082c.092.29.143.599.143.918a3 3 0 1 1-6 0c0-.319.051-.628.143-.918" />
+        </svg>
+        <span id="notificationBadge" data-count="0" class="hidden absolute -top-1 -right-1 bg-brand text-white rounded-full w-5 h-5 flex items-center justify-center text-xs"></span>
+      </button>
+      <div id="notificationList" class="hidden absolute right-0 mt-2 w-64 bg-white text-gray-700 rounded shadow-lg z-20"></div>
+    </div>
+    <button id="startTourBtn" class="menu-item hidden" title="Introdução">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519a3.75 3.75 0 1 1 4.243 6.212c-.203.178-.43.325-.67.441-.555.26-.903.816-.903 1.43V16.5m0 2.25h.008v.008H12v-.008Z" />
+      </svg>
+    </button>
+    <div class="relative">
+      <button id="userMenuBtn" class="menu-item rounded-full overflow-hidden" title="Usuário">
+        <img id="userPhoto" src="" alt="Avatar" class="hidden h-10 w-10 object-cover">
+        <span id="userInitials" class="h-10 w-10 rounded-full bg-neutral-200 flex items-center justify-center text-sm font-medium text-neutral-600">U</span>
+      </button>
+      <div id="userMenu" class="hidden absolute right-0 mt-2 w-40 bg-white rounded-md shadow-md py-2">
+        <div id="currentUser" class="px-4 py-2 text-sm text-neutral-700">Usuário</div>
+        <div class="border-t my-1"></div>
+        <a href="perfil-mentorado.html" class="block px-4 py-2 text-sm text-neutral-700 hover:bg-neutral-100">Perfil</a>
+        <button id="logoutBtn" class="block w-full text-left px-4 py-2 text-sm text-neutral-700 hover:bg-neutral-100">Sair</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/shared.js
+++ b/shared.js
@@ -282,9 +282,11 @@ document.addEventListener('sidebarLoaded', function () {
 window.CUSTOM_SIDEBAR_PATH = window.CUSTOM_SIDEBAR_PATH || 'partials/sidebar.html';
 window.CUSTOM_NAVBAR_PATH  = window.CUSTOM_NAVBAR_PATH  || 'partials/navbar.html';
 
-// Pages related to Vendas, Marketing or Precificação use a specialized navbar
+// Pages related to Expedição or Etiquetas use a specific navbar
 const _path = decodeURIComponent(window.location.pathname.toLowerCase());
-if (/(vendas|sobras|faturamento|saques|anuncio|ads|promoc|marketing|precifica|lista-precos|custeio)/.test(_path)) {
+if (/(expedicao|etiquet|zpl)/.test(_path)) {
+  window.CUSTOM_NAVBAR_PATH = 'partials/navbar-expedicao.html';
+} else if (/(vendas|sobras|faturamento|saques|anuncio|ads|promoc|marketing|precifica|lista-precos|custeio)/.test(_path)) {
   window.CUSTOM_NAVBAR_PATH = 'partials/navbar-grupos.html';
 }
 const PARTIALS_VERSION = '2025-08-25-02'; // mude quando atualizar parciais


### PR DESCRIPTION
## Summary
- Introduce dedicated expedition/labels navbar with quick links to etiquetas PDF/ZPL tools, coletas, pedidos reais, configuration pages and related settings
- Auto-load the new navbar on pages whose paths include expedicao, etiqueta or zpl

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2c7f3ce4c832a8ed3c3fe0c669cb6