### PR TITLE
Centralize sidebar styling

### DIFF
--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -156,6 +156,9 @@ body.has-sidebar .content-wrapper {
 .submenu {
   padding-left: 0;
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.3s ease;
 }
 
 .submenu-link {
@@ -170,20 +173,12 @@ body.has-sidebar .content-wrapper {
   color: var(--primary-light);
 }
 
-@media print {
-  .submenu {
-    overflow: hidden;
-    max-height: 0;
-    transition: max-height 0.3s ease;
-  }
+.submenu-toggle svg {
+  transition: transform 0.3s ease;
+}
 
-  .submenu-toggle svg {
-    transition: transform 0.3s ease;
-  }
-
-  .submenu-toggle.open svg {
-    transform: rotate(180deg);
-  }
+.submenu-toggle.open svg {
+  transform: rotate(180deg);
 }
 
 /* Client sidebar layout */

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -356,7 +356,6 @@
       <ul
         id="menuVendas"
         class="submenu space-y-1 overflow-hidden transition-all duration-300"
-        style="max-height: 0"
       >
         <li>
           <a
@@ -464,7 +463,6 @@
       <ul
         id="menuEtiquetas"
         class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-        style="max-height: 0"
       >
         <li>
           <a
@@ -541,7 +539,6 @@
       <ul
         id="menuPrecificacao"
         class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-        style="max-height: 0"
       >
         <li>
           <a
@@ -624,7 +621,6 @@
       <ul
         id="menuMarketing"
         class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-        style="max-height: 0"
       >
         <li>
           <a
@@ -703,7 +699,6 @@
       <ul
         id="menuAnuncios"
         class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-        style="max-height: 0"
       >
         <li>
           <a
@@ -803,7 +798,6 @@
       <ul
         id="menuExpedicao"
         class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-        style="max-height: 0"
       >
         <li>
           <a
@@ -896,7 +890,6 @@
       <ul
         id="menuGestaoContas"
         class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-        style="max-height: 0"
       >
         <li>
           <a
@@ -961,7 +954,6 @@
       <ul
         id="menuAcompanhamento"
         class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-        style="max-height: 0"
       >
         <li>
           <a
@@ -1047,7 +1039,6 @@
       <ul
         id="menuOutros"
         class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-        style="max-height: 0"
       >
         <li>
           <a
@@ -1139,7 +1130,6 @@
       <ul
         id="menuConfiguracoes"
         class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-        style="max-height: 0"
       >
         <li>
           <a


### PR DESCRIPTION
## Summary
- move submenu collapse behaviour and arrow transitions into `css/sidebar.css`
- remove inline `max-height` attributes from sidebar partial to rely on the centralized stylesheet

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8a1015fb8832ab8e208ce842a03cf