### PR TITLE
Handle multiple decryption keys when loading orders

### DIFF
--- a/expedicao-pedidosreais.html
+++ b/expedicao-pedidosreais.html
@@ -279,20 +279,26 @@
     async function carregarPedidos(user) {
       try {
         const { decryptString } = await import('./crypto.js');
-        const pass = getPassphrase() || user.uid;
         todosPedidos = [];
+        const passCandidates = [getPassphrase(), user.email, `chave-${user.uid}`, user.uid];
         const listaSnap = await db.collectionGroup('lista').where('uid', '==', user.uid).get();
         for (const doc of listaSnap.docs) {
           if (!doc.ref.path.includes('/pedidosreais/')) continue;
           let d = doc.data();
           if (d.encrypted) {
-            try {
-              const txt = await decryptString(d.encrypted, pass);
-              d = JSON.parse(txt);
-            } catch (e) {
-              console.error('Erro ao descriptografar pedido', e);
+            let txt;
+            for (const p of passCandidates) {
+              if (!p) continue;
+              try {
+                txt = await decryptString(d.encrypted, p);
+                if (txt) break;
+              } catch (_) {}
+            }
+            if (!txt) {
+              console.error('Erro ao descriptografar pedido', doc.id);
               continue;
             }
+            d = JSON.parse(txt);
           }
           d.pedidoId = d.pedidoId || doc.id;
           todosPedidos.push(d);
@@ -602,7 +608,8 @@
         pedidos.push(pedido);
         }
         const { encryptString, decryptString } = await import('./crypto.js');
-        const pass = getPassphrase() || usuarioAtual.uid;
+        const pass = getPassphrase() || usuarioAtual.email || `chave-${usuarioAtual.uid}` || usuarioAtual.uid;
+        const decryptCandidates = [getPassphrase(), usuarioAtual.email, `chave-${usuarioAtual.uid}`, usuarioAtual.uid];
         let atualizados = 0;
         let novos = 0;
         for (let i = 0; i < pedidos.length; i++) {
@@ -615,9 +622,19 @@
           let precisaAtualizar = true;
           if (snap.exists) {
             try {
-              const atual = JSON.parse(await decryptString(snap.data().encrypted, pass));
-              if (JSON.stringify(atual) === JSON.stringify(p)) {
-                precisaAtualizar = false;
+              let txt;
+              for (const cand of decryptCandidates) {
+                if (!cand) continue;
+                try {
+                  txt = await decryptString(snap.data().encrypted, cand);
+                  if (txt) break;
+                } catch (_) {}
+              }
+              if (txt) {
+                const atual = JSON.parse(txt);
+                if (JSON.stringify(atual) === JSON.stringify(p)) {
+                  precisaAtualizar = false;
+                }
               }
             } catch (e) {
               console.error('Erro ao comparar pedido existente', e);


### PR DESCRIPTION
## Summary
- Try several candidate keys when decrypting orders
- Attempt multiple passphrases when comparing existing encrypted orders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c308db4fbc832a97cf09f68dbfe05c