### PR TITLE
Remove layout from cadastro-interesse and add login link

### DIFF
--- a/cadastro-interesse.html
+++ b/cadastro-interesse.html
@@ -9,7 +9,6 @@
 </head>
 <body class="bg-gray-100">
   <div class="main-container">
-    <div id="navbar-container"></div>
     <div class="content-wrapper max-w-xl mx-auto mt-10 p-6 bg-white rounded shadow">
       <h1 class="text-2xl font-bold mb-4 text-center">Seja Cliente VendedorPro</h1>
       <p class="mb-6 text-gray-700 text-center">Plano mensal de <strong>R$29,90</strong>. Preencha o formulário e enviaremos os dados de pagamento via e-mail.</p>
@@ -30,8 +29,10 @@
         </div>
         <button type="submit" class="btn btn-primary w-full">Enviar</button>
       </form>
+      <p class="mt-6 text-center">
+        <a href="login.html" class="text-indigo-600 hover:underline">Voltar ao login</a>
+      </p>
     </div>
   </div>
-  <script src="shared.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove sidebar/navbar loading from cadastro-interesse page
- Add link to return to login

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4e4409948832aac451739624af29b