### PR TITLE
Fix admin access check for user panel

### DIFF
--- a/painel-usuarios.html
+++ b/painel-usuarios.html
@@ -101,7 +101,8 @@
           const { decryptString } = await import('./crypto.js');
           const pass = getPassphrase() || `chave-${user.uid}`;
           const data = JSON.parse(await decryptString(enc, pass));
-          if (data.perfil !== 'ADM') {
+          const perfil = String(data.perfil || '').toLowerCase();
+          if (!['adm', 'admin', 'administrador'].includes(perfil)) {
             alert('Acesso permitido apenas para administradores.');
             window.location.href = 'index.html';
           }


### PR DESCRIPTION
## Summary
- ensure admin profiles are recognized regardless of case

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c803216420832a9b49fecef8af8bb4