### PR TITLE
fix: cast filter fields to string

### DIFF
--- a/precificacao-tabs/lista-precos.js
+++ b/precificacao-tabs/lista-precos.js
@@ -62,13 +62,13 @@ async function carregarProdutos() {
 
 function aplicarFiltros() {
   const termo =
-    document.getElementById('filtroBusca')?.value.toLowerCase() || '';
+    document.getElementById('filtroBusca')?.value?.toLowerCase() || '';
   const tipo = document.getElementById('tipoFiltro')?.value || 'contains';
 
   const filtrados = produtos.filter((p) => {
-    const nome = (p.produto || '').toLowerCase();
-    const sku = (p.sku || '').toLowerCase();
-    const loja = (p.plataforma || '').toLowerCase();
+    const nome = String(p.produto || '').toLowerCase();
+    const sku = String(p.sku || '').toLowerCase();
+    const loja = String(p.plataforma || '').toLowerCase();
     if (!termo) return true;
     if (tipo === 'exact') {
       return nome === termo || sku === termo || loja === termo;


### PR DESCRIPTION
## Summary
- cast filtro strings to avoid toLowerCase errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c42d15453c832aba5b030b1968d4c2