### PR TITLE
Remove Dashboard Geral and Início from sidebar

### DIFF
--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -12,15 +12,6 @@
 
   <ul class="sidebar-menu py-4">
     <li>
-      <a href="/dashboard-geral.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-dashboard" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 3.001a.75.75 0 0 0-.75.75V11.25H3.75a.75.75 0 0 0-.75.75 9 9 0 1 0 9-9Z" />
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12.75 2.243A9.004 9.004 0 0 1 21.757 11.25H12.75V2.243Z" />
-        </svg>
-        <span class="link-text">Dashboard Geral</span>
-      </a>
-    </li>
-    <li>
       <a href="/gestor.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao" data-perfil="gestor,mentor">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9 12H12.75M9 15H12.75M9 18H12.75M15.75 18.75H18A2.25 2.25 0 0 0 20.25 16.5V6.108A2.25 2.25 0 0 0 18.273 3.916c-.374-.031-.748-.058-1.123-.08M11.35 3.836A2.251 2.251 0 0 1 13.5 2.25h1.5a2.25 2.25 0 0 1 2.151 1.586M11.35 3.836c-.376.022-.75.049-1.124.08A2.25 2.25 0 0 0 8.25 6.108V8.25M8.25 8.25H4.875a1.125 1.125 0 0 0-1.125 1.125V20.625c0 .621.504 1.125 1.125 1.125H14.625a1.125 1.125 0 0 0 1.125-1.125V9.375A1.125 1.125 0 0 0 14.625 8.25H8.25ZM6.75 12h.007v.008H6.75V12Zm0 3h.007v.008H6.75V15Zm0 3h.007v.008H6.75V18Z"/>
@@ -136,14 +127,6 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v6.75A1.125 1.125 0 0 1 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 9.75 19.875V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 16.5 19.875V4.125Z"/>
         </svg>
         <span class="link-text">Desempenho</span>
-      </a>
-    </li>
-    <li>
-      <a href="/index.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-inicio" data-perfil="usuario,gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/>
-        </svg>
-        <span class="link-text">Início</span>
       </a>
     </li>
     <li>

--- a/shared.js
+++ b/shared.js
@@ -203,7 +203,6 @@
     intro
       .setOptions({
         steps: [
-          { element: '#menu-inicio', intro: 'Voltar para a página inicial.' },
           {
             element: '#menu-vendas',
             intro: 'Área para acompanhar vendas e sobras.',


### PR DESCRIPTION
## Summary
- remove Dashboard Geral and Início links from sidebar menu
- adjust sidebar tour to start at Vendas

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c466906408832a8eb70404cb59fe40