### PR TITLE
style: make sidebar icons and text black with shadow

### DIFF
--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -77,10 +77,26 @@ body.has-sidebar .content-wrapper {
   overflow-y: auto;
   overflow-x: hidden;
   background-color: #5c4fd5;
-  color: #e0e7ff;
+  color: #000;
   width: var(--sidebar-width);
   min-height: 100vh;
   padding-top: 1rem;
+}
+
+/* Ensure sidebar text and icons are black with subtle shadow */
+.sidebar-link {
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+}
+
+.sidebar svg {
+  color: #000;
+  stroke: #000;
+  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.1));
+}
+
+.sidebar input,
+.sidebar input::placeholder {
+  color: #000;
 }
 
 .sidebar-menu,
@@ -163,7 +179,7 @@ body.has-sidebar .content-wrapper {
 /* Dark mode */
 body.dark .sidebar {
   background-color: #4b3bbd;
-  color: #e0e7ff;
+  color: #000;
 }
 
 body.dark .sidebar-link {


### PR DESCRIPTION
## Summary
- adjust sidebar styles so text and icons render in black with subtle shadow

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68c4dd84e5f8832ab630c19eb3da0265