### PR TITLE
Add shared general updates panel

### DIFF
--- a/FIRESTORE_INDEXES.md
+++ b/FIRESTORE_INDEXES.md
@@ -21,3 +21,24 @@ query(
   limit(PAGE_SIZE)
 )
 ```
+
+## Painel de Atualizações Gerais
+
+O painel consolidado utiliza um único conjunto de dados para mensagens, problemas e produtos. Cada consulta filtra pela categoria desejada e pelos participantes autorizados, ordenando pela data de criação. Crie o índice composto abaixo:
+
+- Collection: `painelAtualizacoesGerais`
+- Fields:
+  - `participantes` array-contains
+  - `categoria` ascending
+  - `createdAt` descending
+
+Esse índice atende, por exemplo, à consulta de mensagens em `painel-atualizacoes-gerais.js`:
+
+```js
+query(
+  collection(db, 'painelAtualizacoesGerais'),
+  where('categoria', '==', 'mensagem'),
+  where('participantes', 'array-contains', currentUser.uid),
+  orderBy('createdAt', 'desc')
+)
+```

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -33,6 +33,16 @@
         { "fieldPath": "timestamp", "order": "DESCENDING" },
         { "fieldPath": "__name__", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "painelAtualizacoesGerais",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "participantes", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "categoria", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -64,6 +64,16 @@ service cloud.firestore {
       allow update, delete: if request.auth != null && resource.data.autorUid == request.auth.uid;
     }
 
+    match /painelAtualizacoesGerais/{docId} {
+      allow create: if request.auth != null && request.resource.data.autorUid == request.auth.uid;
+      allow read: if request.auth != null && (
+        resource.data.autorUid == request.auth.uid ||
+        (resource.data.participantes != null && request.auth.uid in resource.data.participantes) ||
+        isGestorOrADM(request.auth.uid)
+      );
+      allow update, delete: if request.auth != null && resource.data.autorUid == request.auth.uid;
+    }
+
     match /contasfechamento/{docId} {
       allow read, write: if request.auth != null;
     }

--- a/login.js
+++ b/login.js
@@ -449,6 +449,7 @@ function applyPerfilRestrictions(perfil) {
       'menu-outros',
       'menu-configuracoes',
       'menu-comunicacao',
+      'menu-painel-atualizacoes-gerais',
     ],
     cliente: [
       'menu-vendas',
@@ -457,9 +458,11 @@ function applyPerfilRestrictions(perfil) {
       'menu-expedicao',
       'menu-configuracoes',
       'menu-comunicacao',
+      'menu-painel-atualizacoes-gerais',
     ],
     gestor: [
       'menu-atualizacoes',
+      'menu-painel-atualizacoes-gerais',
       'menu-financeiro',
       'menu-saques',
       'menu-gestao',
@@ -477,6 +480,7 @@ function applyPerfilRestrictions(perfil) {
       'menu-expedicao',
       'menu-configuracoes',
       'menu-comunicacao',
+      'menu-painel-atualizacoes-gerais',
     ],
   };
 

--- a/painel-atualizacoes-gerais.html
+++ b/painel-atualizacoes-gerais.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Painel de Atualizações Gerais</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/styles.css?v=20240826" />
+</head>
+<body class="bg-gray-100 text-gray-800">
+  <div class="app-container">
+    <div id="sidebar-container"></div>
+    <div id="navbar-container"></div>
+
+    <main class="main-content p-4 space-y-6">
+      <header class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 class="text-2xl font-bold">Painel de Atualizações Gerais</h1>
+          <p class="text-sm text-gray-600">
+            Centralize comunicados rápidos, reporte problemas dos setores e mantenha a equipe alinhada com as peças em linha.
+          </p>
+        </div>
+        <div id="painelStatus" class="text-sm text-gray-500"></div>
+      </header>
+
+      <section class="card p-5 space-y-4">
+        <div class="flex items-center justify-between flex-wrap gap-2">
+          <h2 class="text-xl font-semibold flex items-center gap-2">
+            <span class="text-blue-600"><i class="fa-solid fa-comments"></i></span>
+            Atualizações rápidas
+          </h2>
+          <span id="mensagemStatus" class="text-sm text-gray-500"></span>
+        </div>
+        <form id="formMensagem" class="space-y-3">
+          <label class="block text-sm font-medium text-gray-700" for="mensagemTexto">
+            Compartilhe uma mensagem com a sua equipe
+          </label>
+          <textarea
+            id="mensagemTexto"
+            class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            rows="3"
+            placeholder="Ex: Ajustes de preços aplicados a partir de amanhã."
+            required
+          ></textarea>
+          <div class="flex items-center justify-between text-xs text-gray-500">
+            <span id="mensagemEscopo" class="italic"></span>
+            <button
+              type="submit"
+              class="btn btn-primary text-sm px-4 py-2"
+            >Enviar mensagem</button>
+          </div>
+        </form>
+        <div>
+          <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Últimas mensagens</h3>
+          <div id="listaMensagens" class="mt-3 space-y-3"></div>
+          <p id="mensagensVazio" class="text-sm text-gray-500 hidden">
+            Nenhuma mensagem registrada até o momento.
+          </p>
+        </div>
+      </section>
+
+      <section class="card p-5 space-y-5">
+        <div class="flex items-center justify-between flex-wrap gap-2">
+          <h2 class="text-xl font-semibold flex items-center gap-2">
+            <span class="text-amber-500"><i class="fa-solid fa-triangle-exclamation"></i></span>
+            Problemas por setor
+          </h2>
+          <span id="problemaStatus" class="text-sm text-gray-500"></span>
+        </div>
+        <form id="formProblema" class="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div class="space-y-2">
+            <label for="problemaTitulo" class="text-sm font-medium text-gray-700">Descrição do problema</label>
+            <textarea
+              id="problemaTitulo"
+              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+              rows="3"
+              placeholder="Ex: Falta de matéria-prima no setor de corte"
+              required
+            ></textarea>
+          </div>
+          <div class="space-y-2">
+            <label for="problemaSolucao" class="text-sm font-medium text-gray-700">Solução (opcional)</label>
+            <textarea
+              id="problemaSolucao"
+              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+              rows="3"
+              placeholder="Ex: Solicitar reposição urgente ao fornecedor"
+            ></textarea>
+          </div>
+          <div class="space-y-2">
+            <label for="problemaSetor" class="text-sm font-medium text-gray-700">Setor</label>
+            <input
+              id="problemaSetor"
+              type="text"
+              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+              placeholder="Ex: Corte"
+              required
+            />
+          </div>
+          <div class="space-y-2">
+            <label for="problemaResponsavel" class="text-sm font-medium text-gray-700">Responsável</label>
+            <input
+              id="problemaResponsavel"
+              type="text"
+              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+              placeholder="Quem está acompanhando a resolução?"
+              required
+            />
+          </div>
+          <div class="space-y-2">
+            <label for="problemaData" class="text-sm font-medium text-gray-700">Data do registro</label>
+            <input
+              id="problemaData"
+              type="date"
+              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+              required
+            />
+          </div>
+          <div class="flex items-end">
+            <button type="submit" class="btn btn-primary text-sm px-4 py-2 w-full md:w-auto">Registrar problema</button>
+          </div>
+        </form>
+        <div>
+          <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Histórico de problemas</h3>
+          <div id="listaProblemas" class="mt-3 space-y-3"></div>
+          <p id="problemasVazio" class="text-sm text-gray-500 hidden">
+            Nenhum problema registrado.
+          </p>
+        </div>
+      </section>
+
+      <section class="card p-5 space-y-5">
+        <div class="flex items-center justify-between flex-wrap gap-2">
+          <h2 class="text-xl font-semibold flex items-center gap-2">
+            <span class="text-emerald-500"><i class="fa-solid fa-cubes"></i></span>
+            Peças em linha
+          </h2>
+          <span id="produtoStatus" class="text-sm text-gray-500"></span>
+        </div>
+        <p id="produtosAviso" class="text-sm text-gray-500 hidden">
+          Apenas gestores ou responsáveis financeiros podem cadastrar novos produtos.
+        </p>
+        <form id="formProduto" class="grid grid-cols-1 gap-4 md:grid-cols-3 hidden">
+          <div class="md:col-span-1 space-y-2">
+            <label for="produtoNome" class="text-sm font-medium text-gray-700">Produto / Peça</label>
+            <input
+              id="produtoNome"
+              type="text"
+              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              placeholder="Ex: Kit móvel 4 portas"
+              required
+            />
+          </div>
+          <div class="md:col-span-2 space-y-2">
+            <label for="produtoObs" class="text-sm font-medium text-gray-700">Observações (opcional)</label>
+            <textarea
+              id="produtoObs"
+              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              rows="2"
+              placeholder="Detalhes sobre estoque, priorização ou datas"
+            ></textarea>
+          </div>
+          <div class="md:col-span-3 flex justify-end">
+            <button type="submit" class="btn btn-primary text-sm px-4 py-2">Adicionar produto</button>
+          </div>
+        </form>
+        <div>
+          <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Produtos cadastrados</h3>
+          <div id="listaProdutos" class="mt-3 space-y-3"></div>
+          <p id="produtosVazio" class="text-sm text-gray-500 hidden">
+            Nenhum produto em linha cadastrado até o momento.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';
+      window.CUSTOM_NAVBAR_PATH = '/partials/navbar.html';
+    </script>
+    <script src="shared.js"></script>
+    <script type="module" src="firebase-config.js"></script>
+    <script type="module" src="painel-atualizacoes-gerais.js"></script>
+  </div>
+</body>
+</html>

--- a/painel-atualizacoes-gerais.js
+++ b/painel-atualizacoes-gerais.js
@@ -1,0 +1,747 @@
+import {
+  initializeApp,
+  getApps,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import {
+  getFirestore,
+  collection,
+  collectionGroup,
+  doc,
+  addDoc,
+  getDoc,
+  getDocs,
+  onSnapshot,
+  query,
+  where,
+  orderBy,
+  limit,
+  serverTimestamp,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import {
+  getAuth,
+  onAuthStateChanged,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { firebaseConfig } from './firebase-config.js';
+import { carregarUsuariosFinanceiros } from './responsavel-financeiro.js';
+
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+const db = getFirestore(app);
+const auth = getAuth(app);
+
+const formMensagem = document.getElementById('formMensagem');
+const formProblema = document.getElementById('formProblema');
+const formProduto = document.getElementById('formProduto');
+const mensagemInput = document.getElementById('mensagemTexto');
+const problemaTituloInput = document.getElementById('problemaTitulo');
+const problemaSolucaoInput = document.getElementById('problemaSolucao');
+const problemaSetorInput = document.getElementById('problemaSetor');
+const problemaResponsavelInput = document.getElementById('problemaResponsavel');
+const problemaDataInput = document.getElementById('problemaData');
+const produtoNomeInput = document.getElementById('produtoNome');
+const produtoObsInput = document.getElementById('produtoObs');
+
+const listaMensagensEl = document.getElementById('listaMensagens');
+const listaProblemasEl = document.getElementById('listaProblemas');
+const listaProdutosEl = document.getElementById('listaProdutos');
+const mensagensVazioEl = document.getElementById('mensagensVazio');
+const problemasVazioEl = document.getElementById('problemasVazio');
+const produtosVazioEl = document.getElementById('produtosVazio');
+const mensagemStatusEl = document.getElementById('mensagemStatus');
+const problemaStatusEl = document.getElementById('problemaStatus');
+const produtoStatusEl = document.getElementById('produtoStatus');
+const painelStatusEl = document.getElementById('painelStatus');
+const produtosAvisoEl = document.getElementById('produtosAviso');
+const mensagemEscopoEl = document.getElementById('mensagemEscopo');
+
+let currentUser = null;
+let participantesCompartilhamento = [];
+let mensagensUnsub = null;
+let problemasUnsub = null;
+let produtosUnsub = null;
+let nomeResponsavel = '';
+
+function setStatus(element, message = '', isError = false) {
+  if (!element) return;
+  element.textContent = message;
+  element.classList.toggle('text-red-600', Boolean(message) && isError);
+  element.classList.toggle('text-gray-500', !isError);
+}
+
+function showTemporaryStatus(
+  element,
+  message,
+  isError = false,
+  timeout = 5000,
+) {
+  if (!element) return;
+  setStatus(element, message, isError);
+  if (message) {
+    setTimeout(() => {
+      if (element.textContent === message) {
+        setStatus(element, '');
+      }
+    }, timeout);
+  }
+}
+
+function formatDate(value, includeTime = true) {
+  if (!value) return '';
+  let date = null;
+  if (value.toDate) {
+    try {
+      date = value.toDate();
+    } catch (_) {
+      date = null;
+    }
+  } else if (value instanceof Date) {
+    date = value;
+  } else if (typeof value === 'string') {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.valueOf())) {
+      date = parsed;
+    }
+  }
+  if (!date) return '';
+  return includeTime
+    ? date.toLocaleString('pt-BR', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    : date.toLocaleDateString('pt-BR');
+}
+
+async function montarEscopoCompartilhamento(user) {
+  const participantes = new Set();
+  const emails = new Set();
+  const equipesParaInspecionar = new Set();
+
+  const addUid = (uid) => {
+    if (uid && typeof uid === 'string') {
+      participantes.add(uid);
+    }
+  };
+
+  const addEmail = (email) => {
+    if (!email) return;
+    const normalized = String(email).trim().toLowerCase();
+    if (normalized) emails.add(normalized);
+  };
+
+  addUid(user.uid);
+  if (user.email) addEmail(user.email);
+
+  const usuarioDoc = await getDoc(doc(db, 'usuarios', user.uid));
+  const usuarioData = usuarioDoc.exists() ? usuarioDoc.data() : {};
+  const uidDoc = await getDoc(doc(db, 'uid', user.uid));
+  const uidData = uidDoc.exists() ? uidDoc.data() : {};
+  const perfil = usuarioData.perfil || uidData.perfil || '';
+
+  const coletarDadosCompartilhamento = (data) => {
+    if (!data || typeof data !== 'object') return;
+    const uidFields = [
+      'responsavelFinanceiroUid',
+      'responsavelExpedicaoUid',
+      'gestorUid',
+      'gestoresFinanceirosUids',
+      'gestoresExpedicaoUids',
+      'equipeUids',
+      'equipesUids',
+      'timeUids',
+    ];
+    uidFields.forEach((field) => {
+      const value = data[field];
+      if (!value) return;
+      if (Array.isArray(value)) value.forEach(addUid);
+      else addUid(value);
+    });
+
+    const emailFields = [
+      'responsavelFinanceiroEmail',
+      'responsavelExpedicaoEmail',
+      'gestorEmail',
+      'gestoresFinanceirosEmails',
+      'gestoresExpedicaoEmails',
+      'equipeEmails',
+      'equipesEmails',
+      'timeEmails',
+      'teamEmails',
+      'responsaveisEquipeEmails',
+      'usuariosEquipeEmails',
+    ];
+    emailFields.forEach((field) => {
+      const value = data[field];
+      if (!value) return;
+      if (Array.isArray(value)) value.forEach(addEmail);
+      else addEmail(value);
+    });
+
+    if (Array.isArray(data.equipe)) {
+      data.equipe.forEach((item) => {
+        if (item?.email) addEmail(item.email);
+        if (item?.uid) addUid(item.uid);
+      });
+    }
+    if (Array.isArray(data.team)) {
+      data.team.forEach((item) => {
+        if (item?.email) addEmail(item.email);
+        if (item?.uid) addUid(item.uid);
+      });
+    }
+  };
+
+  const adicionarMembrosEquipe = async (ownerUid) => {
+    if (!ownerUid) return;
+    try {
+      const membrosRef = collection(
+        db,
+        'artifacts',
+        'equipes',
+        'users',
+        ownerUid,
+        'members',
+      );
+      const membrosSnap = await getDocs(membrosRef);
+      membrosSnap.forEach((docSnap) => {
+        const data = docSnap.data() || {};
+        if (data.email) addEmail(data.email);
+        if (data.uid) addUid(data.uid);
+      });
+    } catch (err) {
+      console.error('Erro ao carregar membros da equipe:', err);
+    }
+
+    try {
+      const expRef = collection(db, 'uid', ownerUid, 'expedicaoTeam');
+      const expSnap = await getDocs(expRef);
+      expSnap.forEach((docSnap) => {
+        const data = docSnap.data() || {};
+        if (data.email) addEmail(data.email);
+        if (data.uid) addUid(data.uid);
+      });
+    } catch (err) {
+      console.error('Erro ao carregar equipe de expedição:', err);
+    }
+  };
+
+  coletarDadosCompartilhamento(usuarioData);
+  coletarDadosCompartilhamento(uidData);
+  await adicionarMembrosEquipe(user.uid);
+
+  const meuEmail = user.email ? user.email.toLowerCase() : '';
+  if (meuEmail) {
+    try {
+      const consultas = [
+        getDocs(
+          query(
+            collection(db, 'usuarios'),
+            where('responsavelFinanceiroEmail', '==', meuEmail),
+          ),
+        ),
+        getDocs(
+          query(
+            collection(db, 'usuarios'),
+            where('responsavelExpedicaoEmail', '==', meuEmail),
+          ),
+        ),
+        getDocs(
+          query(
+            collection(db, 'usuarios'),
+            where('gestoresFinanceirosEmails', 'array-contains', meuEmail),
+          ),
+        ),
+        getDocs(
+          query(
+            collection(db, 'usuarios'),
+            where('gestoresExpedicaoEmails', 'array-contains', meuEmail),
+          ),
+        ),
+      ];
+      const resultados = await Promise.all(consultas);
+      resultados.forEach((snap) => {
+        snap.forEach((docSnap) => {
+          addUid(docSnap.id);
+          coletarDadosCompartilhamento(docSnap.data());
+        });
+      });
+    } catch (err) {
+      console.error(
+        'Erro ao localizar usuários vinculados ao seu e-mail:',
+        err,
+      );
+    }
+
+    try {
+      const membrosSnap = await getDocs(
+        query(collectionGroup(db, 'members'), where('email', '==', meuEmail)),
+      );
+      membrosSnap.forEach((docSnap) => {
+        const pathSegments = docSnap.ref.path.split('/');
+        const usersIndex = pathSegments.indexOf('users');
+        if (usersIndex >= 0 && usersIndex + 1 < pathSegments.length) {
+          const ownerUid = pathSegments[usersIndex + 1];
+          addUid(ownerUid);
+          equipesParaInspecionar.add(ownerUid);
+        }
+      });
+    } catch (err) {
+      console.error('Erro ao localizar equipes que incluem o usuário:', err);
+    }
+  }
+
+  for (const ownerUid of equipesParaInspecionar) {
+    await adicionarMembrosEquipe(ownerUid);
+  }
+
+  const adicionarUidsPorEmails = async () => {
+    const processados = new Set();
+    let pendentes = Array.from(emails).filter(
+      (email) => email && !processados.has(email),
+    );
+    while (pendentes.length) {
+      const lote = pendentes.slice(0, 10);
+      try {
+        const snap = await getDocs(
+          query(collection(db, 'usuarios'), where('email', 'in', lote)),
+        );
+        const encontrados = new Set();
+        snap.forEach((docSnap) => {
+          addUid(docSnap.id);
+          const data = docSnap.data() || {};
+          const email = (data.email || '').toLowerCase();
+          if (email) encontrados.add(email);
+          coletarDadosCompartilhamento(data);
+        });
+        for (const email of lote) {
+          processados.add(email);
+        }
+        const faltantes = lote.filter((email) => !encontrados.has(email));
+        for (const email of faltantes) {
+          try {
+            const altSnap = await getDocs(
+              query(collection(db, 'uid'), where('email', '==', email)),
+            );
+            altSnap.forEach((docSnap) => {
+              addUid(docSnap.id);
+              coletarDadosCompartilhamento(docSnap.data());
+            });
+          } catch (err) {
+            console.error('Erro ao buscar UID pelo e-mail:', err);
+          }
+        }
+      } catch (err) {
+        console.error('Erro ao mapear e-mails para usuários:', err);
+        for (const email of lote) {
+          processados.add(email);
+        }
+      }
+      pendentes = Array.from(emails).filter(
+        (email) => email && !processados.has(email),
+      );
+    }
+  };
+
+  await adicionarUidsPorEmails();
+
+  return { participantes: Array.from(participantes), perfil };
+}
+
+function atualizarEscopoMensagem(participantes) {
+  if (!mensagemEscopoEl) return;
+  if (!participantes || participantes.length === 0) {
+    mensagemEscopoEl.textContent = '';
+    return;
+  }
+  const quantidade = participantes.length;
+  mensagemEscopoEl.textContent = `Compartilhado com ${quantidade} integrante${
+    quantidade > 1 ? 's' : ''
+  } da equipe.`;
+}
+
+function renderMensagem(docSnap) {
+  const data = docSnap.data() || {};
+  const item = document.createElement('article');
+  item.className = 'bg-white border border-blue-100 rounded-lg p-3 shadow-sm';
+
+  const header = document.createElement('div');
+  header.className = 'flex items-center justify-between text-xs text-gray-500';
+
+  const dataEl = document.createElement('span');
+  dataEl.textContent = formatDate(data.createdAt, true) || '—';
+  const respEl = document.createElement('span');
+  respEl.className = 'font-medium text-gray-600';
+  respEl.textContent =
+    data.responsavelNome || data.autorNome || 'Responsável não informado';
+
+  header.appendChild(dataEl);
+  header.appendChild(respEl);
+
+  const corpo = document.createElement('p');
+  corpo.className = 'mt-2 text-sm text-gray-700 whitespace-pre-line';
+  corpo.textContent = data.texto || '';
+
+  item.appendChild(header);
+  item.appendChild(corpo);
+  return item;
+}
+
+function renderProblema(docSnap) {
+  const data = docSnap.data() || {};
+  const card = document.createElement('article');
+  card.className = 'bg-white border border-amber-100 rounded-lg p-3 shadow-sm';
+
+  const header = document.createElement('div');
+  header.className =
+    'flex flex-wrap items-center justify-between gap-2 text-xs text-gray-500';
+
+  const setorEl = document.createElement('span');
+  setorEl.className = 'font-semibold text-gray-700';
+  setorEl.textContent = data.setor
+    ? `Setor: ${data.setor}`
+    : 'Setor não informado';
+
+  const responsavelEl = document.createElement('span');
+  responsavelEl.textContent = data.responsavel
+    ? `Responsável: ${data.responsavel}`
+    : 'Responsável não informado';
+
+  const dataOcorrenciaEl = document.createElement('span');
+  dataOcorrenciaEl.textContent = data.dataOcorrencia
+    ? `Data: ${formatDate(data.dataOcorrencia, false)}`
+    : '';
+
+  header.appendChild(setorEl);
+  header.appendChild(responsavelEl);
+  if (dataOcorrenciaEl.textContent) header.appendChild(dataOcorrenciaEl);
+
+  const descricao = document.createElement('p');
+  descricao.className = 'mt-2 text-sm text-gray-700 whitespace-pre-line';
+  descricao.textContent = data.problema || '';
+
+  card.appendChild(header);
+  card.appendChild(descricao);
+
+  if (data.solucao) {
+    const solucao = document.createElement('p');
+    solucao.className =
+      'mt-2 text-xs text-gray-600 bg-amber-50 border border-amber-100 rounded p-2';
+    solucao.textContent = `Solução: ${data.solucao}`;
+    card.appendChild(solucao);
+  }
+
+  const rodape = document.createElement('div');
+  rodape.className = 'mt-2 text-[11px] text-gray-400 flex justify-between';
+  const autor = document.createElement('span');
+  autor.textContent = data.autorNome ? `Registrado por ${data.autorNome}` : '';
+  const createdAt = document.createElement('span');
+  createdAt.textContent = data.createdAt
+    ? `Registro: ${formatDate(data.createdAt, true)}`
+    : '';
+  if (autor.textContent) rodape.appendChild(autor);
+  if (createdAt.textContent) rodape.appendChild(createdAt);
+  if (rodape.childElementCount) card.appendChild(rodape);
+
+  return card;
+}
+
+function renderProduto(docSnap) {
+  const data = docSnap.data() || {};
+  const card = document.createElement('article');
+  card.className =
+    'bg-white border border-emerald-100 rounded-lg p-3 shadow-sm';
+
+  const header = document.createElement('div');
+  header.className = 'flex items-center justify-between text-sm text-gray-700';
+  const nomeEl = document.createElement('span');
+  nomeEl.className = 'font-semibold';
+  nomeEl.textContent = data.nome || 'Produto sem nome';
+  const autorEl = document.createElement('span');
+  autorEl.className = 'text-xs text-gray-500';
+  autorEl.textContent = data.autorNome ? `Por ${data.autorNome}` : '';
+  header.appendChild(nomeEl);
+  header.appendChild(autorEl);
+  card.appendChild(header);
+
+  if (data.observacoes) {
+    const obs = document.createElement('p');
+    obs.className = 'mt-2 text-sm text-gray-600 whitespace-pre-line';
+    obs.textContent = data.observacoes;
+    card.appendChild(obs);
+  }
+
+  const dataCriacao = document.createElement('p');
+  dataCriacao.className = 'mt-2 text-[11px] text-gray-400';
+  dataCriacao.textContent = data.createdAt
+    ? `Atualizado em ${formatDate(data.createdAt, true)}`
+    : '';
+  card.appendChild(dataCriacao);
+
+  return card;
+}
+
+function carregarMensagens() {
+  if (!currentUser) return;
+  mensagensUnsub?.();
+  const mensagensRef = query(
+    collection(db, 'painelAtualizacoesGerais'),
+    where('categoria', '==', 'mensagem'),
+    where('participantes', 'array-contains', currentUser.uid),
+    orderBy('createdAt', 'desc'),
+    limit(10),
+  );
+  mensagensUnsub = onSnapshot(
+    mensagensRef,
+    (snap) => {
+      listaMensagensEl.innerHTML = '';
+      if (snap.empty) {
+        mensagensVazioEl?.classList.remove('hidden');
+        return;
+      }
+      mensagensVazioEl?.classList.add('hidden');
+      const frag = document.createDocumentFragment();
+      snap.forEach((docSnap) => {
+        frag.appendChild(renderMensagem(docSnap));
+      });
+      listaMensagensEl.appendChild(frag);
+    },
+    (err) => {
+      console.error('Erro ao carregar mensagens:', err);
+      mensagensVazioEl?.classList.remove('hidden');
+    },
+  );
+}
+
+function carregarProblemas() {
+  if (!currentUser) return;
+  problemasUnsub?.();
+  const problemasRef = query(
+    collection(db, 'painelAtualizacoesGerais'),
+    where('categoria', '==', 'problema'),
+    where('participantes', 'array-contains', currentUser.uid),
+    orderBy('createdAt', 'desc'),
+    limit(25),
+  );
+  problemasUnsub = onSnapshot(
+    problemasRef,
+    (snap) => {
+      listaProblemasEl.innerHTML = '';
+      if (snap.empty) {
+        problemasVazioEl?.classList.remove('hidden');
+        return;
+      }
+      problemasVazioEl?.classList.add('hidden');
+      const frag = document.createDocumentFragment();
+      snap.forEach((docSnap) => frag.appendChild(renderProblema(docSnap)));
+      listaProblemasEl.appendChild(frag);
+    },
+    (err) => {
+      console.error('Erro ao carregar problemas:', err);
+      problemasVazioEl?.classList.remove('hidden');
+    },
+  );
+}
+
+function carregarProdutos() {
+  if (!currentUser) return;
+  produtosUnsub?.();
+  const produtosRef = query(
+    collection(db, 'painelAtualizacoesGerais'),
+    where('categoria', '==', 'produto'),
+    where('participantes', 'array-contains', currentUser.uid),
+    orderBy('createdAt', 'desc'),
+  );
+  produtosUnsub = onSnapshot(
+    produtosRef,
+    (snap) => {
+      listaProdutosEl.innerHTML = '';
+      if (snap.empty) {
+        produtosVazioEl?.classList.remove('hidden');
+        return;
+      }
+      produtosVazioEl?.classList.add('hidden');
+      const itens = [];
+      snap.forEach((docSnap) => itens.push(docSnap));
+      itens
+        .sort((a, b) => {
+          const nomeA = (a.data()?.nome || '').toLowerCase();
+          const nomeB = (b.data()?.nome || '').toLowerCase();
+          if (nomeA < nomeB) return -1;
+          if (nomeA > nomeB) return 1;
+          return 0;
+        })
+        .forEach((docSnap) =>
+          listaProdutosEl.appendChild(renderProduto(docSnap)),
+        );
+    },
+    (err) => {
+      console.error('Erro ao carregar produtos:', err);
+      produtosVazioEl?.classList.remove('hidden');
+    },
+  );
+}
+
+async function enviarMensagem(event) {
+  event.preventDefault();
+  if (!currentUser) return;
+  const texto = mensagemInput?.value.trim();
+  if (!texto) {
+    showTemporaryStatus(
+      mensagemStatusEl,
+      'Digite uma mensagem antes de enviar.',
+      true,
+    );
+    return;
+  }
+  try {
+    await addDoc(collection(db, 'painelAtualizacoesGerais'), {
+      categoria: 'mensagem',
+      texto,
+      autorUid: currentUser.uid,
+      autorNome: nomeResponsavel,
+      responsavelUid: currentUser.uid,
+      responsavelNome: nomeResponsavel,
+      participantes: participantesCompartilhamento,
+      createdAt: serverTimestamp(),
+    });
+    mensagemInput.value = '';
+    showTemporaryStatus(
+      mensagemStatusEl,
+      'Mensagem compartilhada com a equipe.',
+    );
+  } catch (err) {
+    console.error('Erro ao enviar mensagem:', err);
+    showTemporaryStatus(
+      mensagemStatusEl,
+      'Não foi possível registrar a mensagem. Tente novamente.',
+      true,
+    );
+  }
+}
+
+async function registrarProblema(event) {
+  event.preventDefault();
+  if (!currentUser) return;
+  const problema = problemaTituloInput?.value.trim();
+  const solucao = problemaSolucaoInput?.value.trim();
+  const setor = problemaSetorInput?.value.trim();
+  const responsavel = problemaResponsavelInput?.value.trim();
+  const dataOcorrencia = problemaDataInput?.value;
+  if (!problema || !setor || !responsavel || !dataOcorrencia) {
+    showTemporaryStatus(
+      problemaStatusEl,
+      'Preencha todos os campos obrigatórios para registrar o problema.',
+      true,
+    );
+    return;
+  }
+  try {
+    await addDoc(collection(db, 'painelAtualizacoesGerais'), {
+      categoria: 'problema',
+      problema,
+      solucao: solucao || '',
+      setor,
+      responsavel,
+      dataOcorrencia,
+      autorUid: currentUser.uid,
+      autorNome: nomeResponsavel,
+      participantes: participantesCompartilhamento,
+      createdAt: serverTimestamp(),
+    });
+    formProblema.reset();
+    showTemporaryStatus(problemaStatusEl, 'Problema registrado com sucesso.');
+  } catch (err) {
+    console.error('Erro ao registrar problema:', err);
+    showTemporaryStatus(
+      problemaStatusEl,
+      'Não foi possível salvar o problema. Tente novamente.',
+      true,
+    );
+  }
+}
+
+async function registrarProduto(event) {
+  event.preventDefault();
+  if (!currentUser) return;
+  const nome = produtoNomeInput?.value.trim();
+  const observacoes = produtoObsInput?.value.trim();
+  if (!nome) {
+    showTemporaryStatus(
+      produtoStatusEl,
+      'Informe o nome do produto para concluir o cadastro.',
+      true,
+    );
+    return;
+  }
+  try {
+    await addDoc(collection(db, 'painelAtualizacoesGerais'), {
+      categoria: 'produto',
+      nome,
+      observacoes: observacoes || '',
+      autorUid: currentUser.uid,
+      autorNome: nomeResponsavel,
+      participantes: participantesCompartilhamento,
+      createdAt: serverTimestamp(),
+    });
+    formProduto?.reset();
+    showTemporaryStatus(produtoStatusEl, 'Produto cadastrado com sucesso.');
+  } catch (err) {
+    console.error('Erro ao cadastrar produto:', err);
+    showTemporaryStatus(
+      produtoStatusEl,
+      'Não foi possível cadastrar o produto. Tente novamente.',
+      true,
+    );
+  }
+}
+
+formMensagem?.addEventListener('submit', enviarMensagem);
+formProblema?.addEventListener('submit', registrarProblema);
+formProduto?.addEventListener('submit', registrarProduto);
+
+onAuthStateChanged(auth, async (user) => {
+  if (!user) {
+    window.location.href = 'index.html?login=1';
+    return;
+  }
+  currentUser = user;
+  nomeResponsavel = user.displayName || user.email || 'Usuário';
+  setStatus(painelStatusEl, 'Carregando configurações da equipe...');
+  try {
+    const { participantes } = await montarEscopoCompartilhamento(user);
+    participantesCompartilhamento = participantes.length
+      ? participantes
+      : [user.uid];
+    atualizarEscopoMensagem(participantesCompartilhamento);
+    setStatus(painelStatusEl, '');
+
+    try {
+      const { isGestor, isResponsavelFinanceiro } =
+        await carregarUsuariosFinanceiros(db, user);
+      const podeGerirProdutos = isGestor || isResponsavelFinanceiro;
+      if (podeGerirProdutos) {
+        formProduto?.classList.remove('hidden');
+        produtosAvisoEl?.classList.add('hidden');
+      } else {
+        formProduto?.classList.add('hidden');
+        produtosAvisoEl?.classList.remove('hidden');
+      }
+    } catch (err) {
+      console.error('Erro ao verificar permissões financeiras:', err);
+      formProduto?.classList.add('hidden');
+      produtosAvisoEl?.classList.remove('hidden');
+    }
+
+    carregarMensagens();
+    carregarProblemas();
+    carregarProdutos();
+  } catch (err) {
+    console.error('Erro ao preparar painel de atualizações gerais:', err);
+    setStatus(
+      painelStatusEl,
+      'Não foi possível carregar o compartilhamento da equipe.',
+      true,
+    );
+  }
+});

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -116,6 +116,29 @@
     </li>
     <li>
       <a
+        href="/painel-atualizacoes-gerais.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-painel-atualizacoes-gerais"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M8.25 4.5h-2.5A1.75 1.75 0 0 0 4 6.25v11.5A1.75 1.75 0 0 0 5.75 19.5h12.5A1.75 1.75 0 0 0 20 17.75V9.75a1.75 1.75 0 0 0-1.75-1.75h-5.5a1.75 1.75 0 0 1-1.75-1.75v-1.75A1.75 1.75 0 0 0 9.25 3H8.25m0 0V4.5m0-1.5h3"
+          />
+        </svg>
+        <span class="link-text">Painel Atualizações</span>
+      </a>
+    </li>
+    <li>
+      <a
         href="/saques.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-saques"

--- a/shared.js
+++ b/shared.js
@@ -578,6 +578,7 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-gestao',
     'menu-financeiro',
     'menu-atualizacoes',
+    'menu-painel-atualizacoes-gerais',
     'menu-comunicacao',
     'menu-saques',
     'menu-acompanhamento-gestor',
@@ -590,7 +591,8 @@ document.addEventListener('sidebarLoaded', async () => {
   ];
 
   const CLIENTE_HIDDEN_MENU_IDS = ADMIN_GESTOR_MENU_IDS.filter(
-    (id) => id !== 'menu-comunicacao',
+    (id) =>
+      !['menu-comunicacao', 'menu-painel-atualizacoes-gerais'].includes(id),
   );
 
   function showOnly(ids) {
@@ -634,6 +636,7 @@ document.addEventListener('sidebarLoaded', async () => {
     const comunicacao = getLi('menu-comunicacao');
     const equipes = getLi('menu-equipes');
     const desempenho = getLi('menu-desempenho');
+    const painelAtualizacoes = getLi('menu-painel-atualizacoes-gerais');
 
     function createGroup(mainLi, submenuId, items) {
       if (!mainLi) return null;
@@ -681,6 +684,7 @@ document.addEventListener('sidebarLoaded', async () => {
     menu.innerHTML = '';
     [
       atualizacoes,
+      painelAtualizacoes,
       financeiroGroup,
       gestaoGroup,
       comunicacaoGroup,


### PR DESCRIPTION
## Summary
- add the Painel de Atualizações Gerais page with messaging, problemas e produtos boards for the whole equipe
- implement Firestore logic so updates are shared with responsáveis financeiros, gestores de expedição e membros configurados
- expose the new tab to todos os perfis, update permissões do sidebar e documentar os novos índices e regras do Firestore

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8a9615bd8832aaa3d6089b004b535