### PR TITLE
Restore client sidebar submenus and styling

### DIFF
--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -179,63 +179,33 @@ body.dark .sidebar-link.active {
 
 /* Client sidebar layout */
 .sidebar.client-layout {
-  background: #1a1b4b;
-  color: #f9fafb;
-}
-.sidebar.client-layout .sidebar-logo {
-  padding-top: 1rem;
-  padding-bottom: 1rem;
-}
-.sidebar.client-layout .client-top-icons {
-  display: flex;
-  justify-content: space-around;
-  margin-bottom: 1rem;
-}
-.sidebar.client-layout .client-icon {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  background: #a855f7;
-  border: 2px solid #f9fafb;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.sidebar.client-layout .client-icon:hover {
-  background: #c084fc;
-}
-.sidebar.client-layout .client-icon svg {
-  width: 24px;
-  height: 24px;
-  color: #f9fafb;
+  background: #ffffff;
+  color: #1f2937;
 }
 .sidebar.client-layout .sidebar-link {
   display: flex;
   align-items: center;
-  justify-content: center;
-  height: 3rem;
-  width: calc(100% - 2rem);
-  margin: 0.5rem 1rem;
-  padding: 0 1rem;
-  box-sizing: border-box;
-  border-radius: 9999px;
-  background: #a855f7;
-  border: 2px solid #f9fafb;
-  font-weight: 600;
-  color: #f9fafb;
-}
-.sidebar.client-layout .sidebar-link svg {
-  display: none;
+  justify-content: flex-start;
+  gap: 12px;
+  width: 100%;
+  padding: 0.8rem 1.5rem;
+  background: transparent;
+  color: inherit;
+  border-radius: 0.375rem;
+  border-left: 4px solid transparent;
 }
 .sidebar.client-layout .sidebar-link:hover {
-  background: #c084fc;
+  background: #f3f4f6;
 }
 .sidebar.client-layout .sidebar-link.active {
-  border-color: #facc15;
+  background: #e5e7eb;
+  border-left-color: #3b82f6;
 }
-.sidebar.client-layout .submenu,
+.sidebar.client-layout .sidebar-link svg {
+  display: block;
+}
 .sidebar.client-layout .submenu-toggle {
-  display: none;
+  display: block;
 }
 
 /* Mobile-specific sidebar rules */

--- a/shared.js
+++ b/shared.js
@@ -729,57 +729,7 @@ document.addEventListener('sidebarLoaded', async () => {
     const sidebar = document.getElementById('sidebar');
     if (sidebar) {
       sidebar.classList.add('client-layout');
-      const logo = sidebar.querySelector('.sidebar-logo');
-      if (logo) {
-        logo.innerHTML = `
-          <div class="client-top-icons">
-            <a href="/index.html" class="client-icon" aria-label="Início">
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.59 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/></svg>
-            </a>
-            <a href="/desempenho.html" class="client-icon" aria-label="Desempenho">
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0"/><path d="M12 12m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0"/><path d="M13.41 10.59l2.59 -2.59"/><path d="M7 12a5 5 0 0 1 5 -5"/></svg>
-            </a>
-          </div>`;
-      }
     }
-
-    const menu = document.querySelector('#sidebar .sidebar-menu');
-    if (!menu) return;
-
-    const getLi = (id) => document.getElementById(id)?.closest('li') || null;
-
-    const precificacao = getLi('menu-precificacao');
-    const marketing = getLi('menu-marketing');
-    const gestaoContas = getLi('menu-gestao-contas');
-    const acompanhamento = getLi('menu-acompanhamento');
-    const anunciosUl = document.getElementById('menuAnuncios');
-    const outrosUl = document.getElementById('menuOutros');
-
-    if (anunciosUl) {
-      if (precificacao)
-        precificacao
-          .querySelectorAll('ul li')
-          .forEach((li) => anunciosUl.appendChild(li));
-      if (marketing)
-        marketing
-          .querySelectorAll('ul li')
-          .forEach((li) => anunciosUl.appendChild(li));
-    }
-    if (precificacao) precificacao.remove();
-    if (marketing) marketing.remove();
-
-    if (outrosUl) {
-      if (gestaoContas)
-        gestaoContas
-          .querySelectorAll('ul li')
-          .forEach((li) => outrosUl.appendChild(li));
-      if (acompanhamento)
-        acompanhamento
-          .querySelectorAll('ul li')
-          .forEach((li) => outrosUl.appendChild(li));
-    }
-    if (gestaoContas) gestaoContas.remove();
-    if (acompanhamento) acompanhamento.remove();
   }
 
   async function applySidebarPermissions(uid) {


### PR DESCRIPTION
## Summary
- Keep client sidebar categories intact so each maintains its own submenu
- Re-style client sidebar for a lighter look with visible toggles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4d43b4e70832aa1716bbb06eafb37