### PR TITLE
feat: centralize user profile loading with cache

### DIFF
--- a/configuracao-perfil.js
+++ b/configuracao-perfil.js
@@ -5,7 +5,6 @@ import {
 import {
   getFirestore,
   doc,
-  getDoc,
   setDoc,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
 import {
@@ -14,6 +13,7 @@ import {
   sendPasswordResetEmail,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 import { firebaseConfig } from './firebase-config.js';
+import { loadUserProfile } from './user-profile.js';
 
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
@@ -54,9 +54,8 @@ function renderStores(stores = []) {
 
 async function loadProfile(uid) {
   try {
-    const snap = await getDoc(doc(db, 'perfil', uid));
-    if (snap.exists()) {
-      const data = snap.data();
+    const data = await loadUserProfile(uid);
+    if (data) {
       fotoPerfilData = data.fotoPerfil || '';
       if (fotoPerfilData) {
         document.getElementById('fotoPreview').src = fotoPerfilData;

--- a/shared.js
+++ b/shared.js
@@ -556,13 +556,15 @@ document.addEventListener('sidebarLoaded', async () => {
   const [
     { initializeApp, getApps },
     { getAuth, onAuthStateChanged },
-    { getFirestore, doc, getDoc },
+    { getFirestore },
     { firebaseConfig },
+    { loadUserProfile },
   ] = await Promise.all([
     import('https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js'),
     import('https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js'),
     import('https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js'),
     import('./firebase-config.js'),
+    import('./user-profile.js'),
   ]);
 
   const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
@@ -714,14 +716,8 @@ document.addEventListener('sidebarLoaded', async () => {
 
   async function applySidebarPermissions(uid) {
     try {
-      const snap = await getDoc(doc(db, 'usuarios', uid));
-      const rawPerfil = (
-        (snap.exists() && String(snap.data().perfil || '')) ||
-        ''
-      )
-        .trim()
-        .toLowerCase();
-      const perfil = normalizePerfil(rawPerfil);
+      const profile = await loadUserProfile(uid);
+      const perfil = normalizePerfil(profile?.perfil || '');
 
       const isADM = perfil === 'adm';
       const isGestor = perfil === 'gestor';

--- a/user-profile.js
+++ b/user-profile.js
@@ -1,0 +1,53 @@
+import { db } from './firebase-config.js';
+import {
+  doc,
+  getDoc,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+
+const profileCache = {};
+
+export async function loadUserProfile(uid) {
+  if (!uid) return null;
+  if (profileCache[uid]) return profileCache[uid];
+  const key = `userProfile:${uid}`;
+  try {
+    const cached = sessionStorage.getItem(key) || localStorage.getItem(key);
+    if (cached) {
+      const obj = JSON.parse(cached);
+      profileCache[uid] = obj;
+      return obj;
+    }
+  } catch {}
+
+  const usuarioSnap = await getDoc(doc(db, 'usuarios', uid));
+  const perfilSnap = await getDoc(doc(db, 'perfil', uid));
+  const mentSnap = await getDoc(doc(db, 'perfilMentorado', uid));
+  if (!usuarioSnap.exists()) return null;
+  const usuario = usuarioSnap.data() || {};
+  const perfil = perfilSnap.exists() ? perfilSnap.data() : {};
+  const perfilMentorado = mentSnap.exists() ? mentSnap.data() : {};
+
+  const data = {
+    uid,
+    perfil: usuario.perfil || perfil.perfil || 'usuario',
+    nome: usuario.nome || perfil.nome || '',
+    email: usuario.email || perfil.email || '',
+    isAdm: !!usuario.isAdm,
+    lojas: usuario.lojas || perfil.lojas || [],
+    ...perfil,
+    perfilMentorado,
+  };
+  try {
+    sessionStorage.setItem(key, JSON.stringify(data));
+  } catch {}
+  profileCache[uid] = data;
+  return data;
+}
+
+export function clearUserProfileCache(uid) {
+  const key = `userProfile:${uid}`;
+  delete profileCache[uid];
+  try {
+    sessionStorage.removeItem(key);
+  } catch {}
+}


### PR DESCRIPTION
## Summary
- add loadUserProfile helper to unify usuario, perfil and perfilMentorado data with session storage cache
- preload user data on login and expose authUser/userProfile/userPerms
- refactor sidebar and profile pages to reuse cached profile info

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c839098a30832aa9188793f6ab903c