### PR TITLE
fix: expose price list export functions

### DIFF
--- a/precificacao-tabs/lista-precos.js
+++ b/precificacao-tabs/lista-precos.js
@@ -503,3 +503,16 @@ authListaPrecos.onAuthStateChanged(user => {
   }
   carregarProdutos();
 });
+
+// Expose functions used by inline event handlers
+window.exportarExcelLista = exportarExcelLista;
+window.exportarPlanilhaPrecificacao = exportarPlanilhaPrecificacao;
+window.exportarPDFLista = exportarPDFLista;
+window.importarExcelLista = importarExcelLista;
+window.excluirSelecionados = excluirSelecionados;
+window.excluirTodos = excluirTodos;
+window.toggleSelecionado = toggleSelecionado;
+window.verDetalhes = verDetalhes;
+window.editarProduto = editarProduto;
+window.excluirProduto = excluirProduto;
+window.fecharModal = fecharModal;


### PR DESCRIPTION
## Summary
- make price list export functions globally accessible for inline handlers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c428af6320832aa96c2c17a5b1a4a1