### PR TITLE
Remove search field from sidebar

### DIFF
--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -11,31 +11,6 @@
       </svg>
     </a>
   </div>
-
-  <div class="px-4">
-    <div class="relative">
-      <input
-        type="text"
-        placeholder="Search"
-        class="w-full bg-white/10 text-white placeholder-white/70 text-sm pl-8 pr-3 py-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/30"
-      />
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke-width="1.5"
-        stroke="currentColor"
-        class="absolute left-2.5 top-2.5 w-4 h-4 text-white opacity-70"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          d="m21 21-4.35-4.35m0 0A7.5 7.5 0 1 0 4.5 4.5a7.5 7.5 0 0 0 12.15 12.15Z"
-        />
-      </svg>
-    </div>
-  </div>
-
   <ul class="sidebar-menu py-4">
     <li>
       <a href="/gestor.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao" data-perfil="gestor,mentor">


### PR DESCRIPTION
## Summary
- remove unused search input from sidebar template

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4e6d08568832a8d096b916c75281c