### PR TITLE
feat: unify sidebar styling

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -13,6 +13,7 @@
   --sidebar-bg: var(--primary);
   --sidebar-text: #000000;
   --sidebar-border: #000000;
+  --sidebar-width: 18rem;
   --success: #4caf50;
   --error: #f44336;
   --background: #ffffff;

--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -1,7 +1,3 @@
-:root {
-  --sidebar-width: 18rem;
-}
-
 /* Sidebar container & overlay */
 #sidebar-container {
   position: fixed;
@@ -83,10 +79,12 @@ body.has-sidebar .content-wrapper {
   overflow-x: hidden;
   background-color: var(--sidebar-bg);
   color: var(--sidebar-text);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
   width: var(--sidebar-width);
   min-height: 100vh;
   padding-top: 1rem;
   border-right: 1px solid var(--sidebar-border);
+  box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
   font-family: 'Poppins', 'Inter', sans-serif;
 }
 

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -1,398 +1,1345 @@
 <nav id="sidebar" class="sidebar flex flex-col" aria-label="Menu lateral">
   <div class="sidebar-logo p-4 flex items-center justify-center space-x-4">
-      <a href="/configuracao-perfil.html" class="bg-white w-12 h-12 rounded-lg flex items-center justify-center" aria-label="Perfil">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-7 h-7 text-black">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9.75a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 19.5a7.5 7.5 0 1 1 15 0"/>
-        </svg>
-      </a>
-    <a href="/index.html" class="text-white flex items-center justify-center w-12 h-12" aria-label="Início">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-8 h-8">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12 11.2045 3.0455c.4393-.4393 1.1517-.4393 1.591 0L21.75 12M4.5 9.75v10.125C4.5 20.4963 5.0037 21 5.625 21H9.75v-4.875c0-.6213.5037-1.125 1.125-1.125h2.25c.6213 0 1.125.5037 1.125 1.125V21h4.125c.6213 0 1.125-.5037 1.125-1.125V9.75M8.25 21h8.25" />
+    <a
+      href="/configuracao-perfil.html"
+      class="bg-white w-12 h-12 rounded-lg flex items-center justify-center"
+      aria-label="Perfil"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.5"
+        stroke="currentColor"
+        class="w-7 h-7 text-black"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M15.75 9.75a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 19.5a7.5 7.5 0 1 1 15 0"
+        />
+      </svg>
+    </a>
+    <a
+      href="/index.html"
+      class="flex items-center justify-center w-12 h-12"
+      aria-label="Início"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.5"
+        stroke="currentColor"
+        class="w-8 h-8"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M2.25 12 11.2045 3.0455c.4393-.4393 1.1517-.4393 1.591 0L21.75 12M4.5 9.75v10.125C4.5 20.4963 5.0037 21 5.625 21H9.75v-4.875c0-.6213.5037-1.125 1.125-1.125h2.25c.6213 0 1.125.5037 1.125 1.125V21h4.125c.6213 0 1.125-.5037 1.125-1.125V9.75M8.25 21h8.25"
+        />
       </svg>
     </a>
   </div>
   <ul class="sidebar-menu py-4">
     <li>
-      <a href="/gestor.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12H12.75M9 15H12.75M9 18H12.75M15.75 18.75H18A2.25 2.25 0 0 0 20.25 16.5V6.108A2.25 2.25 0 0 0 18.273 3.916c-.374-.031-.748-.058-1.123-.08M11.35 3.836A2.251 2.251 0 0 1 13.5 2.25h1.5a2.25 2.25 0 0 1 2.151 1.586M11.35 3.836c-.376.022-.75.049-1.124.08A2.25 2.25 0 0 0 8.25 6.108V8.25M8.25 8.25H4.875a1.125 1.125 0 0 0-1.125 1.125V20.625c0 .621.504 1.125 1.125 1.125H14.625a1.125 1.125 0 0 0 1.125-1.125V9.375A1.125 1.125 0 0 0 14.625 8.25H8.25ZM6.75 12h.007v.008H6.75V12Zm0 3h.007v.008H6.75V15Zm0 3h.007v.008H6.75V18Z"/>
+      <a
+        href="/gestor.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-gestao"
+        data-perfil="gestor,mentor"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M9 12H12.75M9 15H12.75M9 18H12.75M15.75 18.75H18A2.25 2.25 0 0 0 20.25 16.5V6.108A2.25 2.25 0 0 0 18.273 3.916c-.374-.031-.748-.058-1.123-.08M11.35 3.836A2.251 2.251 0 0 1 13.5 2.25h1.5a2.25 2.25 0 0 1 2.151 1.586M11.35 3.836c-.376.022-.75.049-1.124.08A2.25 2.25 0 0 0 8.25 6.108V8.25M8.25 8.25H4.875a1.125 1.125 0 0 0-1.125 1.125V20.625c0 .621.504 1.125 1.125 1.125H14.625a1.125 1.125 0 0 0 1.125-1.125V9.375A1.125 1.125 0 0 0 14.625 8.25H8.25ZM6.75 12h.007v.008H6.75V12Zm0 3h.007v.008H6.75V15Zm0 3h.007v.008H6.75V18Z"
+          />
         </svg>
         <span class="link-text">Gestão</span>
       </a>
     </li>
     <li>
