### PR TITLE
Centralize index card styles and layout

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -9,6 +9,31 @@
   flex-direction: column;
 }
 
+/* Grid layout for card containers */
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+
+/* Common card header icon */
+.card-header-icon {
+  width: 50px;
+  height: 50px;
+  border-radius: 0.625rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 15px;
+  background-color: rgba(20, 184, 166, 0.1); /* subtle highlight */
+  color: var(--primary);
+}
+
+.card-header i {
+  font-size: 1.6rem;
+  color: var(--white);
+}
+
 /* Cards de resumo - usados em sobras-tabs/acompanhamento.html, acompanhamento-tiny.html, pedidos-tiny.html e CONTROLE DE SOBRAS SHOPEE.html */
 .resumo-grid {
   display: grid;
@@ -147,4 +172,93 @@
 
 .ticket-card::after {
   right: -10px;
+}
+
+/* Task card styles for dashboard */
+#tarefasCard {
+  border-left: 4px solid var(--primary);
+}
+
+#tarefasCard .card-header {
+  background-color: var(--background);
+  color: var(--text);
+  border-bottom: 1px solid var(--border);
+  border-radius: 0.75rem 0.75rem 0 0;
+}
+
+#tarefasCard .card-header-icon {
+  background-color: rgba(20, 184, 166, 0.1);
+  color: var(--primary);
+}
+
+#tarefasCard .card-body {
+  background-color: var(--background);
+}
+
+#tarefasCard .progress {
+  width: 100%;
+  background-color: var(--border);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  height: 0.5rem;
+}
+
+#tarefasCard .progress-bar {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(to right, var(--success), #86efac);
+  transition: width 0.3s ease;
+}
+
+#tarefasCard .task-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  background-color: var(--secondary);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+  transition:
+    background-color 0.2s,
+    box-shadow 0.2s,
+    transform 0.2s;
+}
+
+#tarefasCard .task-item:hover {
+  background-color: var(--secondary);
+  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.08);
+  transform: translateY(-2px);
+}
+
+#tarefasCard .task-item.completed {
+  background-color: rgba(126, 87, 194, 0.1);
+}
+
+#tarefasCard .task-text.completed {
+  text-decoration: line-through;
+  color: var(--text-light);
+}
+
+#tarefasCard .task-text {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+#tarefasCard .task-actions {
+  display: flex;
+  gap: 0.25rem;
+  margin-left: auto;
+}
+
+#tarefasCard .task-actions button {
+  background-color: var(--border);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  transition: background-color 0.2s;
+}
+
+#tarefasCard .task-actions button:hover {
+  background-color: var(--gray-300);
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -33,18 +33,6 @@
   padding: 30px;
 }
 
-.card-header-icon {
-  width: 50px;
-  height: 50px;
-  border-radius: 0.625rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-right: 15px;
-  background-color: rgba(20, 184, 166, 0.1); /* subtle highlight */
-  color: var(--primary);
-}
-
 .alert-success {
   color: var(--success);
   padding: 12px 20px;
@@ -146,94 +134,6 @@ input:checked + .dark-mode-slider:before {
 
 .introjs-bullets li a.active {
   background-color: var(--orange-500);
-}
-/* Estilos modernos para o card de tarefas */
-#tarefasCard {
-  border-left: 4px solid var(--primary);
-}
-
-#tarefasCard .card-header {
-  background-color: var(--background);
-  color: var(--text);
-  border-bottom: 1px solid var(--border);
-  border-radius: 0.75rem 0.75rem 0 0;
-}
-
-#tarefasCard .card-header-icon {
-  background-color: rgba(20, 184, 166, 0.1);
-  color: var(--primary);
-}
-
-#tarefasCard .card-body {
-  background-color: var(--background);
-}
-
-#tarefasCard .progress {
-  width: 100%;
-  background-color: var(--border);
-  border-radius: 0.5rem;
-  overflow: hidden;
-  height: 0.5rem;
-}
-
-#tarefasCard .progress-bar {
-  height: 100%;
-  width: 0%;
-  background: linear-gradient(to right, var(--success), #86efac);
-  transition: width 0.3s ease;
-}
-
-#tarefasCard .task-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
-  border-radius: 0.5rem;
-  background-color: var(--secondary);
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
-  transition:
-    background-color 0.2s,
-    box-shadow 0.2s,
-    transform 0.2s;
-}
-
-#tarefasCard .task-item:hover {
-  background-color: var(--secondary);
-  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.08);
-  transform: translateY(-2px);
-}
-
-#tarefasCard .task-item.completed {
-  background-color: rgba(126, 87, 194, 0.1);
-}
-
-#tarefasCard .task-text.completed {
-  text-decoration: line-through;
-  color: var(--text-light);
-}
-
-#tarefasCard .task-text {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-#tarefasCard .task-actions {
-  display: flex;
-  gap: 0.25rem;
-  margin-left: auto;
-}
-
-#tarefasCard .task-actions button {
-  background-color: var(--border);
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.25rem;
-  transition: background-color 0.2s;
-}
-
-#tarefasCard .task-actions button:hover {
-  background-color: var(--gray-300);
 }
 @keyframes skeleton-loading {
   0%,
@@ -557,10 +457,6 @@ button:hover {
   animation: 0.3s fadeIn;
 }
 
-.card-header i {
-  font-size: 1.6rem;
-  color: var(--white);
-}
 .alert {
   padding: 1rem;
   border-radius: 0.75rem;

--- a/index.html
+++ b/index.html
@@ -73,13 +73,13 @@
         <!-- Visão Geral -->
         <section class="section">
           <h2 class="section-title">Visão Geral</h2>
-            <div id="kpiCards" class="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
+            <div id="kpiCards" class="mt-4 cards-grid"></div>
         </section>
 
         <!-- Análise de Vendas -->
         <section class="section">
           <h2 class="section-title">Análise de Vendas</h2>
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+          <div class="cards-grid mt-4">
             <div id="resumoFaturamento"></div>
 
             <div class="card cursor-pointer h-full" id="faturamentoMetaCard" onclick="location.href='/VendedorPro/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=metas';">
@@ -106,7 +106,7 @@
       <!-- Produtos em Destaque -->
       <section class="section">
         <h2 class="section-title">Produtos em Destaque</h2>
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div class="cards-grid">
           <div class="card" id="topSkusCard" data-blur-id="topSkusCard">
             <div class="card-header">
              <div class="card-header-icon">
@@ -130,7 +130,7 @@
       <!-- Organização -->
       <section class="section">
         <h2 class="section-title">Organização</h2>
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div class="cards-grid">
           <div class="card" id="tarefasCard">
             <div class="card-header">
               <div class="card-header-icon">


### PR DESCRIPTION
## Summary
- consolidate card styling into cards.css, including task card details
- introduce cards-grid class for consistent card layout
- update index.html to use centralized card styles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4eb305894832a8e04290faf0802ed