### PR TITLE
Allow admin profile full sidebar access

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -711,12 +711,14 @@ document.addEventListener('sidebarLoaded', async () => {
       ].includes(perfil);
       const isCliente = ['cliente', 'user', 'usuario'].includes(perfil);
 
-      if (isADM || isGestor) {
+      if (isADM) {
+        document.querySelectorAll('#sidebar .sidebar-link').forEach((a) => {
+          const li = a.closest('li') || a.parentElement;
+          if (li) li.style.display = '';
+        });
+      } else if (isGestor) {
         showOnly(ADMIN_GESTOR_MENU_IDS);
-        if (
-          isGestor &&
-          !['gestor', 'responsavel financeiro'].includes(perfil)
-        ) {
+        if (!['gestor', 'responsavel financeiro'].includes(perfil)) {
           hideIds(['menu-sku-associado']);
         }
         buildGestorSidebarLayout();


### PR DESCRIPTION
## Summary
- Permit adm users to see all sidebar menu items without restrictions
- Keep existing restrictions for gestor and client profiles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c8025125fc832abfcd9f30c8c94c97