-      <a href="/financeiro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-financeiro" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182A3.221 3.221 0 0 0 12 12c-.725 0-1.45-.219-2.003-.659-1.106-.879-1.106-2.303 0-3.182 1.106-.879 2.899-.879 4.005 0l.415.33M21 12c0 4.971-4.029 9-9 9s-9-4.029-9-9 4.029-9 9-9 9 4.029 9 9Z"/>
+      <a
+        href="/financeiro.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-financeiro"
+        data-perfil="gestor,mentor"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182A3.221 3.221 0 0 0 12 12c-.725 0-1.45-.219-2.003-.659-1.106-.879-1.106-2.303 0-3.182 1.106-.879 2.899-.879 4.005 0l.415.33M21 12c0 4.971-4.029 9-9 9s-9-4.029-9-9 4.029-9 9-9 9 4.029 9 9Z"
+          />
         </svg>
         <span class="link-text">Financeiro</span>
       </a>
     </li>
     <li>
-      <a href="/atualizacoes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-atualizacoes" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M18.375 12.739 10.682 20.432a5.25 5.25 0 0 1-7.424-7.424L15.257 3.129a3 3 0 0 1 4.243 4.243L8.552 18.32m.009-.009a1.5 1.5 0 0 1-2.121 0 1.5 1.5 0 0 1 0-2.122L14.25 8.379"/>
+      <a
+        href="/atualizacoes.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-atualizacoes"
+        data-perfil="gestor,mentor"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M18.375 12.739 10.682 20.432a5.25 5.25 0 0 1-7.424-7.424L15.257 3.129a3 3 0 0 1 4.243 4.243L8.552 18.32m.009-.009a1.5 1.5 0 0 1-2.121 0 1.5 1.5 0 0 1 0-2.122L14.25 8.379"
+          />
         </svg>
         <span class="link-text">Atualizações Diarias</span>
       </a>
     </li>
     <li>
-      <a href="/saques.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-saques" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75C7.717 18.75 13.014 19.481 18.047 20.851c.728.198 1.454-.343 1.454-1.096V18.75M3.75 4.5V5.25A.75.75 0 0 1 3 6H2.25M2.25 6V5.625A1.125 1.125 0 0 1 3.375 4.5H20.25M2.25 6v9M20.25 4.5V5.25A.75.75 0 0 0 21 6h.75M20.25 4.5h.375A1.125 1.125 0 0 1 21.75 5.625V15.375A1.125 1.125 0 0 1 20.625 16.5H20.25M21.75 15H21a.75.75 0 0 0-.75.75V16.5M20.25 16.5H3.75m0 0H3.375A1.125 1.125 0 0 1 2.25 15.375V15M3.75 16.5V15.75A.75.75 0 0 0 3 15H2.25M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z"/>
+      <a
+        href="/saques.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-saques"
+        data-perfil="gestor,mentor"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M2.25 18.75C7.717 18.75 13.014 19.481 18.047 20.851c.728.198 1.454-.343 1.454-1.096V18.75M3.75 4.5V5.25A.75.75 0 0 1 3 6H2.25M2.25 6V5.625A1.125 1.125 0 0 1 3.375 4.5H20.25M2.25 6v9M20.25 4.5V5.25A.75.75 0 0 0 21 6h.75M20.25 4.5h.375A1.125 1.125 0 0 1 21.75 5.625V15.375A1.125 1.125 0 0 1 20.625 16.5H20.25M21.75 15H21a.75.75 0 0 0-.75.75V16.5M20.25 16.5H3.75m0 0H3.375A1.125 1.125 0 0 1 2.25 15.375V15M3.75 16.5V15.75A.75.75 0 0 0 3 15H2.25M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z"
+          />
         </svg>
         <span class="link-text">Saques</span>
       </a>
     </li>
     <li>
-  <a href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamentoGestor" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-acompanhamento-gestor" data-perfil="gestor,mentor">
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-      <path stroke-linecap="round" stroke-linejoin="round" 
-            d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
-    </svg>
-    
-    <!-- Texto do link -->
-    <span class="link-text">Mentorados/Vendedores</span>
-  </a>
-</li>
+      <a
+        href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamentoGestor"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-acompanhamento-gestor"
+        data-perfil="gestor,mentor"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+          />
+        </svg>
+
+        <!-- Texto do link -->
+        <span class="link-text">Mentorados/Vendedores</span>
+      </a>
+    </li>
 
     <li>
-      <a href="/acompanhamento-tiny.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-acompanhamento-tiny" data-perfil="gestor,mentor,gestor financeiro">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3 3h18v4H3V3zm0 6h18v12H3V9zm5 2v2h2v-2H8zm0 4v2h2v-2H8zm4-4v2h2v-2h-2zm0 4v2h2v-2h-2z"/>
+      <a
+        href="/acompanhamento-tiny.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-acompanhamento-tiny"
+        data-perfil="gestor,mentor,gestor financeiro"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M3 3h18v4H3V3zm0 6h18v12H3V9zm5 2v2h2v-2H8zm0 4v2h2v-2H8zm4-4v2h2v-2h-2zm0 4v2h2v-2h-2z"
+          />
         </svg>
         <span class="link-text">Pedidos Faturados</span>
       </a>
     </li>
