### PR TITLE
feat: add granular user levels

### DIFF
--- a/login.js
+++ b/login.js
@@ -76,7 +76,7 @@ window.saveDisplayName = async () => {
   }
   try {
     const pass = getPassphrase() || `chave-${user.uid}`;
-    let perfil = 'Cliente';
+    let perfil = 'Usuario Basico';
     const uidRef = doc(db, 'uid', user.uid);
     const snap = await getDoc(uidRef);
     if (snap.exists()) {
@@ -367,7 +367,20 @@ function restoreSidebar() {
 }
 function applyPerfilRestrictions(perfil) {
   const currentPerfil = (perfil || '').toLowerCase().trim();
-  if (!currentPerfil || currentPerfil === 'expedicao') return;
+  const known = [
+    'usuario completo',
+    'usuario basico',
+    'gestor expedicao',
+    'gestores de expedição',
+    'responsavel financeiro',
+    'adm',
+  ];
+  if (
+    !currentPerfil ||
+    known.includes(currentPerfil) ||
+    currentPerfil === 'expedicao'
+  )
+    return;
   document.querySelectorAll('[data-perfil]').forEach((el) => {
     const allowed = (el.getAttribute('data-perfil') || '')
       .toLowerCase()

--- a/painel-usuarios.html
+++ b/painel-usuarios.html
@@ -26,9 +26,11 @@
           <input type="email" id="email" placeholder="E-mail do Usuário" class="w-full p-2 border rounded">
           <input type="text" id="emailExpedicao" placeholder="E-mails Responsável Expedição (até 2, separados por vírgula)" class="w-full p-2 border rounded">
       <select id="perfil" class="w-full p-2 border rounded">
-        <option value="Cliente">Cliente</option>
+        <option value="Usuario Completo">Usuario Completo</option>
+        <option value="Usuario Basico">Usuario Basico</option>
+        <option value="Gestor Expedicao">Gestores de expedição</option>
+        <option value="Responsavel Financeiro">Responsavel financeiro</option>
         <option value="ADM">ADM</option>
-        <option value="EXPEDICAO">Expedição</option>
       </select>
       <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Salvar Usuário</button>
     </form>

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -635,6 +635,7 @@
           <a
             href="/SISTEMA%20DE%20CUSTEIO%20DE%20PRODU%C3%87%C3%83O%20E%20PRODUTOS.html#mdf"
             class="sidebar-link block py-2 px-4 transition-colors"
+            id="menu-precificacao-custeio"
             >Custeio de Produção</a
           >
         </li>
@@ -642,6 +643,7 @@
           <a
             href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=historico"
             class="sidebar-link block py-2 px-4 transition-colors"
+            id="menu-precificacao-historico"
             >Histórico</a
           >
         </li>
@@ -1222,6 +1224,7 @@
           <a
             href="/painel-usuarios.html"
             class="sidebar-link block py-2 px-4 transition-colors"
+            id="menu-configuracoes-usuarios"
             >Painel de Usuários</a
           >
         </li>

--- a/shared.js
+++ b/shared.js
@@ -568,6 +568,104 @@ document.addEventListener('sidebarLoaded', async () => {
   const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
   const db = getFirestore(app);
 
+  const NIVEL_MENUS = {
+    adm: [
+      'menu-gestao',
+      'menu-financeiro',
+      'menu-atualizacoes',
+      'menu-saques',
+      'menu-acompanhamento-gestor',
+      'menu-acompanhamento-tiny',
+      'menu-acompanhamento-vendas',
+      'menu-produtos-vendidos',
+      'menu-mentoria',
+      'menu-perfil-mentorado',
+      'menu-equipes',
+      'menu-produtos',
+      'menu-sku-associado',
+      'menu-desempenho',
+      'menu-vendas',
+      'menu-etiquetas',
+      'menu-precificacao',
+      'menu-precificacao-custeio',
+      'menu-precificacao-historico',
+      'menu-marketing',
+      'menu-anuncios',
+      'menu-expedicao',
+      'menu-gestao-contas',
+      'menu-acompanhamento',
+      'menu-outros',
+      'menu-configuracoes',
+      'menu-configuracoes-usuarios',
+      'menu-comunicacao',
+    ],
+    'usuario completo': [
+      'menu-desempenho',
+      'menu-vendas',
+      'menu-saques',
+      'menu-etiquetas',
+      'menu-precificacao',
+      'menu-precificacao-custeio',
+      'menu-precificacao-historico',
+      'menu-marketing',
+      'menu-anuncios',
+      'menu-expedicao',
+      'menu-gestao-contas',
+      'menu-acompanhamento',
+      'menu-outros',
+      'menu-configuracoes',
+      'menu-comunicacao',
+    ],
+    'usuario basico': [
+      'menu-desempenho',
+      'menu-vendas',
+      'menu-etiquetas',
+      'menu-precificacao',
+      'menu-expedicao',
+      'menu-configuracoes',
+      'menu-comunicacao',
+    ],
+    'gestor expedicao': [
+      'menu-desempenho',
+      'menu-expedicao',
+      'menu-configuracoes',
+      'menu-comunicacao',
+    ],
+    'responsavel financeiro': [
+      'menu-atualizacoes',
+      'menu-financeiro',
+      'menu-saques',
+      'menu-acompanhamento-tiny',
+      'menu-acompanhamento-gestor',
+      'menu-acompanhamento',
+      'menu-produtos-vendidos',
+      'menu-desempenho',
+      'menu-perfil-mentorado',
+      'menu-produtos',
+      'menu-sku-associado',
+      'menu-equipes',
+      'menu-comunicacao',
+    ],
+  };
+
+  function applyNivelMenus(perfil) {
+    const allowed = NIVEL_MENUS[perfil];
+    if (!allowed) return false;
+    document.querySelectorAll('#sidebar [id^="menu-"]').forEach((el) => {
+      const li = el.closest('li') || el.parentElement;
+      if (li) li.style.display = allowed.includes(el.id) ? '' : 'none';
+    });
+    const painel = document.getElementById('menu-configuracoes-usuarios');
+    if (painel && perfil !== 'adm') painel.closest('li').style.display = 'none';
+    if (perfil === 'usuario basico') {
+      const custeio = document.getElementById('menu-precificacao-custeio');
+      if (custeio) custeio.closest('li').style.display = 'none';
+      const historico = document.getElementById('menu-precificacao-historico');
+      if (historico) historico.closest('li').style.display = 'none';
+    }
+    return true;
+  }
+
   const ADMIN_GESTOR_MENU_IDS = [
     'menu-gestao',
     'menu-financeiro',
@@ -711,6 +809,8 @@ document.addEventListener('sidebarLoaded', async () => {
       const perfil = ((snap.exists() && String(snap.data().perfil || '')) || '')
         .trim()
         .toLowerCase();
+
+      if (applyNivelMenus(perfil)) return;
 
       const isADM = ['adm', 'admin', 'administrador'].includes(perfil);
       const isGestor = [


### PR DESCRIPTION
## Summary
- add selectable user levels in user admin panel
- map sidebar menus to new access levels
- ignore legacy perfil restrictions for new roles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7f096c098832a9c6a29c4052cdb9c