### PR TITLE
Centraliza estilos de cards em arquivo dedicado

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -1,0 +1,92 @@
+/* Card styles consolidated across tabs */
+
+/* Base card styles shared by Anúncios, Precificação e Sobras */
+.card {
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+  background-color: var(--background);
+  padding: 1.5rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: column;
+}
+
+/* Icon styling within card headers */
+.card-header i {
+  font-size: 1.6rem;
+  color: var(--white);
+}
+
+/* Hover effect for all cards */
+.card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 15px 25px rgba(0, 0, 0, 0.1);
+}
+
+/* Dark mode adjustments for cards */
+body.dark-mode .card {
+  background: var(--secondary);
+  color: var(--text);
+}
+
+/* Mobile adjustments for cards */
+@media (max-width: 640px) {
+  .card {
+    padding: 1rem;
+  }
+  #resumoTotais .card {
+    padding: 0.5rem;
+  }
+}
+
+/* Precificação: scenario cards */
+.scenario-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  background: var(--background);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  margin-top: 0.5rem;
+}
+.scenario-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 9999px;
+}
+.scenario-title {
+  flex: 1;
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+.scenario-value {
+  font-size: 1rem;
+  font-weight: 700;
+}
+.scenario-ideal {
+  background-color: rgba(76, 175, 80, 0.1);
+}
+.scenario-ideal .scenario-dot {
+  background-color: var(--success);
+}
+.scenario-medium {
+  background-color: rgba(255, 193, 7, 0.1);
+}
+.scenario-medium .scenario-dot {
+  background-color: #ffc107;
+}
+.scenario-promo {
+  background-color: rgba(244, 67, 54, 0.1);
+}
+.scenario-promo .scenario-dot {
+  background-color: var(--error);
+}
+
+/* Precificação: dashboard cards */
+.dashboard-card {
+  background: var(--background);
+  border-radius: 0.75rem;
+  padding: 20px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+}

--- a/css/components.css
+++ b/css/components.css
@@ -1,13 +1,3 @@
-.card {
-  border-radius: 1rem;
-  border: 1px solid var(--border);
-  background-color: var(--background);
-  padding: 1.5rem;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-  display: flex;
-  flex-direction: column;
-}
-
 .btn-primary {
   display: inline-flex;
   align-items: center;

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,6 +1,7 @@
 @import url('base.css');
 @import url('components.css');
 @import url('utilities.css');
+@import url('cards.css');
 
 .text-brand {
   color: var(--primary);
@@ -637,10 +638,6 @@ button:hover {
   animation: 0.3s fadeIn;
 }
 
-.card-header i {
-  font-size: 1.6rem;
-  color: var(--white);
-}
 .alert {
   padding: 1rem;
   border-radius: 0.75rem;
@@ -946,7 +943,6 @@ body.dark-mode {
   color: var(--text);
   background: var(--background);
 }
-body.dark-mode .card,
 body.dark-mode .chart-container,
 body.dark-mode .tab-content,
 body.dark-mode .table-container {
@@ -1136,16 +1132,6 @@ body.dark-mode .data-table th {
   padding: 25px;
   min-height: calc(100vh - var(--navbar-height));
 }
-.card:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 15px 25px rgba(0, 0, 0, 0.1);
-}
-.dashboard-card {
-  background: var(--background);
-  border-radius: 0.75rem;
-  padding: 20px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
-}
 .tabs {
   display: flex;
   gap: 10px;
@@ -1255,48 +1241,6 @@ select:focus {
 }
 body.dark-mode .table tr:nth-child(2n) {
   background: rgba(255, 255, 255, 0.03);
-}
-.scenario-card {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  background: var(--background);
-  border-radius: 0.75rem;
-  padding: 0.75rem 1rem;
-  margin-top: 0.5rem;
-}
-.scenario-dot {
-  width: 0.75rem;
-  height: 0.75rem;
-  border-radius: 9999px;
-}
-.scenario-title {
-  flex: 1;
-  font-weight: 600;
-  font-size: 0.875rem;
-}
-.scenario-value {
-  font-size: 1rem;
-  font-weight: 700;
-}
-.scenario-ideal {
-  background-color: rgba(76, 175, 80, 0.1);
-}
-.scenario-ideal .scenario-dot {
-  background-color: var(--success);
-}
-.scenario-medium {
-  background-color: rgba(255, 193, 7, 0.1);
-}
-.scenario-medium .scenario-dot {
-  background-color: #ffc107;
-}
-.scenario-promo {
-  background-color: rgba(244, 67, 54, 0.1);
-}
-.scenario-promo .scenario-dot {
-  background-color: var(--error);
 }
 .platform-tag {
   display: inline-block;
@@ -1768,9 +1712,6 @@ body.dark .sidebar-link.active {
 
 /* Mobile adjustments for cards and tables */
 @media (max-width: 640px) {
-  .card {
-    padding: 1rem;
-  }
   .data-table {
     display: block;
     width: 100%;
@@ -1782,12 +1723,6 @@ body.dark .sidebar-link.active {
   }
 }
 
-@media (max-width: 640px) {
-  #resumoTotais .card {
-    padding: 0.5rem;
-  }
-}
-/* Client sidebar layout */
 .sidebar.client-layout {
   background: #1a1b4b;
   color: #f9fafb;


### PR DESCRIPTION
## Summary
- Consolidate card styles into new `cards.css`
- Import shared card styles through `styles.css`
- Remove duplicative card rules from components and main stylesheet

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4cd543a08832aa8ec8d0fbb5b5777