### PR TITLE
fix: enable price list Excel export

### DIFF
--- a/precificacao-tabs/lista-precos.js
+++ b/precificacao-tabs/lista-precos.js
@@ -503,3 +503,18 @@ authListaPrecos.onAuthStateChanged(user => {
   }
   carregarProdutos();
 });
+
+// Expose functions for inline handlers
+Object.assign(window, {
+  exportarExcelLista,
+  exportarPlanilhaPrecificacao,
+  exportarPDFLista,
+  importarExcelLista,
+  excluirSelecionados,
+  excluirTodos,
+  toggleSelecionado,
+  verDetalhes,
+  editarProduto,
+  excluirProduto,
+  fecharModal
+});


### PR DESCRIPTION
## Summary
- expose price list utility functions to the global scope so inline handlers work

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c428af6320832aa96c2c17a5b1a4a1