### PR TITLE
Show printed label status for real orders

### DIFF
--- a/expedicao-pedidosreais.html
+++ b/expedicao-pedidosreais.html
@@ -73,6 +73,7 @@
             <th class="p-2">Loja</th>
             <th class="p-2">SKU</th>
             <th class="p-2">Rastreamento</th>
+            <th class="p-2">Etiqueta</th>
             <th class="p-2">Status</th>
             <th class="p-2">Subtotal</th>
             <th class="p-2">Taxas</th>
@@ -119,7 +120,7 @@
       tbody.innerHTML = '';
       if (!lista.length) {
         const tr = document.createElement('tr');
-        tr.innerHTML = '<td class="p-2 text-center text-gray-500" colspan="12">Sem registros.</td>';
+        tr.innerHTML = '<td class="p-2 text-center text-gray-500" colspan="13">Sem registros.</td>';
         tbody.appendChild(tr);
         return;
       }
@@ -127,6 +128,7 @@
       for (const d of lista) {
         const tr = document.createElement('tr');
         tr.className = 'border-b';
+        const etiqueta = d.etiquetaImpressa || !!d.numeroRastreamento;
         tr.innerHTML = `
           <td class="p-2">${d.pedidoId || ''}</td>
           <td class="p-2">${d.data || ''}</td>
@@ -135,6 +137,7 @@
           <td class="p-2">${d.loja || ''}</td>
           <td class="p-2">${d.sku || ''}</td>
           <td class="p-2">${d.numeroRastreamento || ''}</td>
+          <td class="p-2">${etiqueta ? 'Impressa' : 'Não impressa'}</td>
           <td class="p-2">${d.status || ''}</td>
           <td class="p-2">${fmt(d.subtotal)}</td>
           <td class="p-2">${fmt(d.taxas)}</td>
@@ -262,21 +265,25 @@
 
     function exportarCSV(lista) {
       if (!lista.length) return;
-      const headers = ['Pedido','Data','Pagamento','Prev. envio','Loja','SKU','Rastreamento','Status','Subtotal','Taxas','Líquido','Reembolso'];
-      const rows = lista.map(d => [
-        d.pedidoId || '',
-        d.data || '',
-        d.horaPagamento || '',
-        d.dataPrevistaEnvio || '',
-        d.loja || '',
-        d.sku || '',
-        d.numeroRastreamento || '',
-        d.status || '',
-        d.subtotal || 0,
-        d.taxas || 0,
-        d.liquido || 0,
-        d.reembolso || 0
-      ].join(';'));
+      const headers = ['Pedido','Data','Pagamento','Prev. envio','Loja','SKU','Rastreamento','Etiqueta','Status','Subtotal','Taxas','Líquido','Reembolso'];
+      const rows = lista.map(d => {
+        const etiqueta = d.etiquetaImpressa || !!d.numeroRastreamento;
+        return [
+          d.pedidoId || '',
+          d.data || '',
+          d.horaPagamento || '',
+          d.dataPrevistaEnvio || '',
+          d.loja || '',
+          d.sku || '',
+          d.numeroRastreamento || '',
+          etiqueta ? 'Impressa' : 'Não impressa',
+          d.status || '',
+          d.subtotal || 0,
+          d.taxas || 0,
+          d.liquido || 0,
+          d.reembolso || 0
+        ].join(';');
+      });
       const csv = [headers.join(';'), ...rows].join('\n');
       const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
       const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- display an "Etiqueta" column on the Pedidos Reais page indicating if a label was printed based on the tracking number
- export the new label status field when generating CSV files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2db57eb04832ab2fa8f2249b0096b