### PR TITLE
Resumir opções do sidebar para usuários

### DIFF
--- a/public/shared.js
+++ b/public/shared.js
@@ -528,7 +528,15 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-desempenho',
   ];
 
-  const CLIENTE_HIDDEN_MENU_IDS = ADMIN_GESTOR_MENU_IDS.filter(id => id !== 'menu-comunicacao');
+  const CLIENTE_HIDDEN_MENU_IDS = [
+    ...ADMIN_GESTOR_MENU_IDS.filter(id => id !== 'menu-comunicacao'),
+    'menu-inicio',
+    'menu-etiquetas',
+    'menu-precificacao',
+    'menu-marketing',
+    'menu-gestao-contas',
+    'menu-acompanhamento'
+  ];
 
   function showOnly(ids) {
     document.querySelectorAll('#sidebar .sidebar-link').forEach(a => {

--- a/shared.js
+++ b/shared.js
@@ -549,7 +549,15 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-desempenho',
   ];
 
-  const CLIENTE_HIDDEN_MENU_IDS = ADMIN_GESTOR_MENU_IDS.filter(id => id !== 'menu-comunicacao');
+  const CLIENTE_HIDDEN_MENU_IDS = [
+    ...ADMIN_GESTOR_MENU_IDS.filter(id => id !== 'menu-comunicacao'),
+    'menu-inicio',
+    'menu-etiquetas',
+    'menu-precificacao',
+    'menu-marketing',
+    'menu-gestao-contas',
+    'menu-acompanhamento'
+  ];
 
   function showOnly(ids) {
     document.querySelectorAll('#sidebar .sidebar-link').forEach(a => {


### PR DESCRIPTION
## Summary
- Reduz itens do sidebar para usuários ocultando links não necessários
- Mantém acesso às páginas sem exibir opções extras

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c304081714832ab8c53ff69f82fbd4