### PR TITLE
Padroniza estilo roxo dos sidebars

### DIFF
--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -76,27 +76,28 @@ body.has-sidebar .content-wrapper {
 .sidebar {
   overflow-y: auto;
   overflow-x: hidden;
-  background-color: #5c4fd5;
-  color: #000;
+  background-color: var(--primary);
+  color: #fff;
   width: var(--sidebar-width);
   min-height: 100vh;
   padding-top: 1rem;
 }
 
-/* Ensure sidebar text and icons are black with subtle shadow */
+/* Subtle text and icon shadow for better contrast */
 .sidebar-link {
-  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  font-weight: 500;
 }
 
 .sidebar svg {
-  color: #000;
-  stroke: #000;
-  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.1));
+  color: currentColor;
+  stroke: currentColor;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.25));
 }
 
 .sidebar input,
 .sidebar input::placeholder {
-  color: #000;
+  color: #fff;
 }
 
 .sidebar-menu,
@@ -150,14 +151,15 @@ body.has-sidebar .content-wrapper {
 }
 
 .submenu-link {
-  color: var(--white);
+  color: inherit;
   text-decoration: none;
   display: block;
   transition: color 0.2s;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
 }
 
 .submenu-link:hover {
-  color: var(--primary);
+  color: var(--primary-light);
 }
 
 @media print {
@@ -178,8 +180,8 @@ body.has-sidebar .content-wrapper {
 
 /* Dark mode */
 body.dark .sidebar {
-  background-color: #4b3bbd;
-  color: #000;
+  background-color: var(--primary-dark);
+  color: #fff;
 }
 
 body.dark .sidebar-link {
@@ -197,8 +199,8 @@ body.dark .sidebar-link.active {
 
 /* Client sidebar layout */
 .sidebar.client-layout {
-  background: #ffffff;
-  color: #1f2937;
+  background: var(--primary);
+  color: #fff;
 }
 .sidebar.client-layout .sidebar-link {
   display: flex;
@@ -213,11 +215,11 @@ body.dark .sidebar-link.active {
   border-left: 4px solid transparent;
 }
 .sidebar.client-layout .sidebar-link:hover {
-  background: #f3f4f6;
+  background-color: rgba(255, 255, 255, 0.1);
 }
 .sidebar.client-layout .sidebar-link.active {
-  background: #e5e7eb;
-  border-left-color: #3b82f6;
+  background-color: rgba(255, 255, 255, 0.2);
+  border-left-color: transparent;
 }
 .sidebar.client-layout .sidebar-link svg {
   display: block;


### PR DESCRIPTION
## Summary
- Unifica a cor e o estilo das sidebars para roxo com texto branco
- Aplica sombra suave e tipografia consistente a todos os links e submenus
- Ajusta estilos no modo escuro e em layouts de cliente para manter a padronização

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4e32dfc54832aa2dd7a2ce536d2fb