### PR TITLE
feat: add logger utility and clean console output

### DIFF
--- a/acompanhamento-promocoes.js
+++ b/acompanhamento-promocoes.js
@@ -149,7 +149,6 @@ window.importarPlanilhaPromocoes = async function(event) {
   const data = XLSX.utils.sheet_to_json(sheet);
 
   const novoTipo = detectarTipoDePromocao(file.name, data);
-  console.log("Tipo detectado:", novoTipo);
 
   data.forEach((linha, i) => {
     const sku = linha["SKU"] || linha["Product SKU"] || linha["Product Id"];

--- a/bling.js
+++ b/bling.js
@@ -2,6 +2,7 @@ import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.
 import { getFirestore } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
 import { getAuth } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 import { saveSecureDoc, loadSecureDoc } from './secure-firestore.js';
+import logger from './logger.js';
 
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
@@ -84,7 +85,7 @@ const url = 'https://proxybling-g6u4niudyq-uc.a.run.app';
     atualizarTabelaPedidos(pedidos);
     alert(`${pedidos.length} pedidos importados`);
   } catch (err) {
-   console.warn('Proxy falhou, tentando acesso direto:', err);
+   logger.warn('Proxy falhou, tentando acesso direto:', err);
     try {
       const directUrl = `https://corsproxy.io/https://bling.com.br/Api/v2/pedidos/json/?apikey=${encodeURIComponent(apiKey)}`;
       const res = await fetch(directUrl);

--- a/createWorker.js
+++ b/createWorker.js
@@ -1,8 +1,9 @@
 // Importa a build ESM do Tesseract que expõe `createWorker`
 import { createWorker } from 'https://cdn.jsdelivr.net/npm/tesseract.js@5.0.4/dist/tesseract.esm.min.js';
+import logger from './logger.js';
 
 export async function createOcrWorker() {
-  const worker = await createWorker({ logger: m => console.log('[OCR]', m) });
+  const worker = await createWorker({ logger: m => logger.log('[OCR]', m) });
   await worker.loadLanguage('por+eng');
   await worker.initialize('por+eng');
   await worker.setParameters({

--- a/criar-anuncio-ia.js
+++ b/criar-anuncio-ia.js
@@ -2,13 +2,14 @@ import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.
 import { getFirestore } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
 import { getAuth } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 import { saveUserDoc } from './secure-firestore.js';
+import logger from './logger.js';
 
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app);
 
 async function chamarIA(prompt, { json = false } = {}) {
-    console.log("📤 Pergunta enviada para a IA:", prompt); // 👈 ADICIONE ESTA LINHA
+    logger.log("📤 Pergunta enviada para a IA:", prompt); // 👈 ADICIONE ESTA LINHA
 
   const body = {
     model: 'deepseek-chat',
@@ -29,7 +30,7 @@ async function chamarIA(prompt, { json = false } = {}) {
 
   const data = await resp.json();
   const texto = data.choices?.[0]?.message?.content?.trim() || '';
-  console.log("🧠 Resposta da IA (bruta):", texto);
+  logger.log("🧠 Resposta da IA (bruta):", texto);
   return texto;
 }
 
@@ -84,7 +85,7 @@ Crie um anúncio profissional com base nas informações abaixo e responda com u
       dados = match ? JSON.parse(match[0]) : {};
     }
 
-    console.log("🎯 Dados processados:", dados);
+    logger.log("🎯 Dados processados:", dados);
 
     document.getElementById('sugestoes').classList.remove('hidden');
     document.getElementById('tituloIA').value = dados.titulo || '';
@@ -115,7 +116,7 @@ Produto: "${termo}"`;
 
   try {
     const texto = await chamarIA(prompt, { json: true });
-    console.log("🧠 Resposta da IA (bruta):", texto);
+    logger.log("🧠 Resposta da IA (bruta):", texto);
 
     let lista;
     try {
@@ -129,7 +130,7 @@ Produto: "${termo}"`;
       }
     }
 
-    console.log("🔑 Palavras-chave:", lista);
+    logger.log("🔑 Palavras-chave:", lista);
 
     const tabela = document.getElementById('resultadoKeywords');
     let html = '<tr><th class="text-left p-2">Palavra</th><th class="text-left p-2">Volume</th><th class="text-left p-2">Concorrência</th><th class="text-left p-2">Uso</th></tr>';

--- a/gerenciamento.js
+++ b/gerenciamento.js
@@ -5,6 +5,7 @@ import {
   query, where, orderBy, limit, startAfter, collectionGroup
 } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 import { saveSecureDoc, loadSecureDoc } from './secure-firestore.js';
+import logger from './logger.js';
 
 import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js";
 
@@ -234,7 +235,7 @@ const normalizeKey = (str) =>
         }
       }
       if (!id) {
-        console.warn(`❌ Linha de ${tipo} sem ID do Produto.`, linha);
+        logger.warn(`❌ Linha de ${tipo} sem ID do Produto.`, linha);
         continue;
       }
       id = String(id).trim();
@@ -245,7 +246,7 @@ const normalizeKey = (str) =>
 
       if (!varianteId) {
         if (tipo === 'desempenho') {
-          console.warn(`❌ Linha de desempenho sem ID da Variação para item ${id}.`);
+          logger.warn(`❌ Linha de desempenho sem ID da Variação para item ${id}.`);
           continue;
         }
         varianteId = 'unico_' + id;
@@ -543,7 +544,7 @@ if (docExiste && !dadosAntigos) {
               }
             }
           } else {
-            console.warn(`❌ Desempenho ignorado - anúncio ${id} não existe no Firebase.`);
+            logger.warn(`❌ Desempenho ignorado - anúncio ${id} não existe no Firebase.`);
           }
         } else {
           const variantesPath = `uid/${user.uid}/anuncios/${id}/variantes`;
@@ -629,7 +630,7 @@ let pageCursors = [null];
 window.carregarAnuncios = async function (direction) {
   const tbody = document.querySelector("#tabelaAnuncios tbody");
   if (!tbody) {
-    console.warn("Elemento #tabelaAnuncios tbody não encontrado.");
+    logger.warn("Elemento #tabelaAnuncios tbody não encontrado.");
     return;
   }
   tbody.innerHTML = '<tr><td colspan="7" class="text-center py-8">Carregando anúncios...</td></tr>';
@@ -735,7 +736,7 @@ for (const v of variantes) {
         }
       }
   } catch (e) {
-    console.warn(`Erro ao buscar SKU ${sku} em produtos:`, e);
+    logger.warn(`Erro ao buscar SKU ${sku} em produtos:`, e);
     v.skuNaoEncontrado = true; // fallback de segurança
     const skuLower = String(sku);
     if (!window.skusNaoCadastrados.includes(skuLower)) {

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="pt-BR">
 <head>
+  <script type="module" src="logger.js"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="manifest" href="manifest.json">

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ import { loadSecureDoc } from './secure-firestore.js';
 import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 import { firebaseConfig } from './firebase-config.js';
 import { checkBackend } from './login.js';
+import logger from './logger.js';
 
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
@@ -321,7 +322,7 @@ async function carregarTopSkus(uid, isAdmin) {
     if (isAdmin) {
       const parentDoc = docSnap.ref.parent.parent;
       if (!parentDoc) {
-        console.warn('Documento sem pai para skusVendidos:', docSnap.ref.path);
+        logger.warn('Documento sem pai para skusVendidos:', docSnap.ref.path);
         continue;
       }
       ownerUid = parentDoc.id;
@@ -450,7 +451,7 @@ async function iniciarPainel(user) {
         const perfil = String(snap.data().perfil || '').toLowerCase();
         isAdmin = (perfil === 'adm' || perfil === 'admin');
       } else {
-        console.warn(`Documento de usuário ${uid} não encontrado em 'usuarios'`);
+        logger.warn(`Documento de usuário ${uid} não encontrado em 'usuarios'`);
       }
     } catch (e) {
       console.error('Erro ao carregar perfil do usuário:', e);

--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,26 @@
+const isProd = (() => {
+  if (typeof window !== 'undefined') {
+    const host = window.location.hostname;
+    return host && host !== 'localhost' && host !== '127.0.0.1';
+  }
+  if (typeof process !== 'undefined' && process.env.NODE_ENV) {
+    return process.env.NODE_ENV === 'production';
+  }
+  return false;
+})();
+
+const logger = {
+  log: (...args) => {
+    if (!isProd) console.log(...args);
+  },
+  warn: (...args) => {
+    if (!isProd) console.warn(...args);
+  }
+};
+
+if (isProd) {
+  console.log = () => {};
+  console.warn = () => {};
+}
+
+export default logger;

--- a/monitoramento.js
+++ b/monitoramento.js
@@ -2,6 +2,7 @@ import { initializeApp, getApps } from "https://www.gstatic.com/firebasejs/9.22.
 import { getFirestore, collection, doc, getDoc, getDocs, addDoc, collectionGroup } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js";
 import { saveSecureDoc, loadSecureDoc } from './secure-firestore.js';
 import { encryptString, decryptString } from './crypto.js';
+import logger from './logger.js';
 import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js";
 
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
@@ -81,7 +82,7 @@ async function monitorar() {
     const termo = (dados.nome || '').trim();  // <- CORRIGIDO
     if (!termo) continue;
 
-    console.log("Buscando por:", termo);
+    logger.log("Buscando por:", termo);
 
     const resultados = await buscarShopee(termo);
     if (!resultados.length) continue;

--- a/pedidos-shopee.js
+++ b/pedidos-shopee.js
@@ -2,6 +2,7 @@ import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.
 import { getFirestore, collection, getDocs } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
 import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 import { loadUserDoc, loadSecureDoc } from './secure-firestore.js';
+import logger from './logger.js';
 
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
@@ -57,7 +58,7 @@ const pass = (await getPassphrase()) || `chave-${uid}`;
         }
       }
 if (pedido) {
-  console.log('📦 Pedido carregado:', d.id, pedido); // 🔍 mostra no console
+  logger.log('📦 Pedido carregado:', d.id, pedido); // 🔍 mostra no console
   pedidos.push({ id: d.id, ...pedido });
 }
     }
@@ -109,15 +110,15 @@ const variante = await loadUserDoc(db, uid, `anuncios/${anuncioDoc.id}/variantes
         const chave = `${normalizarTexto(nomeAnuncio)}|${normalizarTexto(variante.nomeVariante)}`;
         if (variante.skuVariante) {
  mapa[chave] = variante.skuVariante;
-          console.log(`🔑 Chave gerada no anúncio: "${chave}" → SKU: ${variante.skuVariante}`);
+          logger.log(`🔑 Chave gerada no anúncio: "${chave}" → SKU: ${variante.skuVariante}`);
         }
       }
     }
   } catch (err) {
     console.error('Erro ao carregar anúncios para correlação', err);
   }
-    console.log("📦 Mapa de Anúncios completo:");
-  console.log(mapa);
+    logger.log("📦 Mapa de Anúncios completo:");
+  logger.log(mapa);
   return mapa;
 }
 
@@ -128,9 +129,9 @@ function correlacionarPedidosComAnuncios(pedidos, mapa) {
 const chave = `${normalizarTexto(item.produto)}|${normalizarTexto(item.variacao)}`;
       const sku = mapa[chave] || null;
 if (sku) {
-  console.log(`✅ Correlacionado: "${chave}" → SKU: ${sku}`);
+  logger.log(`✅ Correlacionado: "${chave}" → SKU: ${sku}`);
 } else {
-  console.warn(`❌ SKU não encontrado para chave: "${chave}"`);
+  logger.warn(`❌ SKU não encontrado para chave: "${chave}"`);
 }
 
       return { ...item, sku };

--- a/script-ads.js
+++ b/script-ads.js
@@ -1,4 +1,5 @@
 import { encryptString, decryptString } from './crypto.js';
+import logger from './logger.js';
 
 if (!firebase.apps.length) {
   firebase.initializeApp(firebaseConfig);
@@ -55,10 +56,10 @@ const nomeProduto = nomeProdutoRaw
       .map(l => l.split(","))
       .filter(l => l.length === cabecalho.length);
 
-    console.log("📌 Campanha:", nomeProduto);
-    console.log("📆 Data final:", dataFormatada);
-    console.log("📄 Cabeçalho:", cabecalho);
-    console.log("📦 Primeira linha:", dados[0]);
+    logger.log("📌 Campanha:", nomeProduto);
+    logger.log("📆 Data final:", dataFormatada);
+    logger.log("📄 Cabeçalho:", cabecalho);
+    logger.log("📦 Primeira linha:", dados[0]);
 
     const getIndex = (termo) =>
       cabecalho.findIndex(c =>
@@ -136,7 +137,7 @@ for (const linha of dados) {
       },
       { merge: true }
     );
-    console.log("✅ Salvo:", nomeProduto, dataFormatada);
+    logger.log("✅ Salvo:", nomeProduto, dataFormatada);
   } catch (erro) {
     console.error("❌ Erro ao salvar:", erro);
   }

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,12 +1,13 @@
 import { db, collection, doc, setDoc } from './firebase-init.js';
 import { encryptString } from '../crypto.js';
+import logger from '../logger.js';
 
 chrome.runtime.onMessage.addListener(async (msg) => {
   if (msg.tipo === "salvarPedidos") {
     const { uid, passphrase, pedidos } = msg;
 
     if (!uid || !passphrase) {
-      console.warn("⚠️ UID ou senha ausente");
+      logger.warn("⚠️ UID ou senha ausente");
       return;
     }
 
@@ -20,6 +21,6 @@ chrome.runtime.onMessage.addListener(async (msg) => {
       }
     }
 
-    console.log("✅ Pedidos salvos:", pedidos.length);
+    logger.log("✅ Pedidos salvos:", pedidos.length);
   }
 });

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -28,7 +28,6 @@
       return;
     }
 
-    console.log("Pedidos capturados:", pedidos);
     alert(`Foram coletados ${pedidos.length} pedidos. Veja no console (F12).`);
 
     // Pede UID + senha do sistema

--- a/secure-firestore.js
+++ b/secure-firestore.js
@@ -1,5 +1,6 @@
 import { encryptString, decryptString } from './crypto.js';
 import { doc, setDoc, getDoc } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import logger from './logger.js';
 function buildRef(db, collectionPath, id) {
   const segments = collectionPath.split('/').filter(Boolean);
   return doc(db, ...segments, id);
@@ -17,7 +18,7 @@ export async function saveSecureDoc(db, collectionName, id, data, passphrase) {
 
 export async function loadSecureDoc(db, collectionName, id, passphrase) {
  if (!id) {
-    console.warn('⚠️ ID do documento não foi fornecido para a coleção:', collectionName);
+    logger.warn('⚠️ ID do documento não foi fornecido para a coleção:', collectionName);
     return null;
   }
   const ref = buildRef(db, collectionName, id);
@@ -49,8 +50,8 @@ export async function loadSecureDoc(db, collectionName, id, passphrase) {
       jsonStr = JSON.stringify(payload); // Já é objeto válido
     }
 
-    console.log('📄 Documento:', id);
-    console.log('🧪 JSON para descriptografar:', jsonStr);
+    logger.log('📄 Documento:', id);
+    logger.log('🧪 JSON para descriptografar:', jsonStr);
 
     const plaintext = await decryptString(jsonStr, passphrase);
     const data = JSON.parse(plaintext);
@@ -58,7 +59,7 @@ export async function loadSecureDoc(db, collectionName, id, passphrase) {
     if (uid && !data.uid) data.uid = uid;
     return data;
   } catch (err) {
-    console.warn('🔐 Erro ao descriptografar documento:', id, err.message);
+    logger.warn('🔐 Erro ao descriptografar documento:', id, err.message);
     if (Object.keys(rest).length) {
       return { ...rest, ...(uid && { uid }) };
     }
@@ -92,8 +93,8 @@ export async function loadSecureDocFromSnap(docSnap, passphrase) {
       jsonStr = JSON.stringify(payload);
     }
 
-    console.log('📄 Documento:', docSnap.id);
-    console.log('🧪 JSON para descriptografar:', jsonStr);
+    logger.log('📄 Documento:', docSnap.id);
+    logger.log('🧪 JSON para descriptografar:', jsonStr);
 
     const plaintext = await decryptString(jsonStr, passphrase);
     const data = JSON.parse(plaintext);
@@ -101,7 +102,7 @@ export async function loadSecureDocFromSnap(docSnap, passphrase) {
     if (uid && !data.uid) data.uid = uid;
     return data;
   } catch (err) {
-    console.warn('🔐 Erro ao descriptografar documento:', docSnap.id, err.message);
+    logger.warn('🔐 Erro ao descriptografar documento:', docSnap.id, err.message);
     if (Object.keys(rest).length) {
       return { ...rest, ...(uid && { uid }) };
     }

--- a/shared.js
+++ b/shared.js
@@ -201,7 +201,6 @@
       var color = style.color.replace(/\s+/g, '');
       var bg = style.backgroundColor.replace(/\s+/g, '');
       if (color && bg && color === bg) {
-        console.warn('Low contrast text detected:', el);
         el.style.outline = '2px dashed red';
       }
     });

--- a/shopee-sync-extension/background.js
+++ b/shopee-sync-extension/background.js
@@ -1,11 +1,12 @@
 import { db, collection, doc, setDoc } from './firebase-init.js';
 import { encryptString } from '../crypto.js';
+import logger from '../logger.js';
 
 chrome.runtime.onMessage.addListener(async (msg) => {
   if (msg.type === 'salvarPedidos') {
     const { uid, passphrase, pedidos } = msg;
     if (!uid || !passphrase) {
-      console.warn('UID ou senha ausente');
+      logger.warn('UID ou senha ausente');
       return;
     }
     for (const pedido of pedidos) {


### PR DESCRIPTION
## Summary
- add simple logger that suppresses console output in production
- load logger on main page and replace direct console usage with logger calls
- clean stray console.log/console.warn statements in background and orders scripts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3502bba98832abd37799cc644dbaf