### PR TITLE
fix: guard logout listener for missing button

### DIFF
--- a/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
+++ b/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
@@ -2145,7 +2145,7 @@ function applyPriceUpdate(type) {
     }
     function setupEventListeners() {
       // Login/logout
-      document.getElementById('logoutBtn').addEventListener('click', logout);
+      document.getElementById('logoutBtn')?.addEventListener('click', logout);
       
       // Tabs
       document.querySelectorAll('.tab-button').forEach(btn => {


### PR DESCRIPTION
## Summary
- avoid runtime error by checking if logout button exists before registering click handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4f4dc17d0832a847eb1c455b380a9