### PR TITLE
Verify user level using usuarios collection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,7 +3,14 @@ service cloud.firestore {
   match /databases/{database}/documents {
     function isGestorOrADM(uid) {
       return exists(/databases/$(database)/documents/usuarios/$(uid)) &&
-        get(/databases/$(database)/documents/usuarios/$(uid)).data.perfil in ['Gestor', 'ADM'];
+        get(/databases/$(database)/documents/usuarios/$(uid)).data.perfil in [
+          'Gestor',
+          'gestor',
+          'ADM',
+          'adm',
+          'Administrador',
+          'administrador'
+        ];
     }
 
     match /usuarios/{uid}/comissoes/{anoMes} {

--- a/login.html
+++ b/login.html
@@ -29,16 +29,6 @@
         <label for="loginPassphrase" class="block text-sm font-medium text-gray-700">Passphrase <span class="text-gray-400">(opcional)</span></label>
         <input id="loginPassphrase" type="password" placeholder="Passphrase" class="mt-1 w-full p-3 border rounded focus:ring-1 focus:ring-indigo-500" />
       </div>
-      <div class="flex items-center justify-center space-x-6">
-        <label class="flex items-center">
-          <input type="radio" name="userRole" value="usuario" class="mr-1" checked />
-          <span>Usuário</span>
-        </label>
-        <label class="flex items-center">
-          <input type="radio" name="userRole" value="gestor" class="mr-1" />
-          <span>Gestor</span>
-        </label>
-      </div>
       <button id="loginButton" type="submit" class="w-full btn-primary justify-center">Entrar</button>
     </form>
     <p class="mt-4 text-center text-sm text-gray-600">

--- a/login.js
+++ b/login.js
@@ -49,7 +49,6 @@ let isExpedicao = false;
 let notifUnsub = null;
 let expNotifUnsub = null;
 let updNotifUnsub = null;
-let selectedRole = null;
 window.isFinanceiroResponsavel = false;
 window.responsavelFinanceiro = null;
 
@@ -114,32 +113,12 @@ window.saveDisplayName = async () => {
 
 window.openModal = (id) => {
   const el = document.getElementById(id);
-  if (el) {
-    if (id === 'loginModal') {
-      document.getElementById('roleSelection')?.classList.remove('hidden');
-      document.getElementById('loginForm')?.classList.add('hidden');
-      selectedRole = null;
-    }
-    el.style.display = 'flex';
-  }
-};
-
-window.selectRole = (role) => {
-  selectedRole = role;
-  document.getElementById('roleSelection')?.classList.add('hidden');
-  document.getElementById('loginForm')?.classList.remove('hidden');
+  if (el) el.style.display = 'flex';
 };
 
 window.closeModal = (id) => {
   const el = document.getElementById(id);
-  if (el) {
-    el.style.display = 'none';
-    if (id === 'loginModal') {
-      document.getElementById('roleSelection')?.classList.remove('hidden');
-      document.getElementById('loginForm')?.classList.add('hidden');
-      selectedRole = null;
-    }
-  }
+  if (el) el.style.display = 'none';
 };
 
 window.openRecoverModal = () => {
@@ -151,8 +130,6 @@ window.login = () => {
   const email = document.getElementById('loginEmail').value;
   const password = document.getElementById('loginPassword').value;
   const passphrase = document.getElementById('loginPassphrase').value;
-  const roleInput = document.querySelector('input[name="userRole"]:checked');
-  const role = roleInput ? roleInput.value : selectedRole || 'usuario';
 
   setPersistence(auth, browserLocalPersistence)
     .then(() => signInWithEmailAndPassword(auth, email, password))
@@ -163,10 +140,6 @@ window.login = () => {
       showUserArea(cred.user);
       closeModal('loginModal');
       document.getElementById('loginPassphrase').value = '';
-      sessionStorage.setItem('selectedRole', role);
-      if (role === 'gestor') {
-        window.location.href = 'financeiro.html';
-      }
     })
     .catch((err) =>
       showToast('Credenciais inválidas! ' + err.message, 'error'),
@@ -250,12 +223,13 @@ async function showUserArea(user) {
     let perfil = '';
     if (snap.exists() && snap.data().perfil) {
       perfil = String(snap.data().perfil).toLowerCase().trim();
+      if (perfil === 'administrador') perfil = 'adm';
     } else {
       perfil = perfilFallback || 'usuario';
     }
     window.userPerfil = perfil;
 
-    if (perfil === 'gestor') {
+    if (['gestor', 'adm'].includes(perfil)) {
       const path = window.location.pathname.toLowerCase();
       if (
         path.endsWith('/index.html') ||

--- a/partials/auth-modals.html
+++ b/partials/auth-modals.html
@@ -12,15 +12,7 @@
       <p class="text-gray-600 mt-2">Insira suas credenciais para acessar as ferramentas</p>
     </div>
 
-    <div id="roleSelection" class="space-y-6 text-center">
-      <p class="text-gray-600">Escolha o tipo de acesso</p>
-      <div class="flex justify-center space-x-4">
-        <button onclick="selectRole('usuario')" class="btn-primary px-4 py-2">Usuário</button>
-        <button onclick="selectRole('gestor')" class="btn-primary px-4 py-2">Gestor</button>
-      </div>
-    </div>
-
-    <form id="loginForm" class="space-y-6 hidden" onsubmit="login(); return false;">
+    <form id="loginForm" class="space-y-6" onsubmit="login(); return false;">
       <div>
         <label class="block text-sm font-medium mb-2 text-gray-700">E-mail</label>
         <div class="relative">

--- a/storage.rules
+++ b/storage.rules
@@ -14,7 +14,7 @@ service firebase.storage {
       allow read: if request.auth != null && (
         autorUid == request.auth.uid ||
         (get(/databases/(default)/documents/relatorios/{relatorioId}).data.gestores != null && request.auth.uid in get(/databases/(default)/documents/relatorios/{relatorioId}).data.gestores) ||
-        get(/databases/(default)/documents/usuarios/$(request.auth.uid)).data.perfil in ['Gestor', 'ADM']
+        get(/databases/(default)/documents/usuarios/$(request.auth.uid)).data.perfil in ['Gestor', 'gestor', 'ADM', 'adm', 'Administrador', 'administrador']
       );
       allow write: if request.auth != null && autorUid == request.auth.uid;
     }
@@ -24,7 +24,7 @@ service firebase.storage {
         autorUid == request.auth.uid ||
         (get(/databases/(default)/documents/financeiroAtualizacoes/{docId}).data.destinatarios != null &&
           request.auth.uid in get(/databases/(default)/documents/financeiroAtualizacoes/{docId}).data.destinatarios) ||
-        get(/databases/(default)/documents/usuarios/$(request.auth.uid)).data.perfil in ['Gestor', 'ADM']
+        get(/databases/(default)/documents/usuarios/$(request.auth.uid)).data.perfil in ['Gestor', 'gestor', 'ADM', 'adm', 'Administrador', 'administrador']
       );
       allow write: if request.auth != null && autorUid == request.auth.uid;
     }


### PR DESCRIPTION
## Summary
- Remove manual role selection and derive access level from Firestore `usuarios` profiles
- Support `administrador`/`adm` profiles and auto-redirect managers to finance dashboard
- Allow Firestore and Storage rules to recognize admin profiles regardless of casing

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68c7ff02e4ec832a9024cb4b11545bb1