-      <li>
-        <a href="/acompanhamento-vendas.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-acompanhamento-vendas" data-perfil="gestor,responsavel,gestor financeiro">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v6.75A1.125 1.125 0 0 1 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 9.75 19.875V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 16.5 19.875V4.125Z" />
-          </svg>
-          <span class="link-text">Acompanhamento Sobras</span>
-        </a>
-        </li>
-
-      <li>
-        <a href="/produtos-vendidos.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-produtos-vendidos" data-perfil="gestor,mentor,responsavel,gestor financeiro,responsavel financeiro">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"/>
+    <li>
+      <a
+        href="/acompanhamento-vendas.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-acompanhamento-vendas"
+        data-perfil="gestor,responsavel,gestor financeiro"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M3 13.125c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v6.75A1.125 1.125 0 0 1 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 9.75 19.875V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 16.5 19.875V4.125Z"
+          />
         </svg>
-        <span class="link-text">Produtos Vendidos</span>
-        </a>
-      </li>
+        <span class="link-text">Acompanhamento Sobras</span>
+      </a>
+    </li>
 
     <li>
-      <a href="/mentoria.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-mentoria" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5M3.75 3h16.5m0 0h1.5m-1.5 0v11.25a2.25 2.25 0 0 1-2.25 2.25H15.75M8.25 16.5h7.5m-7.5 0L7.25 19.5m8.5-3L16.75 19.5m0 0 .5 1.5m-.5-1.5H7.25m0 0-.5 1.5m1.75-9L10.5 9l2.148 2.148A9.013 9.013 0 0 1 16.5 7.605"/>
+      <a
+        href="/produtos-vendidos.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-produtos-vendidos"
+        data-perfil="gestor,mentor,responsavel,gestor financeiro,responsavel financeiro"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"
+          />
+        </svg>
+        <span class="link-text">Produtos Vendidos</span>
+      </a>
+    </li>
+
+    <li>
+      <a
+        href="/mentoria.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-mentoria"
+        data-perfil="gestor,mentor"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5M3.75 3h16.5m0 0h1.5m-1.5 0v11.25a2.25 2.25 0 0 1-2.25 2.25H15.75M8.25 16.5h7.5m-7.5 0L7.25 19.5m8.5-3L16.75 19.5m0 0 .5 1.5m-.5-1.5H7.25m0 0-.5 1.5m1.75-9L10.5 9l2.148 2.148A9.013 9.013 0 0 1 16.5 7.605"
+          />
         </svg>
         <span class="link-text">Visão Geral do Mentor</span>
       </a>
     </li>
     <li>
-      <a href="/perfil-mentorado.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-perfil-mentorado" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15 9h3.75M15 12h3.75M15 15h3.75M4.5 19.5h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15A2.25 2.25 0 0 0 2.25 6.75v10.5A2.25 2.25 0 0 0 4.5 19.5Zm6-10.125a1.875 1.875 0 1 1-3.75 0 1.875 1.875 0 0 1 3.75 0Zm1.294 6.336A5.985 5.985 0 0 0 8.625 13.5a5.985 5.985 0 0 0-3.169 2.211"/>
+      <a
+        href="/perfil-mentorado.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-perfil-mentorado"
+        data-perfil="gestor,mentor"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M15 9h3.75M15 12h3.75M15 15h3.75M4.5 19.5h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15A2.25 2.25 0 0 0 2.25 6.75v10.5A2.25 2.25 0 0 0 4.5 19.5Zm6-10.125a1.875 1.875 0 1 1-3.75 0 1.875 1.875 0 0 1 3.75 0Zm1.294 6.336A5.985 5.985 0 0 0 8.625 13.5a5.985 5.985 0 0 0-3.169 2.211"
+          />
         </svg>
         <span class="link-text">Perfil do Mentorado</span>
       </a>
     </li>
     <li>
-      <a href="/equipes.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-equipes" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128c.833.242 1.714.372 2.625.372 1.479 0 2.878-.342 4.122-.952v-.173c0-2.278-1.847-4.125-4.125-4.125-1.418 0-2.669.716-3.411 1.806M15 19.128V19.125c0-3.52-2.854-6.375-6.375-6.375S2.25 15.605 2.25 19.125v.009A11.953 11.953 0 0 0 12 21c2.678 0 5.218-.585 7.499-1.632M12.75 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM20.25 8.625a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z"/>
+      <a
+        href="/equipes.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-equipes"
+        data-perfil="gestor,mentor"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M15 19.128c.833.242 1.714.372 2.625.372 1.479 0 2.878-.342 4.122-.952v-.173c0-2.278-1.847-4.125-4.125-4.125-1.418 0-2.669.716-3.411 1.806M15 19.128V19.125c0-3.52-2.854-6.375-6.375-6.375S2.25 15.605 2.25 19.125v.009A11.953 11.953 0 0 0 12 21c2.678 0 5.218-.585 7.499-1.632M12.75 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM20.25 8.625a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z"
+          />
         </svg>
         <span class="link-text">Equipes</span>
       </a>
     </li>
     <li>
