### PR TITLE
feat: registrar rastreamento nos pedidos

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -1708,6 +1708,8 @@ const dataInput = document.getElementById("dataFaturamento");
            const headerPrevEnvio = headersPedido.find(h => h.toLowerCase().includes('data prevista') && h.toLowerCase().includes('envio'));
            let dataPrevistaEnvio = headerPrevEnvio ? row[headerPrevEnvio] : null;
            dataPrevistaEnvio = normalizeDate(dataPrevistaEnvio);
+           const headerRastreamento = headersPedido.find(h => h.toLowerCase().includes('rastreamento'));
+           const numeroRastreamento = headerRastreamento ? String(row[headerRastreamento]).trim() : '';
             const subtotalPedido = parseFloat(row['Subtotal do produto']) || 0;
             const reembolsoPedido = parseFloat(row['Reembolso Shopee']) || 0;
             const cupomPedido = parseFloat(row['Cupom do vendedor']) || 0;
@@ -1729,6 +1731,10 @@ const dataInput = document.getElementById("dataFaturamento");
               reembolso: reembolsoPedido
             };
             if (dataPrevistaEnvio) pedidoPayload.dataPrevistaEnvio = dataPrevistaEnvio;
+            if (numeroRastreamento) {
+              pedidoPayload.numeroRastreamento = numeroRastreamento;
+              pedidoPayload.etiquetaImpressa = true;
+            }
 
             // Atualiza coleção pedidostiny evitando duplicações
             const tinyDocRef = pedidosTinyRef.doc(pedidoId);

--- a/expedicao-pedidosreais.html
+++ b/expedicao-pedidosreais.html
@@ -72,6 +72,7 @@
             <th class="p-2">Prev. envio</th>
             <th class="p-2">Loja</th>
             <th class="p-2">SKU</th>
+            <th class="p-2">Rastreamento</th>
             <th class="p-2">Status</th>
             <th class="p-2">Subtotal</th>
             <th class="p-2">Taxas</th>
@@ -118,7 +119,7 @@
       tbody.innerHTML = '';
       if (!lista.length) {
         const tr = document.createElement('tr');
-        tr.innerHTML = '<td class="p-2 text-center text-gray-500" colspan="11">Sem registros.</td>';
+        tr.innerHTML = '<td class="p-2 text-center text-gray-500" colspan="12">Sem registros.</td>';
         tbody.appendChild(tr);
         return;
       }
@@ -133,6 +134,7 @@
           <td class="p-2">${d.dataPrevistaEnvio || ''}</td>
           <td class="p-2">${d.loja || ''}</td>
           <td class="p-2">${d.sku || ''}</td>
+          <td class="p-2">${d.numeroRastreamento || ''}</td>
           <td class="p-2">${d.status || ''}</td>
           <td class="p-2">${fmt(d.subtotal)}</td>
           <td class="p-2">${fmt(d.taxas)}</td>
@@ -260,7 +262,7 @@
 
     function exportarCSV(lista) {
       if (!lista.length) return;
-      const headers = ['Pedido','Data','Pagamento','Prev. envio','Loja','SKU','Status','Subtotal','Taxas','Líquido','Reembolso'];
+      const headers = ['Pedido','Data','Pagamento','Prev. envio','Loja','SKU','Rastreamento','Status','Subtotal','Taxas','Líquido','Reembolso'];
       const rows = lista.map(d => [
         d.pedidoId || '',
         d.data || '',
@@ -268,6 +270,7 @@
         d.dataPrevistaEnvio || '',
         d.loja || '',
         d.sku || '',
+        d.numeroRastreamento || '',
         d.status || '',
         d.subtotal || 0,
         d.taxas || 0,
@@ -317,27 +320,32 @@
           data = normalizeDate(data);
           dataPrevistaEnvio = normalizeDate(dataPrevistaEnvio);
           const skuHeader = headers.find(h => h.trim() === 'Número de referência SKU');
-          const statusHeader = headers.find(h => h.toLowerCase().includes('status'));
+        const statusHeader = headers.find(h => h.toLowerCase().includes('status'));
+        const rastreamentoHeader = headers.find(h => h.toLowerCase().includes('rastreamento'));
           const subtotal = parseFloat(row['Subtotal do produto']) || 0;
           const reembolso = parseFloat(row['Reembolso Shopee']) || 0;
           const cupom = parseFloat(row['Cupom do vendedor']) || 0;
           const comissao = parseFloat(row['Taxa de comissão']) || 0;
           const servico = parseFloat(row['Taxa de serviço']) || 0;
           const taxas = cupom + comissao + servico;
-          const liquido = subtotal + reembolso - taxas;
-          pedidos.push({
-            pedidoId,
-            status: statusHeader ? row[statusHeader] : '',
-            sku: skuHeader ? row[skuHeader] : '',
-            loja: nomeLoja,
-            data,
-            horaPagamento,
-            dataPrevistaEnvio,
-            subtotal,
-            taxas,
-            liquido,
-            reembolso
-          });
+        const liquido = subtotal + reembolso - taxas;
+        const numeroRastreamento = rastreamentoHeader ? String(row[rastreamentoHeader]).trim() : '';
+        const pedido = {
+          pedidoId,
+          status: statusHeader ? row[statusHeader] : '',
+          sku: skuHeader ? row[skuHeader] : '',
+          loja: nomeLoja,
+          data,
+          horaPagamento,
+          dataPrevistaEnvio,
+          subtotal,
+          taxas,
+          liquido,
+          reembolso,
+          numeroRastreamento
+        };
+        if (numeroRastreamento) pedido.etiquetaImpressa = true;
+        pedidos.push(pedido);
         }
         const { encryptString, decryptString } = await import('./crypto.js');
         const pass = getPassphrase() || usuarioAtual.uid;


### PR DESCRIPTION
## Summary
- capture tracking numbers when importing orders and flag labels as printed
- display tracking numbers on Pedidos Reais list and export

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2d7fac108832aa4405fb2590b8297