### PR TITLE
fix: apply sidebar styles globally

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1528,43 +1528,43 @@ input:checked + .toggle-slider:before {
   cursor: pointer;
   padding-right: 1rem;
 }
+/* Unified sidebar appearance across pages */
+.sidebar {
+  overflow-y: auto;
+  overflow-x: hidden;
+  background-color: var(--primary);
+  color: var(--white);
+  width: var(--sidebar-width);
+  min-height: 100vh;
+  padding-top: 1rem;
+}
+
+.sidebar-menu,
+.sidebar-menu ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sidebar-link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0.8rem 1.5rem;
+  color: var(--white);
+  text-decoration: none;
+  font-size: 0.95rem;
+  border-radius: 0.375rem;
+  transition: background-color 0.2s;
+}
+
+.sidebar-link:hover,
+.sidebar-link.active {
+  background-color: var(--primary-dark);
+  color: var(--white);
+}
+
 @media print {
-  /* Unified sidebar appearance across pages */
-  .sidebar {
-    overflow-y: auto;
-    overflow-x: hidden;
-    background-color: var(--primary);
-    color: var(--white);
-    width: var(--sidebar-width);
-    min-height: 100vh;
-    padding-top: 1rem;
-  }
-
-  .sidebar-menu,
-  .sidebar-menu ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  .sidebar-link {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 0.8rem 1.5rem;
-    color: var(--white);
-    text-decoration: none;
-    font-size: 0.95rem;
-    border-radius: 0.375rem;
-    transition: background-color 0.2s;
-  }
-
-  .sidebar-link:hover,
-  .sidebar-link.active {
-    background-color: var(--primary-dark);
-    color: var(--white);
-  }
-
   .submenu {
     overflow: hidden;
     max-height: 0;

--- a/service-worker.js
+++ b/service-worker.js
@@ -15,7 +15,9 @@ const URLS_TO_CACHE = [
 
 // Workbox handles the installation and activation steps automatically.
 // The precaching list is used by Workbox's precaching module.
-workbox.precaching.precacheAndRoute(URLS_TO_CACHE.map(url => ({ url, revision: null })));
+workbox.precaching.precacheAndRoute(
+  URLS_TO_CACHE.map((url) => ({ url, revision: null })),
+);
 
 // A simple routing example: use a CacheFirst strategy for images.
 workbox.routing.registerRoute(
@@ -33,7 +35,8 @@ workbox.routing.registerRoute(
 
 // Another example: a StaleWhileRevalidate strategy for CSS and JS.
 workbox.routing.registerRoute(
-  ({ request }) => request.destination === 'script' || request.destination === 'style',
+  ({ request }) =>
+    request.destination === 'script' || request.destination === 'style',
   new workbox.strategies.StaleWhileRevalidate({
     cacheName: 'assets-cache',
   }),


### PR DESCRIPTION
## Summary
- move sidebar styling out of print-only block
- keep only print-specific submenu rules under `@media print`
- format service worker to satisfy Prettier

## Testing
- `npm test`
- `npm run lint`
- `npx prettier --check "*.js" "css/*.css"`


------
https://chatgpt.com/codex/tasks/task_e_68c35e7908b8832ab1da5fdb239e3b73