### PR TITLE
Reconhece perfil 'administrador' como admin em todas as páginas

### DIFF
--- a/gerenciamento.js
+++ b/gerenciamento.js
@@ -70,8 +70,11 @@ onAuthStateChanged(auth, async (user) => {
 
   try {
     const snap = await getDoc(doc(db, 'uid', user.uid));
-    const perfil = String(snap.data().perfil || '').toLowerCase();
-    isAdmin = snap.exists() && (perfil === 'adm' || perfil === 'admin');
+    const perfil = String(snap.data().perfil || '')
+      .toLowerCase()
+      .trim();
+    isAdmin =
+      snap.exists() && ['adm', 'admin', 'administrador'].includes(perfil);
   } catch (err) {
     console.error('Erro ao verificar perfil do usuário:', err);
     isAdmin = false;

--- a/index.js
+++ b/index.js
@@ -565,8 +565,10 @@ async function iniciarPainel(user) {
     try {
       const snap = await getDoc(doc(db, 'usuarios', uid)); // <- aqui era 'uid'
       if (snap.exists()) {
-        const perfil = String(snap.data().perfil || '').toLowerCase();
-        isAdmin = perfil === 'adm' || perfil === 'admin';
+        const perfil = String(snap.data().perfil || '')
+          .toLowerCase()
+          .trim();
+        isAdmin = ['adm', 'admin', 'administrador'].includes(perfil);
       } else {
         logger.warn(`Documento de usuário ${uid} não encontrado em 'usuarios'`);
       }

--- a/monitoramento.js
+++ b/monitoramento.js
@@ -31,8 +31,11 @@ onAuthStateChanged(auth, async (user) => {
   }
   try {
     const snap = await getDoc(doc(db, 'uid', user.uid));
-    const perfil = String(snap.data().perfil || '').toLowerCase();
-    isAdmin = snap.exists() && (perfil === 'adm' || perfil === 'admin');
+    const perfil = String(snap.data().perfil || '')
+      .toLowerCase()
+      .trim();
+    isAdmin =
+      snap.exists() && ['adm', 'admin', 'administrador'].includes(perfil);
   } catch (err) {
     console.error('Erro ao verificar perfil do usuário:', err);
     isAdmin = false;


### PR DESCRIPTION
## Summary
- Normaliza o campo de perfil do usuário e reconhece `'administrador'` como admin nas páginas de índice, monitoramento e gerenciamento

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7fad93314832ab3ee693c0d845259