### PR TITLE
refactor: replace innerHTML with safe DOM APIs

### DIFF
--- a/pedidos-bling.js
+++ b/pedidos-bling.js
@@ -15,6 +15,17 @@ onAuthStateChanged(auth, async user => {
   await carregarPedidos();
 });
 
+function setTbodyMessage(tbody, message, classes = '', colspan = 4) {
+  tbody.textContent = '';
+  const tr = document.createElement('tr');
+  const td = document.createElement('td');
+  td.colSpan = colspan;
+  td.className = `text-center py-4 ${classes}`.trim();
+  td.textContent = message;
+  tr.appendChild(td);
+  tbody.appendChild(tr);
+}
+
 // -------------------------------------------------------------
 // ADICIONE ESTA FUNÇÃO AQUI, ANTES DE `carregarPedidos`
 // -------------------------------------------------------------
@@ -22,22 +33,32 @@ function atualizarTabelaPedidos(pedidos) {
   const tbody = document.querySelector('#tabelaPedidosBling tbody');
   if (!tbody) return;
 
-  tbody.innerHTML = ''; // Limpa o corpo da tabela antes de adicionar os novos dados.
+  tbody.textContent = ''; // Limpa o corpo da tabela antes de adicionar os novos dados.
 
   if (pedidos.length === 0) {
-    tbody.innerHTML = '<tr><td colspan="4" class="text-center py-4 text-gray-500">Nenhum pedido encontrado</td></tr>';
+    setTbodyMessage(tbody, 'Nenhum pedido encontrado', 'text-gray-500', 4);
     return;
   }
 
   pedidos.forEach(pedido => {
     const row = document.createElement('tr');
-    // Certifique-se de que a estrutura do seu objeto 'pedido' corresponde a esta.
-    row.innerHTML = `
-      <td data-label="Pedido">${pedido.numero}</td>
-      <td data-label="SKU">${pedido.itens.map(item => item.sku).join(', ')}</td>
-      <td data-label="Valor Pago">R$ ${parseFloat(pedido.valor).toFixed(2)}</td>
-      <td data-label="Valor Líquido">R$ ${parseFloat(pedido.valorLiquido).toFixed(2)}</td>
-    `;
+    const cells = [
+      pedido.numero,
+      pedido.itens.map(item => item.sku).join(', '),
+      `R$ ${parseFloat(pedido.valor).toFixed(2)}`,
+      `R$ ${parseFloat(pedido.valorLiquido).toFixed(2)}`
+    ];
+    cells.forEach((text, idx) => {
+      const td = document.createElement('td');
+      td.textContent = text;
+      switch (idx) {
+        case 0: td.setAttribute('data-label', 'Pedido'); break;
+        case 1: td.setAttribute('data-label', 'SKU'); break;
+        case 2: td.setAttribute('data-label', 'Valor Pago'); break;
+        case 3: td.setAttribute('data-label', 'Valor Líquido'); break;
+      }
+      row.appendChild(td);
+    });
     tbody.appendChild(row);
   });
 }
@@ -48,7 +69,7 @@ function atualizarTabelaPedidos(pedidos) {
 export async function carregarPedidos() {
   const tbody = document.querySelector('#tabelaPedidosBling tbody');
   if (!tbody) return;
-  tbody.innerHTML = '<tr><td colspan="4" class="text-center py-4">Carregando...</td></tr>';
+  setTbodyMessage(tbody, 'Carregando...');
   try {
  const uid = auth.currentUser.uid;
     const pass = getPassphrase() || `chave-${uid}`;
@@ -58,24 +79,10 @@ const pedidos = [];
       const pedido = await loadUserDoc(db, uid, 'pedidosBling', d.id, pass);
       if (pedido) pedidos.push(pedido);
     }
-    // -------------------------------------------------------------
-    // SUBSTITUA ESTE TRECHO
-    // -------------------------------------------------------------
-    // tbody.innerHTML = '';
-    // if (window.atualizarTabelaPedidos) {
-    //   window.atualizarTabelaPedidos(pedidos);
-    // }
-    // if (!tbody.children.length) {
-    //   tbody.innerHTML = '<tr><td colspan="4" class="text-center py-4 text-gray-500">Nenhum pedido encontrado</td></tr>';
-    // }
-    // -------------------------------------------------------------
-    // POR ESTE AQUI
-    // -------------------------------------------------------------
     atualizarTabelaPedidos(pedidos);
-    // -------------------------------------------------------------
   } catch (err) {
     console.error('Erro ao carregar pedidos', err);
-    tbody.innerHTML = '<tr><td colspan="4" class="text-center py-4 text-red-500">Erro ao carregar pedidos</td></tr>';
+    setTbodyMessage(tbody, 'Erro ao carregar pedidos', 'text-red-500');
   }
 }
 

