### PR TITLE
Restringe sidebar para gestores de expedição

### DIFF
--- a/login.js
+++ b/login.js
@@ -337,30 +337,43 @@ function hideUserArea() {
 }
 
 function applyExpedicaoSidebar() {
-  const hideLinks = () => {
+  const filter = () => {
     const sidebar = document.getElementById('sidebar');
     if (!sidebar) return;
-    sidebar.querySelectorAll('a.sidebar-link').forEach(link => {
-      const href = link.getAttribute('href') || '';
-      if (!href.includes('expedicao.html')) {
-        link.classList.add('hidden');
+
+    const expLink = document.getElementById('menu-expedicao');
+    const expLi = expLink ? expLink.closest('li') : null;
+
+    sidebar.querySelectorAll('li').forEach(li => {
+      if (expLi && (li === expLi || expLi.contains(li))) {
+        li.classList.remove('hidden');
+        li.style.display = '';
+      } else {
+        li.classList.add('hidden');
       }
     });
+
+    const submenu = document.getElementById('menuExpedicao');
+    if (submenu) {
+      submenu.style.maxHeight = submenu.scrollHeight + 'px';
+    }
   };
-  hideLinks();
-  document.addEventListener('sidebarLoaded', hideLinks);
+
+  filter();
+  document.addEventListener('sidebarLoaded', filter);
 }
 
 function restoreSidebar() {
   const sidebar = document.getElementById('sidebar');
   if (!sidebar) return;
-  sidebar.querySelectorAll('a.sidebar-link').forEach(link => {
-    link.classList.remove('hidden');
+  sidebar.querySelectorAll('li, a.sidebar-link').forEach(el => {
+    el.classList.remove('hidden');
+    if (el.style) el.style.display = '';
   });
 }
 function applyPerfilRestrictions(perfil) {
   const currentPerfil = (perfil || '').toLowerCase().trim();
-  if (!currentPerfil) return;
+  if (!currentPerfil || currentPerfil === 'expedicao') return;
   document.querySelectorAll('[data-perfil]').forEach(el => {
     const allowed = (el.getAttribute('data-perfil') || '')
       .toLowerCase()

--- a/public/login.js
+++ b/public/login.js
@@ -249,33 +249,47 @@ function hideUserArea() {
 }
 
 function applyExpedicaoSidebar() {
-  const hideLinks = () => {
+  const filter = () => {
     const sidebar = document.getElementById('sidebar');
     if (!sidebar) return;
-    sidebar.querySelectorAll('a.sidebar-link').forEach(link => {
-      const href = link.getAttribute('href') || '';
-      if (!href.includes('expedicao.html')) {
-        link.parentElement.classList.add('hidden');
+
+    const expLink = document.getElementById('menu-expedicao');
+    const expLi = expLink ? expLink.closest('li') : null;
+
+    sidebar.querySelectorAll('li').forEach(li => {
+      if (expLi && (li === expLi || expLi.contains(li))) {
+        li.classList.remove('hidden');
+        li.style.display = '';
+      } else {
+        li.classList.add('hidden');
       }
     });
+
+    const submenu = document.getElementById('menuExpedicao');
+    if (submenu) {
+      submenu.style.maxHeight = submenu.scrollHeight + 'px';
+    }
   };
-  hideLinks();
-  document.addEventListener('sidebarLoaded', hideLinks);
+
+  filter();
+  document.addEventListener('sidebarLoaded', filter);
 }
 
 function restoreSidebar() {
   const sidebar = document.getElementById('sidebar');
   if (!sidebar) return;
-  sidebar.querySelectorAll('a.sidebar-link').forEach(link => {
-    link.parentElement.classList.remove('hidden');
+  sidebar.querySelectorAll('li, a.sidebar-link').forEach(el => {
+    el.classList.remove('hidden');
+    if (el.style) el.style.display = '';
   });
 }
 
 function applyPerfilRestrictions(perfil) {
   const currentPerfil = (perfil || '').toLowerCase();
+  if (currentPerfil === 'expedicao') return;
   const elements = document.querySelectorAll('[data-perfil]');
   if (!elements || elements.length === 0) return;
-  
+
   elements.forEach(el => {
     if (!el) return;
     const allowed = (el.getAttribute('data-perfil') || '')


### PR DESCRIPTION
## Summary
- Exibe apenas o grupo de expedição no sidebar para usuários com perfil de expedição
- Ajusta restauração do sidebar e evita ocultação inicial desse perfil

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c315f29004832aab423ef8de4f8e77