### PR TITLE
Fix sidebar filtering for basic and client users

### DIFF
--- a/login.js
+++ b/login.js
@@ -367,6 +367,14 @@ function applyPerfilRestrictions(perfil) {
       'menu-configuracoes',
       'menu-comunicacao',
     ],
+    cliente: [
+      'menu-vendas',
+      'menu-etiquetas',
+      'menu-precificacao',
+      'menu-expedicao',
+      'menu-configuracoes',
+      'menu-comunicacao',
+    ],
     'gestor expedicao': [
       'menu-expedicao',
       'menu-configuracoes',
@@ -406,7 +414,23 @@ function applyPerfilRestrictions(perfil) {
       .toLowerCase()
       .split(',')
       .map((p) => p.trim());
-    if (currentPerfil !== 'adm' && !allowedPerfis.includes(currentPerfil)) {
+    let show = allowedPerfis.includes(currentPerfil);
+    if (!show) {
+      if (
+        currentPerfil === 'cliente' &&
+        (allowedPerfis.includes('usuario') ||
+          allowedPerfis.includes('usuario basico') ||
+          allowedPerfis.includes('usuario completo'))
+      ) {
+        show = true;
+      } else if (
+        currentPerfil.startsWith('usuario') &&
+        allowedPerfis.includes('usuario')
+      ) {
+        show = true;
+      }
+    }
+    if (currentPerfil !== 'adm' && !show) {
       el.classList.add('hidden');
     } else {
       el.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- Include `cliente` profile in sidebar menu mapping
- Normalize sidebar permission checks so basic and client users use same layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c80b39923c832a82062eaa6df03936