### PR TITLE
refactor: modularize shared utilities

### DIFF
--- a/import-card.js
+++ b/import-card.js
@@ -1,0 +1,14 @@
+(function() {
+  // Toggle visibility of the Importar Produtos card on the precificação page
+  window.toggleImportCard = function() {
+    var card = document.getElementById('importarProdutosCard');
+    var btn = document.getElementById('toggleImportarBtn');
+    if (!card || !btn) return;
+    card.classList.toggle('hidden');
+    if (card.classList.contains('hidden')) {
+      btn.textContent = 'Exibir Importar Produtos';
+    } else {
+      btn.textContent = 'Esconder Importar Produtos';
+    }
+  };
+})();

--- a/menu.js
+++ b/menu.js
@@ -1,0 +1,12 @@
+(function() {
+  // Toggle submenu visibility using max-height for smooth transitions
+  window.toggleMenu = function(menuId, btn) {
+    var el = document.getElementById(menuId);
+    if (!el) return;
+    var isOpen = el.style.maxHeight && el.style.maxHeight !== '0px';
+    el.style.maxHeight = isOpen ? '0px' : el.scrollHeight + 'px';
+    if (btn) {
+      btn.classList.toggle('open', !isOpen);
+    }
+  };
+})();

--- a/partials/navbar-expedicao.html
+++ b/partials/navbar-expedicao.html
@@ -94,3 +94,5 @@
     </div>
   </div>
 </div>
+
+<script src="../menu.js"></script>

--- a/partials/navbar-grupos.html
+++ b/partials/navbar-grupos.html
@@ -101,3 +101,5 @@
     </div>
   </div>
 </div>
+
+<script src="../menu.js"></script>

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -401,3 +401,5 @@
     </li>
   </ul>
 </nav>
+
+<script src="../menu.js"></script>

--- a/precificacao-tabs/precificacao.html
+++ b/precificacao-tabs/precificacao.html
@@ -298,3 +298,5 @@
           </button>
         </div>
       </div>
+
+<script src="../import-card.js"></script>

--- a/shared.js
+++ b/shared.js
@@ -37,29 +37,6 @@
     });
   }
   
-  // Toggle submenu visibility using max-height for smooth transitions
-  window.toggleMenu = function(menuId, btn) {
-    var el = document.getElementById(menuId);
-    if (!el) return;
-    var isOpen = el.style.maxHeight && el.style.maxHeight !== '0px';
-    el.style.maxHeight = isOpen ? '0px' : el.scrollHeight + 'px';
-    if (btn) {
-      btn.classList.toggle('open', !isOpen);
-    }
-  };
-
-  // Toggle visibility of the Importar Produtos card on the precificação page
-  window.toggleImportCard = function() {
-    var card = document.getElementById('importarProdutosCard');
-    var btn = document.getElementById('toggleImportarBtn');
-    if (!card || !btn) return;
-    card.classList.toggle('hidden');
-    if (card.classList.contains('hidden')) {
-      btn.textContent = 'Exibir Importar Produtos';
-    } else {
-      btn.textContent = 'Esconder Importar Produtos';
-    }
-  };
   // Load Intro.js library if not already loaded
   function loadIntroJs() {
     return new Promise(function(resolve, reject) {


### PR DESCRIPTION
## Summary
- extract menu toggle logic into `menu.js` and load it in navigation partials
- move import card toggle into `import-card.js` used by precificação tab
- streamline `shared.js` by removing page-specific helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c35604f7cc832aa7fe4da9ef0c310f