--- a/pedidos-shopee.js
+++ b/pedidos-shopee.js
@@ -23,10 +23,21 @@ function normalizarTexto(texto) {
     .trim();
 }
 
+function setTbodyMessage(tbody, message, classes = '', colspan = 5) {
+  tbody.textContent = '';
+  const tr = document.createElement('tr');
+  const td = document.createElement('td');
+  td.colSpan = colspan;
+  td.className = `text-center py-4 ${classes}`.trim();
+  td.textContent = message;
+  tr.appendChild(td);
+  tbody.appendChild(tr);
+}
+
 export async function carregarPedidosShopee() {
   const tbody = document.querySelector('#tabelaPedidosShopee tbody');
   if (!tbody) return;
-  tbody.innerHTML = '<tr><td colspan="5" class="text-center py-4">Carregando...</td></tr>';
+  setTbodyMessage(tbody, 'Carregando...');
   try {
     const uid = auth.currentUser.uid;
 const pass = (await getPassphrase()) || `chave-${uid}`;
@@ -52,29 +63,33 @@ if (pedido) {
     }
 correlacionarPedidosComAnuncios(pedidos, mapaAnuncios);
 
-    tbody.innerHTML = '';
+    tbody.textContent = '';
     pedidos.forEach(p => {
       const tr = document.createElement('tr');
-      const data = p.data || p.status || '–'; // usa status se não houver data
-      const total = p.preco || p.total || '–'; // usa preço se não houver total
+      const data = p.data || p.status || '–';
+      const total = p.preco || p.total || '–';
       const skuList = (p.itens || []).map(i => i.sku).filter(Boolean).join(', ') || '–';
-      tr.innerHTML = `
-        <td>${p.id || ''}</td>
-        <td>${data}</td>
-        <td>${total}</td>
-        <td>${skuList}</td>
-        <td><button class="btn btn-secondary text-sm">Ver Detalhes</button></td>
-      `;
-      tr.querySelector('button').addEventListener('click', () => mostrarDetalhesPedido(p));
+      [p.id || '', data, total, skuList].forEach(text => {
+        const td = document.createElement('td');
+        td.textContent = text;
+        tr.appendChild(td);
+      });
+      const tdBtn = document.createElement('td');
+      const btn = document.createElement('button');
+      btn.className = 'btn btn-secondary text-sm';
+      btn.textContent = 'Ver Detalhes';
+      btn.addEventListener('click', () => mostrarDetalhesPedido(p));
+      tdBtn.appendChild(btn);
+      tr.appendChild(tdBtn);
       tbody.appendChild(tr);
     });
 
     if (!tbody.children.length) {
-      tbody.innerHTML = '<tr><td colspan="5" class="text-center py-4 text-gray-500">Nenhum pedido encontrado</td></tr>';
+      setTbodyMessage(tbody, 'Nenhum pedido encontrado', 'text-gray-500');
     }
   } catch (err) {
     console.error('Erro ao carregar pedidos', err);
- tbody.innerHTML = '<tr><td colspan="5" class="text-center py-4 text-red-500">Erro ao carregar pedidos</td></tr>';
+    setTbodyMessage(tbody, 'Erro ao carregar pedidos', 'text-red-500');
   }
 }
 
