### PR TITLE
style: organize home cards

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -4,7 +4,7 @@
   border: 1px solid var(--border);
   background-color: var(--background);
   padding: 1.5rem;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  box-shadow: var(--card-shadow);
   display: flex;
   flex-direction: column;
 }

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
         <!-- Visão Geral -->
         <section class="section">
           <h2 class="section-title">Visão Geral</h2>
-          <div id="kpiCards" class="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-4"></div>
+            <div id="kpiCards" class="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4"></div>
         </section>
 
         <!-- Análise de Vendas -->

--- a/index.js
+++ b/index.js
@@ -332,7 +332,7 @@ async function carregarResumoFaturamento(uid, isAdmin) {
         const arrow = variacao >= 0 ? 'fa-arrow-up' : 'fa-arrow-down';
         const variacaoFmt = `${variacao >= 0 ? '+' : ''}${variacao.toFixed(1)}%`;
         return `
-          <div class="bg-white rounded-xl shadow p-4">
+          <div class="bg-white rounded-xl shadow-lg p-4">
             <div class="flex items-center justify-between">
               <div class="flex items-center gap-2 text-gray-500 text-xs">
                 <div class="flex items-center justify-center w-8 h-8 rounded-lg bg-orange-100 text-orange-600">


### PR DESCRIPTION
## Summary
- layout KPI cards in a responsive four-column grid
- apply stronger shadows and rounded corners to home cards

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4d7965ffc832a943b801aa9017b5a