### PR TITLE
feat: style client sidebar

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1774,3 +1774,50 @@ body.dark .sidebar-link.active {
     padding: 0.5rem;
   }
 }
+/* Client sidebar layout */
+.sidebar.client-layout {
+  background: linear-gradient(180deg, #7c3aed 0%, #4c1d95 100%);
+}
+.sidebar.client-layout .sidebar-logo {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+.sidebar.client-layout .client-top-icons {
+  display: flex;
+  justify-content: space-around;
+  margin-bottom: 1rem;
+}
+.sidebar.client-layout .client-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #ff5f6d 0%, #ffc371 100%);
+  border: 2px solid #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.sidebar.client-layout .client-icon svg {
+  width: 24px;
+  height: 24px;
+  color: #fff;
+}
+.sidebar.client-layout .sidebar-link {
+  justify-content: center;
+  margin: 0.5rem 1rem;
+  border-radius: 9999px;
+  background: linear-gradient(180deg, #ff5f6d 0%, #ffc371 100%);
+  border: 2px solid #fff;
+  font-weight: 600;
+}
+.sidebar.client-layout .sidebar-link svg {
+  display: none;
+}
+.sidebar.client-layout .sidebar-link:hover,
+.sidebar.client-layout .sidebar-link.active {
+  background: linear-gradient(180deg, #ff5f6d 0%, #ffc371 100%);
+}
+.sidebar.client-layout .submenu,
+.sidebar.client-layout .submenu-toggle {
+  display: none;
+}

--- a/shared.js
+++ b/shared.js
@@ -727,6 +727,23 @@ document.addEventListener('sidebarLoaded', async () => {
   }
 
   function buildClienteSidebarLayout() {
+    const sidebar = document.getElementById('sidebar');
+    if (sidebar) {
+      sidebar.classList.add('client-layout');
+      const logo = sidebar.querySelector('.sidebar-logo');
+      if (logo) {
+        logo.innerHTML = `
+          <div class="client-top-icons">
+            <a href="/index.html" class="client-icon" aria-label="Início">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.59 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/></svg>
+            </a>
+            <a href="/desempenho.html" class="client-icon" aria-label="Desempenho">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0"/><path d="M12 12m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0"/><path d="M13.41 10.59l2.59 -2.59"/><path d="M7 12a5 5 0 0 1 5 -5"/></svg>
+            </a>
+          </div>`;
+      }
+    }
+
     const menu = document.querySelector('#sidebar .sidebar-menu');
     if (!menu) return;
 


### PR DESCRIPTION
## Summary
- style client sidebar with purple background and gradient buttons
- inject home and dashboard icons for client sidebar layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c461ef853c832ab11dd9831173c49f