### PR TITLE
fix: handle missing product strings in filter

### DIFF
--- a/precificacao-tabs/lista-precos.js
+++ b/precificacao-tabs/lista-precos.js
@@ -60,15 +60,21 @@ async function carregarProdutos() {
   aplicarFiltros();
 }
 
+function normalizeTexto(valor) {
+  return typeof valor === 'string'
+    ? valor.toLowerCase()
+    : String(valor ?? '').toLowerCase();
+}
+
 function aplicarFiltros() {
   const termo =
     document.getElementById('filtroBusca')?.value?.toLowerCase() || '';
   const tipo = document.getElementById('tipoFiltro')?.value || 'contains';
 
   const filtrados = produtos.filter((p) => {
-    const nome = String(p.produto || '').toLowerCase();
-    const sku = String(p.sku || '').toLowerCase();
-    const loja = String(p.plataforma || '').toLowerCase();
+    const nome = normalizeTexto(p.produto);
+    const sku = normalizeTexto(p.sku);
+    const loja = normalizeTexto(p.plataforma);
     if (!termo) return true;
     if (tipo === 'exact') {
       return nome === termo || sku === termo || loja === termo;


### PR DESCRIPTION
## Summary
- avoid TypeError in price list filters by normalizing product data to strings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c42e2d9ce0832aa89c3febd4aa3ef2