### PR TITLE
Improve navbar search to navigate to any page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -959,12 +959,38 @@ body.dark-mode .data-table th {
   display: flex;
   align-items: center;
   gap: 1rem;
+  position: relative;
 }
 .navbar-search {
   height: 2.5rem;
   padding: 0 0.75rem;
   border-radius: 0.5rem;
   border: none;
+}
+
+.navbar-search-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 0.5rem;
+  margin-top: 0.25rem;
+  z-index: 50;
+  max-height: 15rem;
+  overflow-y: auto;
+}
+
+.navbar-search-results a {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  color: #374151;
+  text-decoration: none;
+}
+
+.navbar-search-results a:hover {
+  background: #f3f4f6;
 }
 .navbar-title {
   font-weight: 600;

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,6 +1,7 @@
 <div class="navbar">
   <div class="navbar-left">
     <input id="navbarSearch" type="text" class="navbar-search" placeholder="Pesquisar..." />
+    <div id="navbarSearchResults" class="navbar-search-results hidden"></div>
   </div>
   <div class="navbar-right">
     <div id="notificationWrapper" class="relative">

--- a/shared.js
+++ b/shared.js
@@ -464,6 +464,59 @@ window.addEventListener('resize', () => {
 window.toggleSidebar = window.toggleSidebar || toggleSidebar;
 window.ensureLayout = ensureLayout;
 
+let searchPages = [];
+
+function collectSearchPages() {
+  searchPages = Array.from(document.querySelectorAll('#sidebar a.sidebar-link'))
+    .map((a) => ({
+      title: a.textContent.trim(),
+      href: a.getAttribute('href'),
+    }))
+    .filter((p) => p.title && p.href);
+}
+
+document.addEventListener('sidebarLoaded', collectSearchPages);
+
+document.addEventListener('navbarLoaded', () => {
+  const input = document.getElementById('navbarSearch');
+  const results = document.getElementById('navbarSearchResults');
+  if (!input || !results) return;
+
+  function renderResults() {
+    const q = input.value.trim().toLowerCase();
+    if (!q) {
+      results.innerHTML = '';
+      results.classList.add('hidden');
+      return;
+    }
+    if (!searchPages.length) collectSearchPages();
+    const filtered = searchPages.filter((p) =>
+      p.title.toLowerCase().includes(q),
+    );
+    if (!filtered.length) {
+      results.innerHTML =
+        '<div class="px-3 py-2 text-sm text-gray-500">Nenhum resultado</div>';
+      results.classList.remove('hidden');
+      return;
+    }
+    results.innerHTML = filtered
+      .map((p) => `<a href="${p.href}">${p.title}</a>`)
+      .join('');
+    results.classList.remove('hidden');
+  }
+
+  input.addEventListener('input', renderResults);
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      const first = results.querySelector('a');
+      if (first) window.location.href = first.getAttribute('href');
+    }
+  });
+  input.addEventListener('blur', () =>
+    setTimeout(() => results.classList.add('hidden'), 200),
+  );
+});
+
 let userMenuClickRegistered = false;
 document.addEventListener('navbarLoaded', () => {
   const btn = document.getElementById('userMenuBtn');


### PR DESCRIPTION
## Summary
- add dropdown container and styles for navbar search results
- implement global search across sidebar links with navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4e6f9e1ac832ab46c7cf30729bae2