### PR TITLE
Atualiza cores do sidebar para usuários comuns

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1778,7 +1778,8 @@ body.dark .sidebar-link.active {
 }
 /* Client sidebar layout */
 .sidebar.client-layout {
-  background: #0000ff;
+  background: #1a1b4b;
+  color: #f9fafb;
 }
 .sidebar.client-layout .sidebar-logo {
   padding-top: 1rem;
@@ -1793,16 +1794,19 @@ body.dark .sidebar-link.active {
   width: 48px;
   height: 48px;
   border-radius: 50%;
-  background: #cc8400;
-  border: 2px solid #fff;
+  background: #a855f7;
+  border: 2px solid #f9fafb;
   display: flex;
   align-items: center;
   justify-content: center;
 }
+.sidebar.client-layout .client-icon:hover {
+  background: #c084fc;
+}
 .sidebar.client-layout .client-icon svg {
   width: 24px;
   height: 24px;
-  color: #fff;
+  color: #f9fafb;
 }
 .sidebar.client-layout .sidebar-link {
   display: flex;
@@ -1814,16 +1818,19 @@ body.dark .sidebar-link.active {
   padding: 0 1rem;
   box-sizing: border-box;
   border-radius: 9999px;
-  background: #cc8400;
-  border: 2px solid #fff;
+  background: #a855f7;
+  border: 2px solid #f9fafb;
   font-weight: 600;
+  color: #f9fafb;
 }
 .sidebar.client-layout .sidebar-link svg {
   display: none;
 }
-.sidebar.client-layout .sidebar-link:hover,
+.sidebar.client-layout .sidebar-link:hover {
+  background: #c084fc;
+}
 .sidebar.client-layout .sidebar-link.active {
-  background: #b36b00;
+  border-color: #facc15;
 }
 .sidebar.client-layout .submenu,
 .sidebar.client-layout .submenu-toggle {


### PR DESCRIPTION
## Summary
- aplica nova paleta de cores ao sidebar do layout de cliente
- ajusta ícones e botões para tons de roxo com destaque amarelo

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4681c2c08832a99735c6275dc4845