### PR TITLE
Filtrar links do dashboard por perfil de usuário

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -568,42 +568,26 @@ document.addEventListener('sidebarLoaded', async () => {
   const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
   const db = getFirestore(app);
 
-  const ADMIN_GESTOR_MENU_IDS = [
-    'menu-gestao',
-    'menu-financeiro',
-    'menu-atualizacoes',
-    'menu-comunicacao',
-    'menu-saques',
-    'menu-acompanhamento-gestor',
-    'menu-mentoria',
-    'menu-perfil-mentorado',
-    'menu-equipes',
-    'menu-produtos',
-    'menu-sku-associado',
-    'menu-desempenho',
-  ];
-
-  const CLIENTE_HIDDEN_MENU_IDS = ADMIN_GESTOR_MENU_IDS.filter(
-    (id) => id !== 'menu-comunicacao',
-  );
-
-  function showOnly(ids) {
-    document.querySelectorAll('#sidebar .sidebar-link').forEach((a) => {
+  function filterSidebarLinks(perfil, isADM) {
+    const links = document.querySelectorAll('#sidebar .sidebar-link');
+    links.forEach((a) => {
       const li = a.closest('li') || a.parentElement;
-      if (li) li.style.display = 'none';
-    });
-    ids.forEach((id) => {
-      const el = document.getElementById(id);
-      const li = el && (el.closest('li') || el.parentElement);
-      if (li) li.style.display = '';
-    });
-  }
+      if (!li) return;
 
-  function hideIds(ids) {
-    ids.forEach((id) => {
-      const el = document.getElementById(id);
-      const li = el && (el.closest('li') || el.parentElement);
-      if (li) li.style.display = 'none';
+      if (isADM) {
+        li.style.display = '';
+        return;
+      }
+
+      const allowedAttr = a.getAttribute('data-perfil');
+      if (!allowedAttr) {
+        li.style.display = '';
+        return;
+      }
+
+      const allowed = allowedAttr.split(',').map((p) => p.trim().toLowerCase());
+
+      li.style.display = allowed.includes(perfil) ? '' : 'none';
     });
   }
 
@@ -711,26 +695,13 @@ document.addEventListener('sidebarLoaded', async () => {
       ].includes(perfil);
       const isCliente = ['cliente', 'user', 'usuario'].includes(perfil);
 
-      if (isADM) {
-        document.querySelectorAll('#sidebar .sidebar-link').forEach((a) => {
-          const li = a.closest('li') || a.parentElement;
-          if (li) li.style.display = '';
-        });
-      } else if (isGestor) {
-        showOnly(ADMIN_GESTOR_MENU_IDS);
-        if (!['gestor', 'responsavel financeiro'].includes(perfil)) {
-          hideIds(['menu-sku-associado']);
-        }
+      if (isGestor) {
         buildGestorSidebarLayout();
       } else if (isCliente) {
-        hideIds(CLIENTE_HIDDEN_MENU_IDS);
-        document.querySelectorAll('#sidebar .sidebar-link').forEach((a) => {
-          const li = a.closest('li') || a.parentElement;
-          if (li && !CLIENTE_HIDDEN_MENU_IDS.includes(a.id))
-            li.style.display = '';
-        });
         buildClienteSidebarLayout();
       }
+
+      filterSidebarLinks(perfil, isADM);
     } catch (e) {
       console.error('Erro ao aplicar permissões do sidebar:', e);
     }


### PR DESCRIPTION
## Summary
- filtra automaticamente itens do sidebar de acordo com o perfil do usuário
- reorganiza a lógica de permissões para aplicar layout e ocultar páginas não liberadas

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c83287fa6c832aa8ac4f34f6f84833