### PR TITLE
Fix problemas sidebar styles by loading Tailwind

### DIFF
--- a/problemas.html
+++ b/problemas.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Problemas</title>
-  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.3.5/dist/tailwind.min.css" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com/3.3.5"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/styles.css?v=20240826">

--- a/shared.js
+++ b/shared.js
@@ -42,7 +42,11 @@
 
   function loadTailwind() {
     return new Promise(function (resolve, reject) {
-      if (document.querySelector('link[href*="tailwind"]')) {
+      if (
+        document.querySelector('link[href*="tailwind"]') ||
+        document.querySelector('script[src*="cdn.tailwindcss.com"]') ||
+        window.tailwind
+      ) {
         resolve();
         return;
       }


### PR DESCRIPTION
## Summary
- load Tailwind via the CDN script on problemas.html so the sidebar utilities render correctly
- update the shared Tailwind loader to detect the CDN script and skip re-injecting the fallback stylesheet

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c84cb38530832a8007b85cd2a6db93