-      <a href="/gestao-produtos.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-produtos" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M21 7.5 12 2.25 3 7.5m18 0L12 12.75M21 7.5v9L12 21.75M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"/>
+      <a
+        href="/gestao-produtos.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-produtos"
+        data-perfil="gestor,mentor"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M21 7.5 12 2.25 3 7.5m18 0L12 12.75M21 7.5v9L12 21.75M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"
+          />
         </svg>
         <span class="link-text">Gestão de Produtos</span>
       </a>
     </li>
     <li>
-      <a href="/sku-associado.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-sku-associado" data-perfil="gestor,responsavel financeiro">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"/>
+      <a
+        href="/sku-associado.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-sku-associado"
+        data-perfil="gestor,responsavel financeiro"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"
+          />
         </svg>
         <span class="link-text">SKU Associado</span>
       </a>
     </li>
     <li>
-      <a href="/desempenho.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-desempenho" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v6.75A1.125 1.125 0 0 1 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 9.75 19.875V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 16.5 19.875V4.125Z"/>
+      <a
+        href="/desempenho.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-desempenho"
+        data-perfil="gestor,mentor"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M3 13.125c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v6.75A1.125 1.125 0 0 1 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 9.75 19.875V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25A1.125 1.125 0 0 1 16.5 19.875V4.125Z"
+          />
         </svg>
         <span class="link-text">Desempenho</span>
       </a>
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-vendas" data-perfil="usuario,gestor,mentor,responsavel,gestor financeiro">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"/>
+        <a
+          href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento"
+          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          id="menu-vendas"
+          data-perfil="usuario,gestor,mentor,responsavel,gestor financeiro"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5 mr-3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"
+            />
           </svg>
           <span class="link-text">Vendas</span>
         </a>
-        <button class="submenu-toggle p-2" onclick="toggleMenu('menuVendas', this)">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
+        <button
+          class="submenu-toggle p-2"
+          onclick="toggleMenu('menuVendas', this)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
           </svg>
         </button>
       </div>
-      <ul id="menuVendas" class="submenu space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-        <li><a href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento" class="sidebar-link block py-2 px-4 transition-colors">Registrar Faturamento</a></li>
-        <li><a href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=registroFaturamento" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Faturamento</a></li>
-        <li><a href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=controleVendas" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Vendas</a></li>
-        <li><a href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamento" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Mensal</a></li>
+      <ul
+        id="menuVendas"
+        class="submenu space-y-1 overflow-hidden transition-all duration-300"
+        style="max-height: 0"
+      >
+        <li>
+          <a
+            href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Registrar Faturamento</a
+          >
+        </li>
+        <li>
+          <a
+            href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=registroFaturamento"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Acompanhamento Faturamento</a
+          >
+        </li>
+        <li>
+          <a
+            href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=controleVendas"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Acompanhamento Vendas</a
+          >
+        </li>
+        <li>
+          <a
+            href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamento"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Acompanhamento Mensal</a
+          >
+        </li>
       </ul>
     </li>
     <li>
-      <a href="/saques.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-saques" data-perfil="gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75C7.717 18.75 13.014 19.481 18.047 20.851c.728.198 1.454-.343 1.454-1.096V18.75M3.75 4.5V5.25A.75.75 0 0 1 3 6H2.25M2.25 6V5.625A1.125 1.125 0 0 1 3.375 4.5H20.25M2.25 6v9M20.25 4.5V5.25A.75.75 0 0 0 21 6h.75M20.25 4.5h.375A1.125 1.125 0 0 1 21.75 5.625V15.375A1.125 1.125 0 0 1 20.625 16.5H20.25M21.75 15H21a.75.75 0 0 0-.75.75V16.5M20.25 16.5H3.75m0 0H3.375A1.125 1.125 0 0 1 2.25 15.375V15M3.75 16.5V15.75A.75.75 0 0 0 3 15H2.25M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z"/>
+      <a
+        href="/saques.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-saques"
+        data-perfil="gestor,mentor"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M2.25 18.75C7.717 18.75 13.014 19.481 18.047 20.851c.728.198 1.454-.343 1.454-1.096V18.75M3.75 4.5V5.25A.75.75 0 0 1 3 6H2.25M2.25 6V5.625A1.125 1.125 0 0 1 3.375 4.5H20.25M2.25 6v9M20.25 4.5V5.25A.75.75 0 0 0 21 6h.75M20.25 4.5h.375A1.125 1.125 0 0 1 21.75 5.625V15.375A1.125 1.125 0 0 1 20.625 16.5H20.25M21.75 15H21a.75.75 0 0 0-.75.75V16.5M20.25 16.5H3.75m0 0H3.375A1.125 1.125 0 0 1 2.25 15.375V15M3.75 16.5V15.75A.75.75 0 0 0 3 15H2.25M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z"
+          />
         </svg>
         <span class="link-text">Saques</span>
       </a>
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="/etiquetas-ocr.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-etiquetas" data-perfil="usuario,gestor,mentor">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"/>
-            <path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6Z"/>
+        <a
+          href="/etiquetas-ocr.html"
+          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          id="menu-etiquetas"
+          data-perfil="usuario,gestor,mentor"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5 mr-3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"
+            />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M6 6h.008v.008H6V6Z"
+            />
           </svg>
           <span class="link-text">Etiquetas</span>
         </a>
