### PR TITLE
Harmonize sidebar colors for gestores e responsáveis financeiros

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1529,11 +1529,12 @@ input:checked + .toggle-slider:before {
   padding-right: 1rem;
 }
 /* Unified sidebar appearance across pages */
+/* Default sidebar theme now matches client layout colors */
 .sidebar {
   overflow-y: auto;
   overflow-x: hidden;
-  background-color: #0000ff;
-  color: var(--white);
+  background-color: #1a1b4b;
+  color: #f9fafb;
   width: var(--sidebar-width);
   min-height: 100vh;
   padding-top: 1rem;
@@ -1552,18 +1553,23 @@ input:checked + .toggle-slider:before {
   gap: 12px;
   width: 100%;
   padding: 0.8rem 1.5rem;
-  background-color: #ffa500;
-  color: var(--white);
+  background-color: #a855f7;
+  color: #f9fafb;
   text-decoration: none;
   font-size: 0.95rem;
   border-radius: 0.375rem;
   transition: background-color 0.2s;
+  border-left: 4px solid transparent;
 }
 
-.sidebar-link:hover,
+.sidebar-link:hover {
+  background-color: #c084fc;
+}
+
 .sidebar-link.active {
-  background-color: #cc8400;
-  color: var(--white);
+  background-color: #c084fc;
+  color: #f9fafb;
+  border-left-color: #facc15;
 }
 
 @media print {
@@ -1583,16 +1589,19 @@ input:checked + .toggle-slider:before {
 }
 
 body.dark .sidebar {
-  background-color: #0000ff;
+  background-color: #1a1b4b;
+  color: #f9fafb;
 }
 
 body.dark .sidebar-link {
-  color: var(--white);
+  color: #f9fafb;
 }
 
 body.dark .sidebar-link:hover,
 body.dark .sidebar-link.active {
-  background-color: #cc8400;
+  background-color: #c084fc;
+  color: #f9fafb;
+  border-left-color: #facc15;
 }
 
 /* Base layout spacing */


### PR DESCRIPTION
## Summary
- Alinha o tema padrão do sidebar com as cores utilizadas por usuários comuns
- Define cores de fundo, links, hover e destaque ativo conforme a paleta principal

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c469b11ae0832a9f8cd859b6a5ba85