### PR TITLE
feat: add paginated communication query

### DIFF
--- a/FIRESTORE_INDEXES.md
+++ b/FIRESTORE_INDEXES.md
@@ -1,0 +1,23 @@
+# Firestore Indexes
+
+## Comunicação
+
+The communication history query filters by recipients and type while ordering by timestamp. To support this, add the following composite index in Firestore:
+
+- Collection: `comunicacao`
+- Fields:
+  - `destinatarios` array-contains
+  - `tipo` ascending
+  - `timestamp` descending
+
+This index matches the paginated query used in `comunicacao.js`:
+
+```js
+query(
+  collection(db, 'comunicacao'),
+  where('destinatarios', 'array-contains', uid),
+  where('tipo', 'in', ['alerta', 'arquivo']),
+  orderBy('timestamp', 'desc'),
+  limit(PAGE_SIZE)
+)
+```

--- a/comunicacao.html
+++ b/comunicacao.html
@@ -45,6 +45,10 @@
     <div class="card p-4">
       <h3 class="text-lg font-semibold mb-2">Histórico</h3>
       <ul id="commsList" class="space-y-2 text-sm"></ul>
+      <div class="flex justify-between mt-2">
+        <button id="prevCommsBtn" class="btn btn-primary text-sm">Anterior</button>
+        <button id="nextCommsBtn" class="btn btn-primary text-sm">Próximos</button>
+      </div>
     </div>
   </main>
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -23,6 +23,16 @@
       "fields": [
         { "fieldPath": "__name__", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "comunicacao",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "destinatarios", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "tipo", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
- paginate communication history with Firestore queries
- add UI controls for browsing communication pages
- document and configure Firestore index for communication queries

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4025e6294832a9bca72fd06640743