-        <button class="submenu-toggle p-2" onclick="toggleMenu('menuEtiquetas', this)">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
+        <button
+          class="submenu-toggle p-2"
+          onclick="toggleMenu('menuEtiquetas', this)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
           </svg>
         </button>
       </div>
-      <ul id="menuEtiquetas" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-        <li><a href="/etiquetas-ocr.html" class="sidebar-link block py-2 px-4 transition-colors">Etiquetas PDF</a></li>
-        <li><a href="/zpl-import.html" class="sidebar-link block py-2 px-4 transition-colors">Etiquetas ZPL</a></li>
-        <li><a href="/zpl-import-ocr.html" class="sidebar-link block py-2 px-4 transition-colors">ZPL Import ocr</a></li>
+      <ul
+        id="menuEtiquetas"
+        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
+        style="max-height: 0"
+      >
+        <li>
+          <a
+            href="/etiquetas-ocr.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Etiquetas PDF</a
+          >
+        </li>
+        <li>
+          <a
+            href="/zpl-import.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Etiquetas ZPL</a
+          >
+        </li>
+        <li>
+          <a
+            href="/zpl-import-ocr.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >ZPL Import ocr</a
+          >
+        </li>
       </ul>
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-precificacao" data-perfil="usuario,gestor,mentor">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"/>
-            <path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6Z"/>
+        <a
+          href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao"
+          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          id="menu-precificacao"
+          data-perfil="usuario,gestor,mentor"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5 mr-3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"
+            />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M6 6h.008v.008H6V6Z"
+            />
           </svg>
           <span class="link-text">Precificação</span>
         </a>
-        <button class="submenu-toggle p-2" onclick="toggleMenu('menuPrecificacao', this)">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
+        <button
+          class="submenu-toggle p-2"
+          onclick="toggleMenu('menuPrecificacao', this)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
           </svg>
         </button>
       </div>
-      <ul id="menuPrecificacao" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-        <li><a href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao" class="sidebar-link block py-2 px-4 transition-colors">Precificação</a></li>
-        <li><a href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=lista-precos" class="sidebar-link block py-2 px-4 transition-colors">Lista Preços</a></li>
-        <li><a href="/SISTEMA%20DE%20CUSTEIO%20DE%20PRODU%C3%87%C3%83O%20E%20PRODUTOS.html#mdf" class="sidebar-link block py-2 px-4 transition-colors">Custeio de Produção</a></li>
-        <li><a href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a></li>
+      <ul
+        id="menuPrecificacao"
+        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
+        style="max-height: 0"
+      >
+        <li>
+          <a
+            href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Precificação</a
+          >
+        </li>
+        <li>
+          <a
+            href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=lista-precos"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Lista Preços</a
+          >
+        </li>
+        <li>
+          <a
+            href="/SISTEMA%20DE%20CUSTEIO%20DE%20PRODU%C3%87%C3%83O%20E%20PRODUTOS.html#mdf"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Custeio de Produção</a
+          >
+        </li>
+        <li>
+          <a
+            href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=historico"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Histórico</a
+          >
+        </li>
       </ul>
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="/promocoes-shopee.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-marketing" data-perfil="usuario,gestor,mentor">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"/>
+        <a
+          href="/promocoes-shopee.html"
+          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          id="menu-marketing"
+          data-perfil="usuario,gestor,mentor"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5 mr-3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"
+            />
           </svg>
           <span class="link-text">Marketing</span>
         </a>
-        <button class="submenu-toggle p-2" onclick="toggleMenu('menuMarketing', this)">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
+        <button
+          class="submenu-toggle p-2"
+          onclick="toggleMenu('menuMarketing', this)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
           </svg>
         </button>
       </div>
-      <ul id="menuMarketing" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-        <li><a href="/promocoes-shopee.html" class="sidebar-link block py-2 px-4 transition-colors">Promoções Shopee</a></li>
-        <li><a href="/ads.html" class="sidebar-link block py-2 px-4 transition-colors">Shopee Ads</a></li>
-        <li><a href="/ads-lista.html" class="sidebar-link block py-2 px-4 transition-colors">Anúncios Salvos</a></li>
-        <li><a href="/acompanhamento-promocoes.html" class="sidebar-link block py-2 px-4 transition-colors">Acompanhamento Promoções</a></li>
+      <ul
+        id="menuMarketing"
+        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
+        style="max-height: 0"
+      >
+        <li>
+          <a
+            href="/promocoes-shopee.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Promoções Shopee</a
+          >
+        </li>
+        <li>
+          <a
+            href="/ads.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Shopee Ads</a
+          >
+        </li>
+        <li>
+          <a
+            href="/ads-lista.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Anúncios Salvos</a
+          >
+        </li>
+        <li>
+          <a
+            href="/acompanhamento-promocoes.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Acompanhamento Promoções</a
+          >
+        </li>
       </ul>
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="/anuncios-tabs/cadastro.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-anuncios" data-perfil="usuario,gestor,mentor">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46"/>
+        <a
+          href="/anuncios-tabs/cadastro.html"
+          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          id="menu-anuncios"
+          data-perfil="usuario,gestor,mentor"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5 mr-3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46"
+            />
           </svg>
           <span class="link-text">Anúncios</span>
         </a>
