### PR TITLE
Align client sidebar styling with other roles

### DIFF
--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -184,37 +184,6 @@ body.has-sidebar .content-wrapper {
   }
 }
 
-/* Client sidebar layout */
-.sidebar.client-layout {
-  background: var(--sidebar-bg);
-  color: var(--sidebar-text);
-}
-.sidebar.client-layout .sidebar-link {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 12px;
-  width: 100%;
-  padding: 0.8rem 1.5rem;
-  background: transparent;
-  color: var(--sidebar-text) !important;
-  border-radius: 0.375rem;
-  border-left: 4px solid var(--sidebar-border);
-}
-.sidebar.client-layout .sidebar-link:hover {
-  background-color: rgba(255, 255, 255, 0.1);
-}
-.sidebar.client-layout .sidebar-link.active {
-  background-color: rgba(255, 255, 255, 0.2);
-  border-left-color: var(--sidebar-border);
-}
-.sidebar.client-layout .sidebar-link svg {
-  display: block;
-}
-.sidebar.client-layout .submenu-toggle {
-  display: block;
-}
-
 /* Mobile-specific sidebar rules */
 @media (max-width: 768px) {
   .sidebar {

--- a/shared.js
+++ b/shared.js
@@ -689,13 +689,6 @@ document.addEventListener('sidebarLoaded', async () => {
     });
   }
 
-  function buildClienteSidebarLayout() {
-    const sidebar = document.getElementById('sidebar');
-    if (sidebar) {
-      sidebar.classList.add('client-layout');
-    }
-  }
-
   async function applySidebarPermissions(uid) {
     try {
       const snap = await getDoc(doc(db, 'usuarios', uid));
@@ -729,7 +722,6 @@ document.addEventListener('sidebarLoaded', async () => {
           if (li && !CLIENTE_HIDDEN_MENU_IDS.includes(a.id))
             li.style.display = '';
         });
-        buildClienteSidebarLayout();
       }
     } catch (e) {
       console.error('Erro ao aplicar permissões do sidebar:', e);


### PR DESCRIPTION
## Summary
- remove client-only sidebar CSS rules
- drop runtime code adding client-specific sidebar class

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4f02aa3ec832aa497bc1cc94ef8b1