### PR TITLE
fix: improve sidebar menu visibility

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -11,7 +11,7 @@
   --nav-text: #000000;
   --nav-border: #000000;
   --sidebar-bg: var(--primary);
-  --sidebar-text: #000000;
+  --sidebar-text: #ffffff;
   --sidebar-border: #000000;
   --sidebar-width: 18rem;
   --success: #4caf50;

--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -80,7 +80,7 @@ body.has-sidebar .content-wrapper {
   overflow-y: auto;
   overflow-x: hidden;
   background-color: var(--sidebar-bg);
-  color: var(--sidebar-text);
+  color: var(--sidebar-text) !important;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
   width: var(--sidebar-width);
   min-height: 100vh;
@@ -189,7 +189,6 @@ body.has-sidebar .content-wrapper {
 /* Client sidebar layout */
 .sidebar.client-layout {
   background: var(--sidebar-bg);
-  color: var(--sidebar-text);
 }
 .sidebar.client-layout .sidebar-link {
   display: flex;


### PR DESCRIPTION
## Summary
- ensure sidebar text color is white for better contrast
- enforce sidebar text color application with !important

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c82fea0380832aa9a4648554faafdd