-        <button class="submenu-toggle p-2" onclick="toggleMenu('menuAnuncios', this)">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
+        <button
+          class="submenu-toggle p-2"
+          onclick="toggleMenu('menuAnuncios', this)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
           </svg>
         </button>
       </div>
-      <ul id="menuAnuncios" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-        <li><a href="/anuncios-tabs/cadastro.html" class="sidebar-link block py-2 px-4 transition-colors">Cadastro / Atualização</a></li>
-        <li><a href="/anuncios-tabs/anuncios.html" class="sidebar-link block py-2 px-4 transition-colors">Anúncios</a></li>
-        <li><a href="/anuncios-tabs/analise.html" class="sidebar-link block py-2 px-4 transition-colors">Análise IA</a></li>
-        <li><a href="/anuncios-tabs/evolucao.html" class="sidebar-link block py-2 px-4 transition-colors">Evolução</a></li>
-        <li><a href="/anuncios-tabs/criar-ia.html" class="sidebar-link block py-2 px-4 transition-colors">Criar Anúncio com IA</a></li>
-        <li><a href="/anuncios-tabs/planilha-shopee.html" class="sidebar-link block py-2 px-4 transition-colors">Planilha Shopee</a></li>
-        <li><a href="/expedicao.html" class="sidebar-link block py-2 px-4 transition-colors">Expedição</a></li>
+      <ul
+        id="menuAnuncios"
+        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
+        style="max-height: 0"
+      >
+        <li>
+          <a
+            href="/anuncios-tabs/cadastro.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Cadastro / Atualização</a
+          >
+        </li>
+        <li>
+          <a
+            href="/anuncios-tabs/anuncios.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Anúncios</a
+          >
+        </li>
+        <li>
+          <a
+            href="/anuncios-tabs/analise.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Análise IA</a
+          >
+        </li>
+        <li>
+          <a
+            href="/anuncios-tabs/evolucao.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Evolução</a
+          >
+        </li>
+        <li>
+          <a
+            href="/anuncios-tabs/criar-ia.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Criar Anúncio com IA</a
+          >
+        </li>
+        <li>
+          <a
+            href="/anuncios-tabs/planilha-shopee.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Planilha Shopee</a
+          >
+        </li>
+        <li>
+          <a
+            href="/expedicao.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Expedição</a
+          >
+        </li>
       </ul>
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="/expedicao.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-expedicao" data-perfil="usuario,gestor,mentor">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 01-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 00-3.213-9.193 2.056 2.056 0 00-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 00-10.026 0 1.106 1.106 0 00-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12"/>
+        <a
+          href="/expedicao.html"
+          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          id="menu-expedicao"
+          data-perfil="usuario,gestor,mentor"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5 mr-3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M8.25 18.75a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 01-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 00-3.213-9.193 2.056 2.056 0 00-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 00-10.026 0 1.106 1.106 0 00-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12"
+            />
           </svg>
           <span class="link-text">Expedição</span>
         </a>
-        <button class="submenu-toggle p-2" onclick="toggleMenu('menuExpedicao', this)">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
+        <button
+          class="submenu-toggle p-2"
+          onclick="toggleMenu('menuExpedicao', this)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
           </svg>
         </button>
       </div>
-      <ul id="menuExpedicao" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-        <li><a href="/atualizacoes-dia.html" class="sidebar-link block py-2 px-4 transition-colors">Atualizações do Dia</a></li>
-        <li><a href="/configuracao-expedicao.html" class="sidebar-link block py-2 px-4 transition-colors">Configuração Expedição</a></li>
-        <li><a href="/relatorios.html" class="sidebar-link block py-2 px-4 transition-colors">Relatórios</a></li>
-        <li><a href="/coletas.html" class="sidebar-link block py-2 px-4 transition-colors">Coletas</a></li>
-        <li><a href="/expedicao-historico.html" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a></li>
-        <li><a href="/expedicao-pedidosreais.html" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Reais</a></li>
+      <ul
+        id="menuExpedicao"
+        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
+        style="max-height: 0"
+      >
+        <li>
+          <a
+            href="/atualizacoes-dia.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Atualizações do Dia</a
+          >
+        </li>
+        <li>
+          <a
+            href="/configuracao-expedicao.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Configuração Expedição</a
+          >
+        </li>
+        <li>
+          <a
+            href="/relatorios.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Relatórios</a
+          >
+        </li>
+        <li>
+          <a
+            href="/coletas.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Coletas</a
+          >
+        </li>
+        <li>
+          <a
+            href="/expedicao-historico.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Histórico</a
+          >
+        </li>
+        <li>
+          <a
+            href="/expedicao-pedidosreais.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Pedidos Reais</a
+          >
+        </li>
       </ul>
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="/gestao-contas.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-gestao-contas" data-perfil="usuario,gestor,mentor">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z"/>
+        <a
+          href="/gestao-contas.html"
+          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          id="menu-gestao-contas"
+          data-perfil="usuario,gestor,mentor"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5 mr-3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z"
+            />
           </svg>
           <span class="link-text">Gestão de Contas</span>
         </a>
