### PR TITLE
Limit initial orders view to recent or pending

### DIFF
--- a/expedicao-pedidosreais.html
+++ b/expedicao-pedidosreais.html
@@ -247,8 +247,26 @@
       const prevEnvioStart = prevEnvioInicio ? new Date(prevEnvioInicio) : null;
       const prevEnvioEnd = prevEnvioFim ? new Date(prevEnvioFim) : null;
 
+      const anyFilter =
+        dataStart ||
+        dataEnd ||
+        prevEnvioStart ||
+        prevEnvioEnd ||
+        loja ||
+        statuses.length ||
+        filtroEtiqueta;
+
       const filtrados = todosPedidos.filter(p => {
         const dataPedido = parseDate(p.data);
+
+        if (!anyFilter) {
+          const doisDiasAtras = new Date();
+          doisDiasAtras.setDate(doisDiasAtras.getDate() - 2);
+          const recente = dataPedido && dataPedido >= doisDiasAtras;
+          const aEnviar = (p.status || '').toLowerCase() === 'a enviar';
+          return recente || aEnviar;
+        }
+
         if (dataStart && (!dataPedido || dataPedido < dataStart)) return false;
         if (dataEnd && (!dataPedido || dataPedido > dataEnd)) return false;
         const dataPrevEnvio = parseDate(p.dataPrevistaEnvio);


### PR DESCRIPTION
## Summary
- Default "Pedidos Reais" view now shows only orders from the last two days or with status "A enviar"

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c317696e40832a80e82fa2861d6a5e