### PR TITLE
Trim profile value before admin check in user panel

### DIFF
--- a/painel-usuarios.html
+++ b/painel-usuarios.html
@@ -101,7 +101,7 @@
           const { decryptString } = await import('./crypto.js');
           const pass = getPassphrase() || `chave-${user.uid}`;
           const data = JSON.parse(await decryptString(enc, pass));
-          const perfil = String(data.perfil || '').toLowerCase();
+          const perfil = String(data.perfil || '').toLowerCase().trim();
           if (!['adm', 'admin', 'administrador'].includes(perfil)) {
             alert('Acesso permitido apenas para administradores.');
             window.location.href = 'index.html';


### PR DESCRIPTION
## Summary
- Trim user profile string before validating admin access in painel-usuarios

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c805bb48b0832aabd6288f21a4fb8c