### PR TITLE
Limit client sidebar to core options

### DIFF
--- a/login.js
+++ b/login.js
@@ -386,6 +386,27 @@ function ensureFinanceiroMenu() {
   }
 }
 
+function setupBasicSidebar() {
+  const menu = document.querySelector('#sidebar .sidebar-menu');
+  if (!menu) return;
+  menu.querySelectorAll('a.sidebar-link.hidden').forEach(a => a.closest('li')?.remove());
+  menu.querySelectorAll('.submenu').forEach(ul => ul.remove());
+  menu.querySelectorAll('.submenu-toggle').forEach(btn => {
+    btn.parentElement?.classList.remove('justify-between');
+    btn.remove();
+  });
+  const order = ['menu-vendas','menu-expedicao','menu-anuncios','menu-outros','menu-configuracoes','menu-comunicacao'];
+  order.forEach(id => {
+    const link = document.getElementById(id);
+    const li = link?.closest('li');
+    if (li) menu.appendChild(li);
+  });
+  const introLi = document.getElementById('startSidebarTourBtn')?.closest('li');
+  const darkLi = document.getElementById('darkModeToggle')?.closest('li');
+  if (introLi) menu.appendChild(introLi);
+  if (darkLi) menu.appendChild(darkLi);
+}
+
 async function checkExpedicao(user) {
   try {
     let snap = await getDocs(query(collection(db, 'usuarios'), where('responsavelExpedicaoEmail', '==', user.email)));
@@ -551,7 +572,10 @@ function checkLogin() {
   });
 
 document.addEventListener('sidebarLoaded', () => {
-  if (window.userPerfil) applyPerfilRestrictions(window.userPerfil);
+  if (window.userPerfil) {
+    applyPerfilRestrictions(window.userPerfil);
+    if (['usuario', 'cliente'].includes(window.userPerfil)) setupBasicSidebar();
+  }
   ensureFinanceiroMenu();
 });
 

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -139,7 +139,7 @@
       </a>
     </li>
     <li>
-      <a href="index.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-inicio" data-perfil="usuario,gestor,mentor">
+      <a href="index.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-inicio" data-perfil="gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/>
         </svg>
@@ -148,7 +148,7 @@
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-vendas" data-perfil="usuario,gestor,mentor,responsavel,gestor financeiro">
+        <a href="CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-vendas" data-perfil="usuario,cliente,gestor,mentor,responsavel,gestor financeiro">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
             <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"/>
           </svg>
@@ -177,7 +177,7 @@
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="etiquetas-ocr.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-etiquetas" data-perfil="usuario,gestor,mentor">
+        <a href="etiquetas-ocr.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-etiquetas" data-perfil="gestor,mentor">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"/>
             <path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6Z"/>
@@ -198,7 +198,7 @@
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-precificacao" data-perfil="usuario,gestor,mentor">
+        <a href="Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-precificacao" data-perfil="gestor,mentor">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"/>
             <path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6Z"/>
@@ -220,7 +220,7 @@
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="promocoes-shopee.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-marketing" data-perfil="usuario,gestor,mentor">
+        <a href="promocoes-shopee.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-marketing" data-perfil="gestor,mentor">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"/>
           </svg>
@@ -241,7 +241,7 @@
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="anuncios-tabs/cadastro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-anuncios" data-perfil="usuario,gestor,mentor">
+        <a href="anuncios-tabs/cadastro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-anuncios" data-perfil="usuario,cliente,gestor,mentor">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
             <path stroke-linecap="round" stroke-linejoin="round" d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46"/>
           </svg>
@@ -265,7 +265,7 @@
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="expedicao.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-expedicao" data-perfil="usuario,gestor,mentor">
+        <a href="expedicao.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-expedicao" data-perfil="usuario,cliente,gestor,mentor">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
             <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 01-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 00-3.213-9.193 2.056 2.056 0 00-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 00-10.026 0 1.106 1.106 0 00-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12"/>
           </svg>
@@ -288,7 +288,7 @@
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="gestao-contas.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao-contas" data-perfil="usuario,gestor,mentor">
+        <a href="gestao-contas.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao-contas" data-perfil="gestor,mentor">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
             <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z"/>
           </svg>
@@ -307,7 +307,7 @@
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="problemas.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-acompanhamento" data-perfil="usuario,gestor,mentor,responsavel,gestor financeiro">
+        <a href="problemas.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-acompanhamento" data-perfil="gestor,mentor,responsavel,gestor financeiro">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m0 3.75h.008v.008H12v-.008ZM21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
           </svg>
@@ -329,7 +329,7 @@
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=produtos" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-outros" data-perfil="usuario,gestor,mentor">
+        <a href="Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=produtos" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-outros" data-perfil="usuario,cliente,gestor,mentor">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/>
           </svg>
@@ -352,7 +352,7 @@
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-configuracoes" data-perfil="usuario,gestor,mentor">
+        <a href="Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-configuracoes" data-perfil="usuario,cliente,gestor,mentor">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"/>
             <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>


### PR DESCRIPTION
## Summary
- Show only sales, shipping, ads, other, settings and communication entries for client profiles
- Strip sidebar submenus and reorder items for basic users

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2fa2aa0dc832a822370016364669e