### PR TITLE
Unify sidebar styling across user roles

### DIFF
--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -168,6 +168,10 @@ body.has-sidebar .content-wrapper {
   color: var(--primary-light);
 }
 
+.sidebar .link-text {
+  display: inline;
+}
+
 @media print {
   .submenu {
     overflow: hidden;
@@ -184,44 +188,10 @@ body.has-sidebar .content-wrapper {
   }
 }
 
-/* Client sidebar layout */
-.sidebar.client-layout {
-  background: var(--sidebar-bg);
-  color: var(--sidebar-text);
-}
-.sidebar.client-layout .sidebar-link {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 12px;
-  width: 100%;
-  padding: 0.8rem 1.5rem;
-  background: transparent;
-  color: var(--sidebar-text) !important;
-  border-radius: 0.375rem;
-  border-left: 4px solid var(--sidebar-border);
-}
-.sidebar.client-layout .sidebar-link:hover {
-  background-color: rgba(255, 255, 255, 0.1);
-}
-.sidebar.client-layout .sidebar-link.active {
-  background-color: rgba(255, 255, 255, 0.2);
-  border-left-color: var(--sidebar-border);
-}
-.sidebar.client-layout .sidebar-link svg {
-  display: block;
-}
-.sidebar.client-layout .submenu-toggle {
-  display: block;
-}
-
 /* Mobile-specific sidebar rules */
 @media (max-width: 768px) {
   .sidebar {
     width: var(--sidebar-width);
-  }
-  .sidebar .link-text {
-    display: inline;
   }
   .sidebar-link {
     justify-content: flex-start;

--- a/shared.js
+++ b/shared.js
@@ -689,13 +689,6 @@ document.addEventListener('sidebarLoaded', async () => {
     });
   }
 
-  function buildClienteSidebarLayout() {
-    const sidebar = document.getElementById('sidebar');
-    if (sidebar) {
-      sidebar.classList.add('client-layout');
-    }
-  }
-
   async function applySidebarPermissions(uid) {
     try {
       const snap = await getDoc(doc(db, 'usuarios', uid));
@@ -729,7 +722,7 @@ document.addEventListener('sidebarLoaded', async () => {
           if (li && !CLIENTE_HIDDEN_MENU_IDS.includes(a.id))
             li.style.display = '';
         });
-        buildClienteSidebarLayout();
+        buildGestorSidebarLayout();
       }
     } catch (e) {
       console.error('Erro ao aplicar permissões do sidebar:', e);


### PR DESCRIPTION
## Summary
- Remove client-specific sidebar CSS and ensure link text displays consistently
- Apply shipping manager sidebar layout to all users for unified appearance

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4f42b95c0832a96f99dade0685619