### PR TITLE
fix: handle malformed encrypted orders

### DIFF
--- a/expedicao-pedidosreais.html
+++ b/expedicao-pedidosreais.html
@@ -287,7 +287,16 @@
           let d = doc.data();
           if (d.encrypted) {
             try {
-              const txt = await decryptString(d.encrypted, pass);
+              let payload = d.encrypted;
+              if (typeof payload !== 'string') {
+                payload = JSON.stringify(payload);
+              } else {
+                payload = payload.trim();
+                if (payload.startsWith('"') && payload.endsWith('"')) {
+                  payload = JSON.parse(payload);
+                }
+              }
+              const txt = await decryptString(payload, pass);
               d = JSON.parse(txt);
             } catch (e) {
               console.error('Erro ao descriptografar pedido', e);


### PR DESCRIPTION
## Summary
- handle malformed encrypted payloads when loading real orders, avoiding decrypt errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c308db4fbc832a97cf09f68dbfe05c