### PR TITLE
style: unify client sidebar buttons

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1776,7 +1776,7 @@ body.dark .sidebar-link.active {
 }
 /* Client sidebar layout */
 .sidebar.client-layout {
-  background: linear-gradient(180deg, #7c3aed 0%, #4c1d95 100%);
+  background: #0000ff;
 }
 .sidebar.client-layout .sidebar-logo {
   padding-top: 1rem;
@@ -1791,7 +1791,7 @@ body.dark .sidebar-link.active {
   width: 48px;
   height: 48px;
   border-radius: 50%;
-  background: linear-gradient(180deg, #ff5f6d 0%, #ffc371 100%);
+  background: #ffa500;
   border: 2px solid #fff;
   display: flex;
   align-items: center;
@@ -1803,10 +1803,16 @@ body.dark .sidebar-link.active {
   color: #fff;
 }
 .sidebar.client-layout .sidebar-link {
+  display: flex;
+  align-items: center;
   justify-content: center;
+  height: 3rem;
+  width: calc(100% - 2rem);
   margin: 0.5rem 1rem;
+  padding: 0 1rem;
+  box-sizing: border-box;
   border-radius: 9999px;
-  background: linear-gradient(180deg, #ff5f6d 0%, #ffc371 100%);
+  background: #ffa500;
   border: 2px solid #fff;
   font-weight: 600;
 }
@@ -1815,7 +1821,7 @@ body.dark .sidebar-link.active {
 }
 .sidebar.client-layout .sidebar-link:hover,
 .sidebar.client-layout .sidebar-link.active {
-  background: linear-gradient(180deg, #ff5f6d 0%, #ffc371 100%);
+  background: #ffa500;
 }
 .sidebar.client-layout .submenu,
 .sidebar.client-layout .submenu-toggle {


### PR DESCRIPTION
## Summary
- ensure client sidebar has blue background
- make client user buttons uniform orange and size

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c464e73f5c832a971441a886acabdb