### PR TITLE
feat: enable Firestore persistence

### DIFF
--- a/dashboard-geral.js
+++ b/dashboard-geral.js
@@ -1,9 +1,4 @@
 import {
-  initializeApp,
-  getApps,
-} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
-import {
-  getFirestore,
   collection,
   getDocs,
   doc,
@@ -11,16 +6,9 @@ import {
   query,
   where,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
-import {
-  getAuth,
-  onAuthStateChanged,
-} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
-import { firebaseConfig, getPassphrase } from './firebase-config.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { db, auth, getPassphrase } from './firebase-config.js';
 import { decryptString } from './crypto.js';
-
-const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
-const db = getFirestore(app);
-const auth = getAuth(app);
 const opts = {
   responsive: true,
   maintainAspectRatio: false,

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,3 +1,13 @@
+import {
+  initializeApp,
+  getApps,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import {
+  getFirestore,
+  enableIndexedDbPersistence,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { getAuth } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+
 // Firebase configuration
 // Fill these values via environment variables or a protected configuration not checked into version control.
 export const firebaseConfig = {
@@ -9,6 +19,15 @@ export const firebaseConfig = {
   appId: '1:1011113149395:web:c1f449e0e974ca8ecb2526',
   databaseURL: 'https://matheus-35023.firebaseio.com',
 };
+
+// Initialize Firebase app once and enable offline persistence
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+const db = getFirestore(app);
+// Best-effort enable persistence; ignore if not supported or already enabled
+enableIndexedDbPersistence(db).catch((err) => {
+  console.warn('Firestore persistence not enabled:', err.code);
+});
+const auth = getAuth(app);
 
 // Utility functions for storing the passphrase securely
 export function setPassphrase(pass) {
@@ -32,6 +51,9 @@ export function clearPassphrase() {
 // Expose to global scope for inline scripts
 if (typeof window !== 'undefined') {
   window.firebaseConfig = firebaseConfig;
+  window.firebaseApp = app;
+  window.db = db;
+  window.auth = auth;
   window.setPassphrase = setPassphrase;
   window.getPassphrase = getPassphrase;
   window.clearPassphrase = clearPassphrase;
@@ -41,8 +63,13 @@ if (typeof window !== 'undefined') {
 if (typeof module !== 'undefined') {
   module.exports = {
     firebaseConfig,
+    app,
+    db,
+    auth,
     setPassphrase,
     getPassphrase,
     clearPassphrase,
   };
 }
+
+export { app, db, auth };


### PR DESCRIPTION
## Summary
- centralize Firebase app init and enable IndexedDB persistence
- reuse shared Firestore/Auth instance in dashboard to avoid redundant initialization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7f23c00dc832aa3f76fa7a655db41