### PR TITLE
Refine sidebar branding and icon layout

### DIFF
--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -1,15 +1,12 @@
-<nav id="sidebar" class="sidebar" aria-label="Menu lateral">
-  <div class="sidebar-logo p-4 flex items-center justify-between">
-    <div class="flex items-center">
-      <div class="bg-white w-10 h-10 rounded-lg flex items-center justify-center mr-3">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-orange-500">
+<nav id="sidebar" class="sidebar flex flex-col" aria-label="Menu lateral">
+  <div class="sidebar-logo p-4 flex items-center justify-center space-x-4">
+      <div class="bg-white w-12 h-12 rounded-lg flex items-center justify-center">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-7 h-7 text-orange-500">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"/>
         </svg>
       </div>
-      <span class="font-bold text-xl text-white">VendedorPro</span>
-    </div>
-    <a href="/index.html" class="text-white" aria-label="Início">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+    <a href="/index.html" class="text-white flex items-center justify-center w-12 h-12" aria-label="Início">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-8 h-8">
         <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12 11.2045 3.0455c.4393-.4393 1.1517-.4393 1.591 0L21.75 12M4.5 9.75v10.125C4.5 20.4963 5.0037 21 5.625 21H9.75v-4.875c0-.6213.5037-1.125 1.125-1.125h2.25c.6213 0 1.125.5037 1.125 1.125V21h4.125c.6213 0 1.125-.5037 1.125-1.125V9.75M8.25 21h8.25" />
       </svg>
     </a>
@@ -412,6 +409,7 @@
       </div>
     </li>
   </ul>
+  <div class="p-4 mt-auto text-center"><span class="font-bold text-xl text-white">VendedorPro</span></div>
 </nav>
 
 


### PR DESCRIPTION
## Summary
- Center and enlarge top sidebar icons for a cleaner header
- Move VendedorPro branding text to the bottom of the sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4dbc3c99c832a8a9b2a68aabb8263