-        <button class="submenu-toggle p-2" onclick="toggleMenu('menuGestaoContas', this)">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
+        <button
+          class="submenu-toggle p-2"
+          onclick="toggleMenu('menuGestaoContas', this)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
           </svg>
         </button>
       </div>
-      <ul id="menuGestaoContas" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-        <li><a href="/pdf-x-excel.html" class="sidebar-link block py-2 px-4 transition-colors">PDF X Excel</a></li>
-        <li><a href="/gestao-contas.html" class="sidebar-link block py-2 px-4 transition-colors">Configurações</a></li>
+      <ul
+        id="menuGestaoContas"
+        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
+        style="max-height: 0"
+      >
+        <li>
+          <a
+            href="/pdf-x-excel.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >PDF X Excel</a
+          >
+        </li>
+        <li>
+          <a
+            href="/gestao-contas.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Configurações</a
+          >
+        </li>
       </ul>
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="/problemas.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-acompanhamento" data-perfil="usuario,gestor,mentor,responsavel,gestor financeiro">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m0 3.75h.008v.008H12v-.008ZM21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
+        <a
+          href="/problemas.html"
+          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          id="menu-acompanhamento"
+          data-perfil="usuario,gestor,mentor,responsavel,gestor financeiro"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5 mr-3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M12 9v3.75m0 3.75h.008v.008H12v-.008ZM21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+            />
           </svg>
           <span class="link-text">Acompanhamento</span>
         </a>
-        <button class="submenu-toggle p-2" onclick="toggleMenu('menuAcompanhamento', this)">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
+        <button
+          class="submenu-toggle p-2"
+          onclick="toggleMenu('menuAcompanhamento', this)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
           </svg>
         </button>
       </div>
-      <ul id="menuAcompanhamento" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-        <li><a href="/problemas.html" class="sidebar-link block py-2 px-4 transition-colors">Problemas</a></li>
-        <li><a href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=previsao" class="sidebar-link block py-2 px-4 transition-colors">Previsão</a></li>
-        <li><a href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar" class="sidebar-link block py-2 px-4 transition-colors">Conferir Sobras</a></li>
-        <li><a href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=sobras" class="sidebar-link block py-2 px-4 transition-colors">Sobras</a></li>
-        <li><a href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a></li>
+      <ul
+        id="menuAcompanhamento"
+        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
+        style="max-height: 0"
+      >
+        <li>
+          <a
+            href="/problemas.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Problemas</a
+          >
+        </li>
+        <li>
+          <a
+            href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=previsao"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Previsão</a
+          >
+        </li>
+        <li>
+          <a
+            href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Conferir Sobras</a
+          >
+        </li>
+        <li>
+          <a
+            href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=sobras"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Sobras</a
+          >
+        </li>
+        <li>
+          <a
+            href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Histórico</a
+          >
+        </li>
       </ul>
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=produtos" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-outros" data-perfil="usuario,gestor,mentor">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/>
+        <a
+          href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=produtos"
+          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          id="menu-outros"
+          data-perfil="usuario,gestor,mentor"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5 mr-3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"
+            />
           </svg>
           <span class="link-text">Outros</span>
         </a>
-        <button class="submenu-toggle p-2" onclick="toggleMenu('menuOutros', this)">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
+        <button
+          class="submenu-toggle p-2"
+          onclick="toggleMenu('menuOutros', this)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
           </svg>
         </button>
       </div>
-      <ul id="menuOutros" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-        <li><a href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=produtos" class="sidebar-link block py-2 px-4 transition-colors">Produtos</a></li>
-        <li><a href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=metas" class="sidebar-link block py-2 px-4 transition-colors">Cadastro de Sobra</a></li>
-        <li><a href="/pedidos-bling.html" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Bling</a></li>
-        <li><a href="/pedidos-tiny.html" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Tiny</a></li>
-        <li><a href="/pedidos-shopee.html" class="sidebar-link block py-2 px-4 transition-colors">Pedidos Shopee</a></li>
-        <li><a href="https://matheus-35023.web.app" class="sidebar-link block py-2 px-4 transition-colors" target="_blank">Tiny</a></li>
+      <ul
+        id="menuOutros"
+        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
+        style="max-height: 0"
+      >
+        <li>
+          <a
+            href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=produtos"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Produtos</a
+          >
+        </li>
+        <li>
+          <a
+            href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=metas"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Cadastro de Sobra</a
+          >
+        </li>
+        <li>
+          <a
+            href="/pedidos-bling.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Pedidos Bling</a
+          >
+        </li>
+        <li>
+          <a
+            href="/pedidos-tiny.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Pedidos Tiny</a
+          >
+        </li>
+        <li>
+          <a
+            href="/pedidos-shopee.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Pedidos Shopee</a
+          >
+        </li>
+        <li>
+          <a
+            href="https://matheus-35023.web.app"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            target="_blank"
+            >Tiny</a
+          >
+        </li>
       </ul>
     </li>
     <li>
       <div class="sidebar-item flex items-center justify-between">
