### PR TITLE
Use SKU reference field for pedidosreais imports

### DIFF
--- a/expedicao-pedidosreais.html
+++ b/expedicao-pedidosreais.html
@@ -303,7 +303,7 @@
               dataPrevistaEnvio = dataPrevistaEnvio.split(' ')[0];
             }
           }
-          const skuHeader = headers.find(h => h.toLowerCase().includes('sku'));
+          const skuHeader = headers.find(h => h.trim() === 'Número de referência SKU');
           const statusHeader = headers.find(h => h.toLowerCase().includes('status'));
           const subtotal = parseFloat(row['Subtotal do produto']) || 0;
           const reembolso = parseFloat(row['Reembolso Shopee']) || 0;


### PR DESCRIPTION
## Summary
- ensure pedidosreais imports use the "Número de referência SKU" column, avoiding "Nº de referência do SKU principal"

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2c976ac34832a80d6da9c8e9d1f76