### PR TITLE
fix: load workbox in service worker

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,3 +1,8 @@
+// Import Workbox from the official CDN so the global `workbox` object is available
+importScripts(
+  'https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js',
+);
+
 const CACHE_VERSION = '20240826';
 const CACHE_PREFIX = 'app-cache-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
@@ -15,7 +20,9 @@ const URLS_TO_CACHE = [
 
 // Workbox handles the installation and activation steps automatically.
 // The precaching list is used by Workbox's precaching module.
-workbox.precaching.precacheAndRoute(URLS_TO_CACHE.map(url => ({ url, revision: null })));
+workbox.precaching.precacheAndRoute(
+  URLS_TO_CACHE.map((url) => ({ url, revision: null })),
+);
 
 // A simple routing example: use a CacheFirst strategy for images.
 workbox.routing.registerRoute(
@@ -33,7 +40,8 @@ workbox.routing.registerRoute(
 
 // Another example: a StaleWhileRevalidate strategy for CSS and JS.
 workbox.routing.registerRoute(
-  ({ request }) => request.destination === 'script' || request.destination === 'style',
+  ({ request }) =>
+    request.destination === 'script' || request.destination === 'style',
   new workbox.strategies.StaleWhileRevalidate({
     cacheName: 'assets-cache',
   }),


### PR DESCRIPTION
## Summary
- load Workbox from CDN so service worker can use workbox APIs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c35e5779a0832a878fc02198372145