-        <a href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-configuracoes" data-perfil="usuario,gestor,mentor">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"/>
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
+        <a
+          href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard"
+          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          id="menu-configuracoes"
+          data-perfil="usuario,gestor,mentor"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5 mr-3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"
+            />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+            />
           </svg>
           <span class="link-text">Configurações</span>
         </a>
-        <button class="submenu-toggle p-2" onclick="toggleMenu('menuConfiguracoes', this)">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
+        <button
+          class="submenu-toggle p-2"
+          onclick="toggleMenu('menuConfiguracoes', this)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
           </svg>
         </button>
       </div>
-      <ul id="menuConfiguracoes" class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300" style="max-height:0;">
-        <li><a href="/painel-usuarios.html" class="sidebar-link block py-2 px-4 transition-colors">Painel de Usuários</a></li>
-        <li><a href="/configuracao-perfil.html" class="sidebar-link block py-2 px-4 transition-colors">Configuração de Perfil</a></li>
-        <li><a href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico" class="sidebar-link block py-2 px-4 transition-colors">Histórico</a></li>
-        <li><a href="/email-expedicao.html" class="sidebar-link block py-2 px-4 transition-colors">E-mail de Expedição</a></li>
-        <li><a href="/manual.html" target="_blank" class="sidebar-link block py-2 px-4 transition-colors">Manual</a></li>
+      <ul
+        id="menuConfiguracoes"
+        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
+        style="max-height: 0"
+      >
+        <li>
+          <a
+            href="/painel-usuarios.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Painel de Usuários</a
+          >
+        </li>
+        <li>
+          <a
+            href="/configuracao-perfil.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Configuração de Perfil</a
+          >
+        </li>
+        <li>
+          <a
+            href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Histórico</a
+          >
+        </li>
+        <li>
+          <a
+            href="/email-expedicao.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >E-mail de Expedição</a
+          >
+        </li>
+        <li>
+          <a
+            href="/manual.html"
+            target="_blank"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Manual</a
+          >
+        </li>
       </ul>
     </li>
     <li>
-      <a href="/comunicacao.html" class="sidebar-link flex items-center py-2 px-4 transition-colors" id="menu-comunicacao" data-perfil="cliente,usuario,gestor,mentor">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m21.75 0-9.423 6.615a2.25 2.25 0 0 1-2.654 0L1.5 6.75" />
+      <a
+        href="/comunicacao.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-comunicacao"
+        data-perfil="cliente,usuario,gestor,mentor"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m21.75 0-9.423 6.615a2.25 2.25 0 0 1-2.654 0L1.5 6.75"
+          />
         </svg>
         <span class="link-text">Comunicação</span>
       </a>
     </li>
     <li>
-      <button id="startSidebarTourBtn" class="sidebar-link w-full text-left flex items-center py-2 px-4 transition-colors">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z"/>
+      <button
+        id="startSidebarTourBtn"
+        class="sidebar-link w-full text-left flex items-center py-2 px-4 transition-colors"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z"
+          />
         </svg>
         <span class="link-text">Modo de Introdução</span>
       </button>
     </li>
     <li>
       <div class="flex items-center justify-between px-4 mt-6">
-        <span class="text-sm text-gray-300">Modo Escuro</span>
+        <span class="text-sm">Modo Escuro</span>
         <label class="relative inline-flex items-center cursor-pointer">
-          <input type="checkbox" id="darkModeToggle" class="sr-only peer">
-          <div class="w-11 h-6 bg-gray-300 peer-focus:outline-none rounded-full peer peer-checked:bg-orange-500 transition"></div>
-          <div class="absolute left-1 top-1 bg-white w-4 h-4 rounded-full transition peer-checked:translate-x-full"></div>
+          <input type="checkbox" id="darkModeToggle" class="sr-only peer" />
+          <div
+            class="w-11 h-6 bg-gray-300 peer-focus:outline-none rounded-full peer peer-checked:bg-orange-500 transition"
+          ></div>
+          <div
+            class="absolute left-1 top-1 bg-white w-4 h-4 rounded-full transition peer-checked:translate-x-full"
+          ></div>
         </label>
       </div>
     </li>
     <li>
-      <button id="logoutSidebarBtn" class="sidebar-link w-full text-left flex items-center py-2 px-4 transition-colors hidden">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15M12 9l-3 3m0 0 3 3m-3-3h12.75"/>
+      <button
+        id="logoutSidebarBtn"
+        class="sidebar-link w-full text-left flex items-center py-2 px-4 transition-colors hidden"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15M12 9l-3 3m0 0 3 3m-3-3h12.75"
+          />
         </svg>
         <span class="link-text">Sair</span>
       </button>
     </li>
   </ul>
-  <div class="p-4 mt-auto text-center"><span class="font-bold text-xl text-white">VendedorPro</span></div>
+  <div class="p-4 mt-auto text-center">
+    <span class="font-bold text-xl">VendedorPro</span>
+  </div>
 </nav>
-
-


### PR DESCRIPTION
## Summary
- add global sidebar width variable
- apply uniform text and container shadow across sidebar
- remove hard-coded text colors from sidebar markup

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68c4ed241090832a93a686ad06bc3dd3