### PR TITLE
feat: ajustar cor do icone de usuario da sidebar

### DIFF
--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -1,7 +1,7 @@
 <nav id="sidebar" class="sidebar flex flex-col" aria-label="Menu lateral">
   <div class="sidebar-logo p-4 flex items-center justify-center space-x-4">
       <a href="/configuracao-perfil.html" class="bg-white w-12 h-12 rounded-lg flex items-center justify-center" aria-label="Perfil">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-7 h-7 text-orange-500">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-7 h-7 text-black">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"/>
         </svg>
       </a>


### PR DESCRIPTION
## Summary
- ajustar icone de usuário no sidebar para apenas o contorno preto

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4eac99ea8832a88292f227bd3a4ab