### PR TITLE
Add role-based sidebar permissions

### DIFF
--- a/comunicacao.js
+++ b/comunicacao.js
@@ -150,7 +150,7 @@ function openChat(userInfo) {
 
 async function loadTeam(user, perfil, data) {
   let members = [];
-  if (['gestor', 'mentor', 'adm', 'admin', 'administrador'].includes(perfil)) {
+  if (['adm', 'completo'].includes(perfil)) {
     const lista = await fetchResponsavelFinanceiroUsuarios(db, user.email);
     members = lista.map((u) => ({
       id: u.uid,

--- a/login.js
+++ b/login.js
@@ -225,11 +225,11 @@ async function showUserArea(user) {
       perfil = String(snap.data().perfil).toLowerCase().trim();
       if (perfil === 'administrador') perfil = 'adm';
     } else {
-      perfil = perfilFallback || 'usuario';
+      perfil = perfilFallback || 'basico';
     }
     window.userPerfil = perfil;
 
-    if (['gestor', 'adm'].includes(perfil)) {
+    if (['completo', 'adm'].includes(perfil)) {
       const path = window.location.pathname.toLowerCase();
       if (
         path.endsWith('/index.html') ||
@@ -245,7 +245,7 @@ async function showUserArea(user) {
     applyPerfilRestrictions(perfil);
 
     // 2) verifica associação com expedição (gestor ou responsável)
-    if (perfil !== 'gestor expedicao') {
+    if (perfil !== 'expedicao') {
       await checkExpedicao(user);
     }
 
@@ -349,7 +349,7 @@ function restoreSidebar() {
 }
 function applyPerfilRestrictions(perfil) {
   const currentPerfil = (perfil || '').toLowerCase().trim();
-  if (!currentPerfil || currentPerfil === 'expedicao') return;
+  if (!currentPerfil) return;
   const sidebar = document.getElementById('sidebar');
   if (!sidebar) return;
 
@@ -358,8 +358,8 @@ function applyPerfilRestrictions(perfil) {
 
   const nivelMenus = {
     adm: allIds,
-    'usuario completo': allIds,
-    'usuario basico': [
+    completo: allIds,
+    basico: [
       'menu-vendas',
       'menu-etiquetas',
       'menu-precificacao',
@@ -367,32 +367,12 @@ function applyPerfilRestrictions(perfil) {
       'menu-configuracoes',
       'menu-comunicacao',
     ],
-    cliente: [
+    expedicao: ['menu-expedicao', 'menu-configuracoes', 'menu-comunicacao'],
+    financeiro: [
       'menu-vendas',
-      'menu-etiquetas',
-      'menu-precificacao',
-      'menu-expedicao',
-      'menu-configuracoes',
-      'menu-comunicacao',
-    ],
-    'gestor expedicao': [
-      'menu-expedicao',
-      'menu-configuracoes',
-      'menu-comunicacao',
-    ],
-    'responsavel financeiro': [
-      'menu-atualizacoes',
       'menu-financeiro',
       'menu-saques',
-      'menu-gestao',
-      'menu-acompanhamento-gestor',
-      'menu-mentoria',
-      'menu-perfil-mentorado',
-      'menu-equipes',
-      'menu-produtos',
-      'menu-sku-associado',
-      'menu-desempenho',
-      'menu-acompanhamento',
+      'menu-configuracoes',
       'menu-comunicacao',
     ],
   };
@@ -414,23 +394,9 @@ function applyPerfilRestrictions(perfil) {
       .toLowerCase()
       .split(',')
       .map((p) => p.trim());
-    let show = allowedPerfis.includes(currentPerfil);
+    const show =
+      allowedPerfis.includes(currentPerfil) || currentPerfil === 'adm';
     if (!show) {
-      if (
-        currentPerfil === 'cliente' &&
-        (allowedPerfis.includes('usuario') ||
-          allowedPerfis.includes('usuario basico') ||
-          allowedPerfis.includes('usuario completo'))
-      ) {
-        show = true;
-      } else if (
-        currentPerfil.startsWith('usuario') &&
-        allowedPerfis.includes('usuario')
-      ) {
-        show = true;
-      }
-    }
-    if (currentPerfil !== 'adm' && !show) {
       el.classList.add('hidden');
     } else {
       el.classList.remove('hidden');
@@ -441,11 +407,7 @@ function applyPerfilRestrictions(perfil) {
 function ensureFinanceiroMenu() {
   const menu = document.getElementById('menu-vendas');
   if (!menu) return;
-  if (
-    window.isFinanceiroResponsavel ||
-    window.userPerfil === 'responsavel' ||
-    window.userPerfil === 'gestor financeiro'
-  ) {
+  if (window.isFinanceiroResponsavel || window.userPerfil === 'financeiro') {
     menu.classList.remove('hidden');
   }
 }

--- a/monitoramento.js
+++ b/monitoramento.js
@@ -34,8 +34,7 @@ onAuthStateChanged(auth, async (user) => {
     const perfil = String(snap.data()?.perfil || '')
       .toLowerCase()
       .trim();
-    isAdmin =
-      snap.exists() && ['adm', 'admin', 'administrador'].includes(perfil);
+    isAdmin = snap.exists() && perfil === 'adm';
   } catch (err) {
     console.error('Erro ao verificar perfil do usuário:', err);
     isAdmin = false;

--- a/responsavel-financeiro.js
+++ b/responsavel-financeiro.js
@@ -54,9 +54,8 @@ export async function carregarUsuariosFinanceiros(db, user) {
         .trim()
     : '';
   const extras = await fetchResponsavelFinanceiroUsuarios(db, user.email);
-  const isResponsavelFinanceiro =
-    extras.length > 0 || ['responsavel', 'gestor financeiro'].includes(perfil);
-  const isGestor = perfil === 'gestor';
+  const isResponsavelFinanceiro = extras.length > 0 || perfil === 'financeiro';
+  const isGestor = perfil === 'completo';
   const usuarios = [
     { uid: user.uid, nome: user.displayName || user.email, email: user.email },
     ...extras,

--- a/shared.js
+++ b/shared.js
@@ -568,130 +568,64 @@ document.addEventListener('sidebarLoaded', async () => {
   const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
   const db = getFirestore(app);
 
-  const ADMIN_GESTOR_MENU_IDS = [
-    'menu-gestao',
-    'menu-financeiro',
-    'menu-atualizacoes',
-    'menu-comunicacao',
-    'menu-saques',
-    'menu-acompanhamento-gestor',
-    'menu-mentoria',
-    'menu-perfil-mentorado',
-    'menu-equipes',
-    'menu-produtos',
-    'menu-sku-associado',
-    'menu-desempenho',
-  ];
-
-  const CLIENTE_HIDDEN_MENU_IDS = ADMIN_GESTOR_MENU_IDS.filter(
-    (id) => id !== 'menu-comunicacao',
-  );
+  const ROLE_MENU_ACCESS = {
+    basico: [
+      'menu-vendas',
+      'menu-etiquetas',
+      'menu-precificacao',
+      'menu-expedicao',
+      'menu-configuracoes',
+      'menu-comunicacao',
+    ],
+    completo: [
+      'menu-gestao',
+      'menu-financeiro',
+      'menu-atualizacoes',
+      'menu-saques',
+      'menu-acompanhamento-gestor',
+      'menu-mentoria',
+      'menu-perfil-mentorado',
+      'menu-equipes',
+      'menu-produtos',
+      'menu-sku-associado',
+      'menu-desempenho',
+      'menu-vendas',
+      'menu-etiquetas',
+      'menu-precificacao',
+      'menu-marketing',
+      'menu-anuncios',
+      'menu-expedicao',
+      'menu-gestao-contas',
+      'menu-acompanhamento',
+      'menu-outros',
+      'menu-configuracoes',
+      'menu-comunicacao',
+    ],
+    expedicao: ['menu-expedicao', 'menu-configuracoes', 'menu-comunicacao'],
+    financeiro: [
+      'menu-vendas',
+      'menu-financeiro',
+      'menu-saques',
+      'menu-configuracoes',
+      'menu-comunicacao',
+    ],
+  };
 
   function showOnly(ids) {
-    document.querySelectorAll('#sidebar .sidebar-link').forEach((a) => {
-      const li = a.closest('li') || a.parentElement;
-      if (li) li.style.display = 'none';
-    });
+    document
+      .querySelectorAll('#sidebar .sidebar-menu > li')
+      .forEach((li) => (li.style.display = 'none'));
     ids.forEach((id) => {
       const el = document.getElementById(id);
-      const li = el && (el.closest('li') || el.parentElement);
+      const li = el && el.closest('li');
       if (li) li.style.display = '';
     });
   }
 
-  function hideIds(ids) {
-    ids.forEach((id) => {
-      const el = document.getElementById(id);
-      const li = el && (el.closest('li') || el.parentElement);
-      if (li) li.style.display = 'none';
-    });
-  }
-
-  function buildGestorSidebarLayout() {
-    const menu = document.querySelector('#sidebar .sidebar-menu');
-    if (!menu) return;
-
-    const getLi = (id) => {
-      const el = document.getElementById(id);
-      return el ? el.closest('li') : null;
-    };
-
-    const atualizacoes = getLi('menu-atualizacoes');
-    const financeiro = getLi('menu-financeiro');
-    const saques = getLi('menu-saques');
-    const gestao = getLi('menu-gestao');
-    const acompGestor = getLi('menu-acompanhamento-gestor');
-    const mentoria = getLi('menu-mentoria');
-    const perfilMentorado = getLi('menu-perfil-mentorado');
-    const produtos = getLi('menu-produtos');
-    const skuAssociado = getLi('menu-sku-associado');
-    const comunicacao = getLi('menu-comunicacao');
-    const equipes = getLi('menu-equipes');
-    const desempenho = getLi('menu-desempenho');
-
-    function createGroup(mainLi, submenuId, items) {
-      if (!mainLi) return null;
-      const a = mainLi.querySelector('a.sidebar-link');
-      if (!a) return null;
-
-      const div = document.createElement('div');
-      div.className = 'sidebar-item flex items-center justify-between';
-      div.appendChild(a);
-
-      const btn = document.createElement('button');
-      btn.className = 'submenu-toggle p-2';
-      btn.innerHTML =
-        '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>';
-      btn.addEventListener('click', () => toggleMenu(submenuId, btn));
-      div.appendChild(btn);
-
-      const ul = document.createElement('ul');
-      ul.id = submenuId;
-      ul.className =
-        'submenu space-y-1 overflow-hidden transition-all duration-300';
-      ul.style.maxHeight = '0';
-      items.forEach((item) => {
-        if (item) ul.appendChild(item);
-      });
-
-      mainLi.innerHTML = '';
-      mainLi.appendChild(div);
-      mainLi.appendChild(ul);
-      return mainLi;
-    }
-
-    const financeiroGroup = createGroup(financeiro, 'menuFinanceiro', [saques]);
-    const gestaoGroup = createGroup(gestao, 'menuGestao', [
-      acompGestor,
-      mentoria,
-      perfilMentorado,
-      produtos,
-      skuAssociado,
-    ]);
-    const comunicacaoGroup = createGroup(comunicacao, 'menuComunicacao', [
-      equipes,
-    ]);
-
-    menu.innerHTML = '';
-    [
-      atualizacoes,
-      financeiroGroup,
-      gestaoGroup,
-      comunicacaoGroup,
-      desempenho,
-    ].forEach((li) => {
-      if (li) {
-        li.style.display = '';
-        menu.appendChild(li);
-      }
-    });
-  }
-
-  function buildClienteSidebarLayout() {
-    const sidebar = document.getElementById('sidebar');
-    if (sidebar) {
-      sidebar.classList.add('client-layout');
-    }
+  function showAllMenus() {
+    document
+      .querySelectorAll('#sidebar .sidebar-menu > li')
+      .forEach((li) => (li.style.display = ''));
   }
 
   async function applySidebarPermissions(uid) {
@@ -701,36 +635,13 @@ document.addEventListener('sidebarLoaded', async () => {
         .trim()
         .toLowerCase();
 
-      const isADM = ['adm', 'admin', 'administrador'].includes(perfil);
-      const isGestor = [
-        'gestor',
-        'mentor',
-        'responsavel',
-        'gestor financeiro',
-        'responsavel financeiro',
-      ].includes(perfil);
-      const isCliente = ['cliente', 'user', 'usuario'].includes(perfil);
-
-      if (isADM) {
-        document.querySelectorAll('#sidebar .sidebar-link').forEach((a) => {
-          const li = a.closest('li') || a.parentElement;
-          if (li) li.style.display = '';
-        });
-      } else if (isGestor) {
-        showOnly(ADMIN_GESTOR_MENU_IDS);
-        if (!['gestor', 'responsavel financeiro'].includes(perfil)) {
-          hideIds(['menu-sku-associado']);
-        }
-        buildGestorSidebarLayout();
-      } else if (isCliente) {
-        hideIds(CLIENTE_HIDDEN_MENU_IDS);
-        document.querySelectorAll('#sidebar .sidebar-link').forEach((a) => {
-          const li = a.closest('li') || a.parentElement;
-          if (li && !CLIENTE_HIDDEN_MENU_IDS.includes(a.id))
-            li.style.display = '';
-        });
-        buildClienteSidebarLayout();
+      if (perfil === 'adm' || perfil === 'completo') {
+        showAllMenus();
+        return;
       }
+
+      const allowed = ROLE_MENU_ACCESS[perfil];
+      if (allowed) showOnly(allowed);
     } catch (e) {
       console.error('Erro ao aplicar permissões do sidebar:', e);
     }


### PR DESCRIPTION
## Summary
- define five user roles and map their allowed sidebar menus
- streamline login handling and menu filtering for new roles
- adjust role checks across communication and monitoring modules

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c80efc1980832aa3af58b027e0e6bd