### PR TITLE
feat: enhance service worker caching with Workbox

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8" />
+  <title>Offline</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <h1>Você está offline</h1>
+  <p>Verifique sua conexão com a internet.</p>
+</body>
+</html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,50 +1,44 @@
-const CACHE_VERSION = '20240826';
-const CACHE_PREFIX  = 'app-cache-v';
-const CACHE_NAME    = `${CACHE_PREFIX}${CACHE_VERSION}`;
-const URLS_TO_CACHE = [
-  'index.html',
-  'index.js',
-  'financeiro.html',
-  'financeiro.js',
-  `css/styles.css?v=${CACHE_VERSION}`,
-  'css/components.css',
-  'css/utilities.css',
-  'icons/icon-192.png',
-  'icons/icon-512.png',
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js');
+
+const PRECACHE_MANIFEST = [
+  {url: 'index.html', revision: null},
+  {url: 'index.js', revision: null},
+  {url: 'financeiro.html', revision: null},
+  {url: 'financeiro.js', revision: null},
+  {url: 'css/styles.css', revision: null},
+  {url: 'css/components.css', revision: null},
+  {url: 'css/utilities.css', revision: null},
+  {url: 'icons/icon-192.png', revision: null},
+  {url: 'icons/icon-512.png', revision: null},
+  {url: 'offline.html', revision: '1'},
 ];
 
-self.addEventListener('install', (event) => {
-  event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(URLS_TO_CACHE))
-  );
+workbox.core.skipWaiting();
+workbox.core.clientsClaim();
+
+workbox.precaching.precacheAndRoute((self.__WB_MANIFEST || []).concat(PRECACHE_MANIFEST), {
+  ignoreURLParametersMatching: [/.*/]
 });
 
-self.addEventListener('activate', (event) => {
-  event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(
-        keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))
-      )
-    )
-  );
-});
+workbox.precaching.cleanupOutdatedCaches();
 
-self.addEventListener('fetch', (event) => {
-  const url = new URL(event.request.url);
+workbox.routing.registerRoute(
+  ({request}) => request.mode === 'navigate',
+  new workbox.strategies.NetworkFirst({
+    cacheName: 'pages-cache',
+  })
+);
 
-  // Skip cross-origin requests so API calls bypass the service worker
-  if (url.origin !== self.location.origin) {
-    return;
+workbox.routing.registerRoute(
+  ({request}) => ['style', 'script', 'image'].includes(request.destination),
+  new workbox.strategies.StaleWhileRevalidate({
+    cacheName: 'assets-cache',
+  })
+);
+
+workbox.routing.setCatchHandler(async ({event}) => {
+  if (event.request.mode === 'navigate') {
+    return caches.match('offline.html', {ignoreSearch: true});
   }
-
-  if (url.pathname.includes('/partials/') && url.pathname.endsWith('.html')) {
-    event.respondWith(fetch(event.request));
-    return;
-  }
-
-  event.respondWith(
-    caches.match(event.request).then((response) =>
-      response || fetch(event.request).catch(() => response)
-    )
-  );
+  return Response.error();
 });


### PR DESCRIPTION
## Summary
- replace manual service worker cache with Workbox precaching and dynamic strategies
- add offline fallback page and clean up outdated caches automatically

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c357f70444832aac76d284de537c25