### PR TITLE
Make sidebar and navbar elements black

### DIFF
--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -68,7 +68,7 @@ body.has-sidebar .content-wrapper {
 }
 
 #sidebar::-webkit-scrollbar-thumb {
-  background-color: rgba(255, 255, 255, 0.3);
+  background-color: rgba(0, 0, 0, 0.3);
   border-radius: 0.125rem;
 }
 
@@ -77,10 +77,11 @@ body.has-sidebar .content-wrapper {
   overflow-y: auto;
   overflow-x: hidden;
   background-color: var(--primary);
-  color: #fff;
+  color: #000;
   width: var(--sidebar-width);
   min-height: 100vh;
   padding-top: 1rem;
+  border-right: 1px solid #000;
 }
 
 /* Subtle text and icon shadow for better contrast */
@@ -90,14 +91,14 @@ body.has-sidebar .content-wrapper {
 }
 
 .sidebar svg {
-  color: currentColor;
-  stroke: currentColor;
+  color: #000 !important;
+  stroke: #000 !important;
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.25));
 }
 
 .sidebar input,
 .sidebar input::placeholder {
-  color: #fff;
+  color: #000 !important;
 }
 
 .sidebar-menu,
@@ -116,7 +117,7 @@ body.has-sidebar .content-wrapper {
 .submenu-toggle {
   background: none;
   border: none;
-  color: inherit;
+  color: #000 !important;
   cursor: pointer;
   padding-right: 1rem;
 }
@@ -128,12 +129,12 @@ body.has-sidebar .content-wrapper {
   width: 100%;
   padding: 0.8rem 1.5rem;
   background-color: transparent;
-  color: inherit;
+  color: #000 !important;
   text-decoration: none;
   font-size: 0.95rem;
   border-radius: 0.375rem;
   transition: background-color 0.2s;
-  border-left: 4px solid transparent;
+  border-left: 4px solid #000;
 }
 
 .sidebar-link:hover {
@@ -142,12 +143,13 @@ body.has-sidebar .content-wrapper {
 
 .sidebar-link.active {
   background-color: rgba(255, 255, 255, 0.2);
-  color: inherit;
-  border-left-color: transparent;
+  color: #000 !important;
+  border-left-color: #000;
 }
 
 .submenu {
   padding-left: 0;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .submenu-link {
@@ -181,7 +183,7 @@ body.has-sidebar .content-wrapper {
 /* Dark mode */
 body.dark .sidebar {
   background-color: var(--primary-dark);
-  color: #fff;
+  color: #000;
 }
 
 body.dark .sidebar-link {
@@ -194,13 +196,13 @@ body.dark .sidebar-link:hover {
 
 body.dark .sidebar-link.active {
   background-color: rgba(255, 255, 255, 0.2);
-  border-left-color: transparent;
+  border-left-color: #000;
 }
 
 /* Client sidebar layout */
 .sidebar.client-layout {
   background: var(--primary);
-  color: #fff;
+  color: #000;
 }
 .sidebar.client-layout .sidebar-link {
   display: flex;
@@ -210,16 +212,16 @@ body.dark .sidebar-link.active {
   width: 100%;
   padding: 0.8rem 1.5rem;
   background: transparent;
-  color: inherit;
+  color: #000 !important;
   border-radius: 0.375rem;
-  border-left: 4px solid transparent;
+  border-left: 4px solid #000;
 }
 .sidebar.client-layout .sidebar-link:hover {
   background-color: rgba(255, 255, 255, 0.1);
 }
 .sidebar.client-layout .sidebar-link.active {
   background-color: rgba(255, 255, 255, 0.2);
-  border-left-color: transparent;
+  border-left-color: #000;
 }
 .sidebar.client-layout .sidebar-link svg {
   display: block;

--- a/css/styles.css
+++ b/css/styles.css
@@ -939,7 +939,7 @@ body.dark-mode .data-table th {
   padding: 0 1rem;
   background: var(--nav-bg);
   color: var(--nav-text);
-  border-bottom: none;
+  border-bottom: 1px solid #000;
 }
 @media (min-width: 768px) {
   .navbar {
@@ -949,6 +949,10 @@ body.dark-mode .data-table th {
 }
 .navbar .hamburger {
   display: none;
+}
+.navbar svg {
+  color: #000;
+  stroke: #000;
 }
 .navbar-right {
   display: flex;


### PR DESCRIPTION
## Summary
- set sidebar text, icons, and borders to black
- style navbar icons and add black bottom border
- add shadow between sidebar menus and submenus

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4e62eea78832abce2b7791020f524