### PR TITLE
refactor: unify user profiles

### DIFF
--- a/comunicacao.js
+++ b/comunicacao.js
@@ -54,6 +54,24 @@ const PAGE_SIZE = 10;
 let lastCommDoc = null;
 const pageStack = [];
 
+function normalizePerfil(perfil) {
+  const p = (perfil || '').toLowerCase().trim();
+  if (['adm', 'admin', 'administrador'].includes(p)) return 'adm';
+  if (['usuario completo', 'usuario'].includes(p)) return 'usuario';
+  if (['usuario basico', 'cliente'].includes(p)) return 'cliente';
+  if (
+    [
+      'gestor',
+      'mentor',
+      'responsavel',
+      'gestor financeiro',
+      'responsavel financeiro',
+    ].includes(p)
+  )
+    return 'gestor';
+  return p;
+}
+
 function addUserOption(user) {
   const li = document.createElement('li');
   li.textContent = user.nome || user.email || user.id;
@@ -149,8 +167,9 @@ function openChat(userInfo) {
 }
 
 async function loadTeam(user, perfil, data) {
+  perfil = normalizePerfil(perfil);
   let members = [];
-  if (['gestor', 'mentor', 'adm', 'admin', 'administrador'].includes(perfil)) {
+  if (['gestor', 'adm'].includes(perfil)) {
     const lista = await fetchResponsavelFinanceiroUsuarios(db, user.email);
     members = lista.map((u) => ({
       id: u.uid,

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -47,7 +47,7 @@
         href="/gestor.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-gestao"
-        data-perfil="gestor,mentor"
+        data-perfil="gestor"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -71,7 +71,7 @@
         href="/financeiro.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-financeiro"
-        data-perfil="gestor,mentor"
+        data-perfil="gestor"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -95,7 +95,7 @@
         href="/atualizacoes.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-atualizacoes"
-        data-perfil="gestor,mentor"
+        data-perfil="gestor"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -119,7 +119,7 @@
         href="/saques.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-saques"
-        data-perfil="gestor,mentor"
+        data-perfil="gestor"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -143,7 +143,7 @@
         href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamentoGestor"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-acompanhamento-gestor"
-        data-perfil="gestor,mentor"
+        data-perfil="gestor"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -170,7 +170,7 @@
         href="/mentoria.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-mentoria"
-        data-perfil="gestor,mentor"
+        data-perfil="gestor"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -194,7 +194,7 @@
         href="/perfil-mentorado.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-perfil-mentorado"
-        data-perfil="gestor,mentor"
+        data-perfil="gestor"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -218,7 +218,7 @@
         href="/equipes.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-equipes"
-        data-perfil="gestor,mentor"
+        data-perfil="gestor"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -242,7 +242,7 @@
         href="/gestao-produtos.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-produtos"
-        data-perfil="gestor,mentor"
+        data-perfil="gestor"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -266,7 +266,7 @@
         href="/sku-associado.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-sku-associado"
-        data-perfil="gestor,responsavel financeiro"
+        data-perfil="gestor"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -290,7 +290,7 @@
         href="/desempenho.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-desempenho"
-        data-perfil="gestor,mentor"
+        data-perfil="gestor"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -315,7 +315,7 @@
           href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento"
           class="sidebar-link flex items-center py-2 px-4 transition-colors"
           id="menu-vendas"
-          data-perfil="usuario,gestor,mentor,responsavel,gestor financeiro"
+          data-perfil="usuario,gestor"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -393,7 +393,7 @@
         href="/saques.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-saques"
-        data-perfil="gestor,mentor"
+        data-perfil="gestor"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -418,7 +418,7 @@
           href="/etiquetas-ocr.html"
           class="sidebar-link flex items-center py-2 px-4 transition-colors"
           id="menu-etiquetas"
-          data-perfil="usuario,gestor,mentor"
+          data-perfil="usuario,gestor"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -495,7 +495,7 @@
           href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao"
           class="sidebar-link flex items-center py-2 px-4 transition-colors"
           id="menu-precificacao"
-          data-perfil="usuario,gestor,mentor"
+          data-perfil="usuario,gestor"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -547,7 +547,7 @@
           <a
             href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao"
             class="sidebar-link block py-2 px-4 transition-colors"
-            data-perfil="usuario completo,usuario basico,adm"
+            data-perfil="usuario,cliente,adm"
             >Precificação</a
           >
         </li>
@@ -555,7 +555,7 @@
           <a
             href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=lista-precos"
             class="sidebar-link block py-2 px-4 transition-colors"
-            data-perfil="usuario completo,usuario basico,adm"
+            data-perfil="usuario,cliente,adm"
             >Lista Preços</a
           >
         </li>
@@ -563,7 +563,7 @@
           <a
             href="/SISTEMA%20DE%20CUSTEIO%20DE%20PRODU%C3%87%C3%83O%20E%20PRODUTOS.html#mdf"
             class="sidebar-link block py-2 px-4 transition-colors"
-            data-perfil="usuario completo,adm"
+            data-perfil="usuario,adm"
             >Custeio de Produção</a
           >
         </li>
@@ -571,7 +571,7 @@
           <a
             href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=historico"
             class="sidebar-link block py-2 px-4 transition-colors"
-            data-perfil="usuario completo,adm"
+            data-perfil="usuario,adm"
             >Histórico</a
           >
         </li>
@@ -583,7 +583,7 @@
           href="/promocoes-shopee.html"
           class="sidebar-link flex items-center py-2 px-4 transition-colors"
           id="menu-marketing"
-          data-perfil="usuario,gestor,mentor"
+          data-perfil="usuario,gestor"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -662,7 +662,7 @@
           href="/anuncios-tabs/cadastro.html"
           class="sidebar-link flex items-center py-2 px-4 transition-colors"
           id="menu-anuncios"
-          data-perfil="usuario,gestor,mentor"
+          data-perfil="usuario,gestor"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -762,7 +762,7 @@
           href="/expedicao.html"
           class="sidebar-link flex items-center py-2 px-4 transition-colors"
           id="menu-expedicao"
-          data-perfil="usuario,gestor,mentor"
+          data-perfil="usuario,gestor"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -855,7 +855,7 @@
           href="/gestao-contas.html"
           class="sidebar-link flex items-center py-2 px-4 transition-colors"
           id="menu-gestao-contas"
-          data-perfil="usuario,gestor,mentor"
+          data-perfil="usuario,gestor"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -920,7 +920,7 @@
           href="/problemas.html"
           class="sidebar-link flex items-center py-2 px-4 transition-colors"
           id="menu-acompanhamento"
-          data-perfil="usuario,gestor,mentor,responsavel,gestor financeiro"
+          data-perfil="usuario,gestor"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -1006,7 +1006,7 @@
           href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=produtos"
           class="sidebar-link flex items-center py-2 px-4 transition-colors"
           id="menu-outros"
-          data-perfil="usuario,gestor,mentor"
+          data-perfil="usuario,gestor"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -1093,7 +1093,7 @@
           href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard"
           class="sidebar-link flex items-center py-2 px-4 transition-colors"
           id="menu-configuracoes"
-          data-perfil="usuario,gestor,mentor"
+          data-perfil="usuario,gestor"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -1185,7 +1185,7 @@
         href="/comunicacao.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-comunicacao"
-        data-perfil="cliente,usuario,gestor,mentor"
+        data-perfil="cliente,usuario,gestor"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary
- merge overlapping roles like cliente/usuario basico, usuario/usuario completo, and gestor/mentor/responsavel financeiro
- centralize profile normalization and update sidebar permissions
- streamline `data-perfil` attributes to canonical profiles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c8308eef00832abd07e30f578b7055