### PR TITLE
fix(pdf): correct month in saques header

### DIFF
--- a/saques.js
+++ b/saques.js
@@ -550,7 +550,8 @@ async function imprimirFechamento() {
     }
   } catch (_) {}
 
-  const dataTitulo = new Date(anoMes + '-01');
+  const [anoTitulo, mesTitulo] = anoMes.split('-').map(Number);
+  const dataTitulo = new Date(anoTitulo, mesTitulo - 1, 1);
   const mesNome = dataTitulo.toLocaleDateString('pt-BR', { month: 'long' });
   const mesAno = `${mesNome.charAt(0).toUpperCase() + mesNome.slice(1)}/${dataTitulo.getFullYear()}`;
   const emissao = new Date().toLocaleDateString('pt-BR');


### PR DESCRIPTION
## Summary
- ensure month names in Saques PDF are parsed in local timezone to avoid off-by-one errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c40ecf0b88832aae923e1979a291de