@@ -141,11 +156,13 @@ function mostrarDetalhesPedido(pedido) {
   const modal = document.getElementById('modalPedido');
   const detalhes = document.getElementById('detalhesPedido');
   if (!modal || !detalhes) return;
-  detalhes.innerHTML = '';
+  detalhes.textContent = '';
   Object.entries(pedido).forEach(([k, v]) => {
     const div = document.createElement('div');
-if (k === 'itens' && Array.isArray(v)) {
-      div.innerHTML = '<strong>Itens:</strong>';
+    if (k === 'itens' && Array.isArray(v)) {
+      const strong = document.createElement('strong');
+      strong.textContent = 'Itens:';
+      div.appendChild(strong);
       const ul = document.createElement('ul');
       v.forEach(item => {
         const li = document.createElement('li');
@@ -155,7 +172,10 @@ if (k === 'itens' && Array.isArray(v)) {
       div.appendChild(ul);
     } else {
       const valor = typeof v === 'object' ? JSON.stringify(v, null, 2) : v;
-      div.innerHTML = `<strong>${k}:</strong> ${valor}`;
+      const strong = document.createElement('strong');
+      strong.textContent = `${k}:`;
+      div.appendChild(strong);
+      div.appendChild(document.createTextNode(` ${valor}`));
     }
     detalhes.appendChild(div);
   });

--- a/perfil-mentorado.js
+++ b/perfil-mentorado.js
@@ -13,21 +13,43 @@ const singleUid = urlParams.get('uid');
 function createPerfilCard(uid, email, data = {}) {
   const card = document.createElement('div');
   card.className = 'border p-4 rounded space-y-2';
-  card.innerHTML = `
-    <h3 class="font-bold">${email}</h3>
-    <input class="form-control" placeholder="Nome" value="${data.nome || ''}" data-field="nome">
-    <input class="form-control" placeholder="Loja" value="${data.loja || ''}" data-field="loja">
-    <input class="form-control" placeholder="Segmento" value="${data.segmento || ''}" data-field="segmento">
-    <input class="form-control" placeholder="Tempo de operação" value="${data.tempoOperacao || ''}" data-field="tempoOperacao">
-    <input class="form-control" placeholder="Link Shopee" value="${data.links?.shopee || ''}" data-field="shopee">
-    <input class="form-control" placeholder="Link Mercado Livre" value="${data.links?.mercadoLivre || ''}" data-field="mercadoLivre">
-    <input class="form-control" placeholder="Site próprio" value="${data.links?.site || ''}" data-field="site">
-    <input class="form-control" placeholder="Instagram" value="${data.links?.instagram || ''}" data-field="instagram">
-    <textarea class="form-control" placeholder="Objetivos">${data.objetivos || ''}</textarea>
-    <button class="btn btn-primary salvar">Salvar</button>
-  `;
+  const titulo = document.createElement('h3');
+  titulo.className = 'font-bold';
+  titulo.textContent = email;
+  card.appendChild(titulo);
 
-  card.querySelector('.salvar').addEventListener('click', async () => {
+  const campos = [
+    { field: 'nome', placeholder: 'Nome', value: data.nome || '' },
+    { field: 'loja', placeholder: 'Loja', value: data.loja || '' },
+    { field: 'segmento', placeholder: 'Segmento', value: data.segmento || '' },
+    { field: 'tempoOperacao', placeholder: 'Tempo de operação', value: data.tempoOperacao || '' },
+    { field: 'shopee', placeholder: 'Link Shopee', value: data.links?.shopee || '' },
+    { field: 'mercadoLivre', placeholder: 'Link Mercado Livre', value: data.links?.mercadoLivre || '' },
+    { field: 'site', placeholder: 'Site próprio', value: data.links?.site || '' },
+    { field: 'instagram', placeholder: 'Instagram', value: data.links?.instagram || '' }
+  ];
+
+  campos.forEach(c => {
+    const input = document.createElement('input');
+    input.className = 'form-control';
+    input.placeholder = c.placeholder;
+    input.value = c.value;
+    input.dataset.field = c.field;
+    card.appendChild(input);
+  });
+
+  const objetivos = document.createElement('textarea');
+  objetivos.className = 'form-control';
+  objetivos.placeholder = 'Objetivos';
+  objetivos.textContent = data.objetivos || '';
+  card.appendChild(objetivos);
+
+  const btn = document.createElement('button');
+  btn.className = 'btn btn-primary salvar';
+  btn.textContent = 'Salvar';
+  card.appendChild(btn);
+
+  btn.addEventListener('click', async () => {
     const getVal = (field) => card.querySelector(`[data-field="${field}"]`).value.trim();
     const payload = {
       nome: getVal('nome'),
@@ -40,7 +62,7 @@ function createPerfilCard(uid, email, data = {}) {
         site: getVal('site'),
         instagram: getVal('instagram')
       },
-      objetivos: card.querySelector('textarea').value.trim()
+      objetivos: objetivos.value.trim()
     };
     try {
       await setDoc(doc(db, 'perfilMentorado', uid), payload, { merge: true });
@@ -55,13 +77,16 @@ function createPerfilCard(uid, email, data = {}) {
 
 async function carregarPerfis() {
   const list = document.getElementById('perfilMentoradoList');
-  list.innerHTML = '';
+  list.textContent = '';
 
   if (singleUid) {
     try {
       const userDoc = await getDoc(doc(db, 'usuarios', singleUid));
       if (!userDoc.exists()) {
-        list.innerHTML = '<p class="text-sm text-gray-500">Usuário não encontrado.</p>';
+        const p = document.createElement('p');
+        p.className = 'text-sm text-gray-500';
+        p.textContent = 'Usuário não encontrado.';
+        list.appendChild(p);
         return;
       }
       const email = userDoc.data().email || singleUid;
@@ -77,7 +102,10 @@ async function carregarPerfis() {
       list.appendChild(createPerfilCard(singleUid, email, perfilData));
     } catch (e) {
       console.error('Erro ao carregar usuário:', e);
-      list.innerHTML = '<p class="text-sm text-red-500">Erro ao carregar usuário.</p>';
+      const p = document.createElement('p');
+      p.className = 'text-sm text-red-500';
+      p.textContent = 'Erro ao carregar usuário.';
+      list.appendChild(p);
     }
     return;
   }


### PR DESCRIPTION
## Summary
- build mentor profile cards and messaging with DOM nodes
- replace table rendering in pedidos pages with createElement and helper to show messages
- add utility to show summary and rows without innerHTML

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c34f261760832a8cc39bd1c5516046