### PR TITLE
Atualiza contagem da expedição com etiquetasResumo

### DIFF
--- a/expedicao.html
+++ b/expedicao.html
@@ -117,7 +117,14 @@
       <div class="overflow-y-auto max-h-96">
           <table class="min-w-full text-sm">
             <thead>
-              <tr><th class="p-2 border">Pedido</th><th class="p-2 border">Loja</th><th class="p-2 border">SKU</th><th class="p-2 border">Data</th><th class="p-2 border">Usuário</th></tr>
+              <tr>
+                <th class="p-2 border">Intervalo</th>
+                <th class="p-2 border">SKU</th>
+                <th class="p-2 border">Quantidade</th>
+                <th class="p-2 border">Arquivo</th>
+                <th class="p-2 border">Data</th>
+                <th class="p-2 border">Usuário</th>
+              </tr>
             </thead>
             <tbody id="checklistBody"></tbody>
           </table>
@@ -165,6 +172,112 @@
     let attentionOnly = false;
     const equipeUsuarios = new Map();
     let checklistRows = [];
+
+    function getResumoTimeWindow() {
+      const now = new Date();
+      const end = new Date(now);
+      end.setHours(15, 20, 0, 0);
+      const start = new Date(end);
+      start.setDate(start.getDate() - 1);
+      start.setHours(15, 30, 0, 0);
+      return { start, end };
+    }
+
+    async function getAllowedUserUids() {
+      if (!currentUser) return [];
+      const allowed = new Set([currentUser.uid]);
+      if (!isResponsavel) return Array.from(allowed);
+      try {
+        const [snap1, snap2] = await Promise.all([
+          db
+            .collection('uid')
+            .where('gestoresExpedicaoEmails', 'array-contains', currentUser.email)
+            .get(),
+          db
+            .collection('uid')
+            .where('responsavelExpedicaoEmail', '==', currentUser.email)
+            .get()
+        ]);
+        snap1.forEach(docu => allowed.add(docu.id));
+        snap2.forEach(docu => allowed.add(docu.id));
+      } catch (err) {
+        console.error('Erro ao buscar usuários permitidos:', err);
+      }
+      return Array.from(allowed);
+    }
+
+    async function fetchResumoDocsForUsers(uids, start, end) {
+      if (!uids || !uids.length) return [];
+      const queries = uids.map(uid =>
+        db
+          .collection('users')
+          .doc(uid)
+          .collection('etiquetasResumo')
+          .orderBy('createdAt', 'asc')
+          .where('createdAt', '>=', start)
+          .get()
+          .then(snap => ({ uid, snap }))
+          .catch(err => {
+            console.error(`Erro ao carregar resumo de etiquetas do usuário ${uid}:`, err);
+            return null;
+          })
+      );
+      const snapshots = await Promise.all(queries);
+      const docs = [];
+      snapshots.forEach(result => {
+        if (!result || !result.snap) return;
+        result.snap.forEach(docSnap => {
+          const data = docSnap.data() || {};
+          const ownerUid = data.ownerUid || result.uid;
+          if (ownerUid !== result.uid) return;
+          let createdAt = null;
+          if (data.createdAt && typeof data.createdAt.toDate === 'function') {
+            createdAt = data.createdAt.toDate();
+          } else if (docSnap.createTime && typeof docSnap.createTime.toDate === 'function') {
+            createdAt = docSnap.createTime.toDate();
+          }
+          if (createdAt && createdAt > end) return;
+          docs.push({ ownerUid, data, docId: docSnap.id, createdAt });
+        });
+      });
+      return docs;
+    }
+
+    function getResumoQuantidade(data) {
+      if (!data) return 0;
+      const totais = Array.isArray(data.totaisPorSku) ? data.totaisPorSku : [];
+      let somaTotais = 0;
+      for (const item of totais) {
+        const valor = Number(item?.quantidade);
+        if (Number.isFinite(valor)) somaTotais += valor;
+      }
+      if (somaTotais > 0) return somaTotais;
+      const paginas = Array.isArray(data.paginas) ? data.paginas : [];
+      let somaPaginas = 0;
+      for (const pag of paginas) {
+        const valor = Number(pag?.quantidade);
+        if (Number.isFinite(valor)) somaPaginas += valor;
+      }
+      if (somaPaginas > 0) return somaPaginas;
+      if (Number.isFinite(data.totalPaginas)) return Number(data.totalPaginas);
+      if (paginas.length) return paginas.length;
+      return 0;
+    }
+
+    function formatResumoRangeLabel(data, paginas, docId) {
+      const inicio = Number.isFinite(data?.contadorInicial) ? Number(data.contadorInicial) : null;
+      const fim = Number.isFinite(data?.contadorFinal) ? Number(data.contadorFinal) : null;
+      if (inicio != null && fim != null) {
+        return inicio === fim ? `${inicio}` : `${inicio} - ${fim}`;
+      }
+      if (inicio != null) return `${inicio}`;
+      if (fim != null) return `${fim}`;
+      if (Array.isArray(paginas) && paginas.length === 1) {
+        const numero = paginas[0]?.numero;
+        if (Number.isFinite(numero)) return `${numero}`;
+      }
+      return data?.arquivo || data?.fileName || data?.pdfDocId || docId || '';
+    }
 
     function escolherGestorEmail(emails) {
       return new Promise(resolve => {
@@ -508,251 +621,196 @@
       }
     }
 
-    async function calcularTotalPedidosDia() {
+    async function calcularTotalPedidosDia(preloadedDocs = null) {
       if (!currentUser) return;
-
-      // Intervalo: 17h do dia anterior até 13h do dia atual
-      const now = new Date();
-      const end = new Date(now.toISOString().split('T')[0] + 'T15:00:00');
-      const start = new Date(end);
-      start.setDate(start.getDate() - 1);
-      start.setHours(17, 0, 0, 0);
-
-      // Determina usuários permitidos (próprio usuário + subordinados)
-      let allowedUsers = [currentUser.uid];
-      if (isResponsavel) {
-        try {
-          const usuarios = new Set();
-          const snap1 = await db
-            .collection('uid')
-            .where('gestoresExpedicaoEmails', 'array-contains', currentUser.email)
-            .get();
-          snap1.forEach(d => usuarios.add(d.id));
-          const snap2 = await db
-            .collection('uid')
-            .where('responsavelExpedicaoEmail', '==', currentUser.email)
-            .get();
-          snap2.forEach(d => usuarios.add(d.id));
-          allowedUsers = [...allowedUsers, ...usuarios];
-        } catch (e) {
-          console.error('Erro ao buscar usuários permitidos:', e);
-        }
+      let docs = preloadedDocs;
+      if (!docs) {
+        const { start, end } = getResumoTimeWindow();
+        const allowedUsers = await getAllowedUserUids();
+        docs = await fetchResumoDocsForUsers(allowedUsers, start, end);
       }
-
       const perUser = {};
-
-      try {
-        // Soma registros da coleção skuimpressos
-        const q1 = db
-          .collectionGroup('skuimpressos')
-          .where('createdAt', '>=', start)
-          .where('createdAt', '<=', end);
-        const snap1 = await q1.get();
-        for (const doc of snap1.docs) {
-          const data = doc.data();
-          const uid = data.userUid;
-          if (!uid || !allowedUsers.includes(uid)) continue;
-          const qty = Number(data.quantidade) || 0;
-          perUser[uid] = (perUser[uid] || 0) + qty;
+      if (Array.isArray(docs)) {
+        for (const item of docs) {
+          if (!item || !item.ownerUid) continue;
+          const quantidade = getResumoQuantidade(item.data);
+          perUser[item.ownerUid] = (perUser[item.ownerUid] || 0) + quantidade;
         }
-
-        // Soma registros da coleção etiquetasimpressas
-        const q2 = db
-          .collectionGroup('etiquetasimpressas')
-          .where('data', '>=', start)
-          .where('data', '<=', end);
-        const snap2 = await q2.get();
-        for (const doc of snap2.docs) {
-          const data = doc.data();
-          const uid = doc.ref.parent.parent?.id;
-          if (!uid || !allowedUsers.includes(uid)) continue;
-          const qty = Number(data.quantidade) || 0;
-          perUser[uid] = (perUser[uid] || 0) + qty;
-        }
-      } catch (err) {
-        console.error('Erro ao calcular pedidos do dia:', err);
       }
-
       renderUserCards(perUser);
     }
 
-     async function carregarChecklist() {
-  if (!checklistBody || !currentUser) return;
-  checklistBody.innerHTML = '';
-  checklistRows = [];
-  if (checklistTotals) checklistTotals.textContent = '';
-  if (checklistEnvioTotals) checklistEnvioTotals.textContent = '';
+    async function carregarChecklist() {
+      if (!checklistBody || !currentUser) return;
+      checklistBody.innerHTML = '';
+      checklistRows = [];
+      if (checklistTotals) checklistTotals.textContent = '';
+      if (checklistEnvioTotals) checklistEnvioTotals.textContent = '';
 
-  let enviados = 0;
-  let pendentes = 0;
+      const totalAEnviarEl = document.getElementById('totalAEnviar');
+      const totalEnviadoEl = document.getElementById('totalEnviado');
+      const totalNaoEnviadoEl = document.getElementById('totalNaoEnviado');
 
-  function parseDate(str) {
-    if (!str) return new Date('');
-    const parts = str.split(/[\/\-]/);
-    if (parts.length === 3) {
-      let y, m, d;
-      if (parts[0].length === 4) {
-        [y, m, d] = parts.map(Number); // formato ISO yyyy-mm-dd
-      } else {
-        [d, m, y] = parts.map(Number); // formato dd/mm/yyyy
-      }
-      return new Date(y, (m || 1) - 1, d || 1);
-    }
-    return new Date(str);
-  }
-
-  function parseDateTime(str) {
-    if (!str) return new Date('');
-    const [datePart, timePart] = str.split(' ');
-    const dt = parseDate(datePart);
-    if (timePart) {
-      const [h, m] = timePart.split(':').map(Number);
-      dt.setHours(h || 0, m || 0, 0, 0);
-    }
-    return dt;
-  }
-
-
-  try {
-    let allowedUsers = [currentUser.uid];
-    if (isResponsavel) {
-      const usuarios = new Set();
-      const snap1 = await db
-        .collection('uid')
-        .where('gestoresExpedicaoEmails', 'array-contains', currentUser.email)
-        .get();
-      snap1.forEach(d => usuarios.add(d.id));
-      const snap2 = await db
-        .collection('uid')
-        .where('responsavelExpedicaoEmail', '==', currentUser.email)
-        .get();
-      snap2.forEach(d => usuarios.add(d.id));
-      allowedUsers = [...allowedUsers, ...usuarios];
-    }
-
-    const userCache = new Map();
-    async function getNome(uid) {
-      if (!userCache.has(uid)) {
-        userCache.set(uid, await getOwnerName(uid, ''));
-      }
-      return userCache.get(uid);
-    }
-
-    const rows = [];
-    const storeTotals = {};
-
-    for (const uid of allowedUsers) {
-      if (!uid) continue;
-      const passes = [
-        getPassphrase(),
-        `chave-${uid}`,
-        uid,
-        currentUser?.uid,
-        currentUser?.email
-      ].filter(Boolean);
+      const { start, end } = getResumoTimeWindow();
 
       try {
-        const listaSnap = await db.collectionGroup('lista').where('uid', '==', uid).get();
-        for (const docu of listaSnap.docs) {
-          const path = docu.ref.path;
-          if (!path.includes('/pedidosreais/')) continue;
-          if (uid === currentUser.uid) {
-            if (!path.startsWith(`uid/${uid}/pedidosreais/`)) continue;
-          } else {
-            if (!path.startsWith(`uid/${currentUser.uid}/uid/${uid}/pedidosreais/`)) continue;
+        const allowedUsers = await getAllowedUserUids();
+        const docs = await fetchResumoDocsForUsers(allowedUsers, start, end);
+        await calcularTotalPedidosDia(docs);
+
+        if (!docs.length) {
+          if (checklistBody) {
+            checklistBody.innerHTML = '<tr><td class="p-2 text-center text-gray-500" colspan="6">Nenhum registro</td></tr>';
           }
-          let d = docu.data();
-          if (d.encrypted) {
-            let decrypted = null;
-            for (const key of passes) {
-              try {
-                const plaintext = await decryptString(d.encrypted, key);
-                decrypted = JSON.parse(plaintext);
-                break;
-              } catch (err) {}
-            }
-            if (!decrypted) {
-              console.warn('Erro ao descriptografar pedido', docu.id);
-              continue;
-            }
-            d = decrypted;
+          if (checklistTotals) checklistTotals.textContent = 'Nenhum SKU encontrado';
+          if (checklistEnvioTotals) {
+            checklistEnvioTotals.textContent = 'Total etiquetas: 0 | Dentro do horário: 0 | Fora do horário: 0';
           }
-          const status = (d.status || '').toUpperCase();
-          if (status !== 'A ENVIAR') continue;
-          if (!d.numeroRastreamento) continue;
-
-          const id = d.pedidoId || docu.id;
-          let data = parseDate(d.dataPrevistaEnvio || d.data || '');
-          if (isNaN(data)) {
-            data = parseDateTime(`${d.data || ''} ${d.horaPagamento || ''}`.trim());
-          }
-          if (isNaN(data)) continue;
-
-          const loja = d.loja || '';
-          const sku = d.sku || '';
-          const usuario = await getNome(uid);
-
-          if (d.coletado) {
-            enviados++;
-          } else {
-            pendentes++;
-          }
-
-          storeTotals[loja] = (storeTotals[loja] || 0) + 1;
-
-          const row = { id, loja, sku, data, usuario };
-          rows.push(row);
-          checklistRows.push(row);
+          if (totalAEnviarEl) totalAEnviarEl.textContent = 0;
+          if (totalEnviadoEl) totalEnviadoEl.textContent = 0;
+          if (totalNaoEnviadoEl) totalNaoEnviadoEl.textContent = 0;
+          return;
         }
-      } catch (err) {
-        console.error(`Erro ao carregar pedidos do usuário ${uid}:`, err);
+
+        const nomeCache = new Map();
+        async function getNome(uid) {
+          if (!uid) return 'Desconhecido';
+          if (!nomeCache.has(uid)) {
+            nomeCache.set(uid, await getOwnerName(uid, ''));
+          }
+          return nomeCache.get(uid) || 'Desconhecido';
+        }
+
+        const rows = [];
+        const skuTotals = new Map();
+        let totalDentro = 0;
+        let totalFora = 0;
+
+        for (const item of docs) {
+          if (!item) continue;
+          const data = item.data || {};
+          const ownerUid = item.ownerUid || data.ownerUid || currentUser.uid;
+          const ownerName = await getNome(ownerUid);
+          const createdAt = item.createdAt || new Date();
+          const paginas = Array.isArray(data.paginas) ? data.paginas : [];
+          const totaisPorSku = Array.isArray(data.totaisPorSku) ? data.totaisPorSku : [];
+          const arquivo = data.arquivo || data.fileName || data.pdfDocId || item.docId || '';
+          const rangeLabel = formatResumoRangeLabel(data, paginas, item.docId);
+          const quantidadeDoc = getResumoQuantidade(data);
+
+          if (data.foraHorario) totalFora += quantidadeDoc;
+          else totalDentro += quantidadeDoc;
+
+          if (totaisPorSku.length) {
+            totaisPorSku.forEach(entry => {
+              const skuRaw = (entry?.sku || '').toString().trim();
+              const quantidade = Number(entry?.quantidade);
+              const qty = Number.isFinite(quantidade) ? quantidade : 0;
+              const skuKey = skuRaw || 'Sem SKU';
+              skuTotals.set(skuKey, (skuTotals.get(skuKey) || 0) + qty);
+              rows.push({
+                etiqueta: rangeLabel,
+                sku: skuRaw,
+                quantidade: qty,
+                data: createdAt,
+                usuario: ownerName,
+                arquivo
+              });
+            });
+          } else if (paginas.length) {
+            paginas.forEach(pagina => {
+              const skuRaw = (pagina?.sku || '').toString().trim();
+              const quantidade = Number(pagina?.quantidade);
+              const qty = Number.isFinite(quantidade) ? quantidade : 0;
+              const skuKey = skuRaw || 'Sem SKU';
+              skuTotals.set(skuKey, (skuTotals.get(skuKey) || 0) + qty);
+              const etiqueta = Number.isFinite(pagina?.numero) ? `${pagina.numero}` : rangeLabel;
+              rows.push({
+                etiqueta,
+                sku: skuRaw,
+                quantidade: qty,
+                data: createdAt,
+                usuario: ownerName,
+                arquivo
+              });
+            });
+          } else {
+            const skuKey = 'Sem SKU';
+            skuTotals.set(skuKey, (skuTotals.get(skuKey) || 0) + quantidadeDoc);
+            rows.push({
+              etiqueta: rangeLabel,
+              sku: '',
+              quantidade: quantidadeDoc,
+              data: createdAt,
+              usuario: ownerName,
+              arquivo
+            });
+          }
+        }
+
+        rows.sort((a, b) => (b.data?.getTime() || 0) - (a.data?.getTime() || 0));
+
+        if (!rows.length) {
+          checklistBody.innerHTML = '<tr><td class="p-2 text-center text-gray-500" colspan="6">Nenhum registro</td></tr>';
+        } else {
+          rows.forEach(row => {
+            const dataStr = row.data ? row.data.toLocaleString('pt-BR') : '-';
+            const quantidadeStr = Number.isFinite(row.quantidade) ? row.quantidade : '-';
+            const tr = document.createElement('tr');
+            tr.innerHTML =
+              `<td class="p-2 border">${row.etiqueta || '-'}</td>` +
+              `<td class="p-2 border">${row.sku || '-'}</td>` +
+              `<td class="p-2 border text-right">${quantidadeStr}</td>` +
+              `<td class="p-2 border">${row.arquivo || '-'}</td>` +
+              `<td class="p-2 border">${dataStr}</td>` +
+              `<td class="p-2 border">${row.usuario || '-'}</td>`;
+            checklistBody.appendChild(tr);
+          });
+        }
+
+        checklistRows = rows;
+
+        const totalEnviar = totalDentro + totalFora;
+        if (totalAEnviarEl) totalAEnviarEl.textContent = totalEnviar;
+        if (totalEnviadoEl) totalEnviadoEl.textContent = totalDentro;
+        if (totalNaoEnviadoEl) totalNaoEnviadoEl.textContent = totalFora;
+
+        if (checklistEnvioTotals) {
+          checklistEnvioTotals.textContent = `Total etiquetas: ${totalEnviar} | Dentro do horário: ${totalDentro} | Fora do horário: ${totalFora}`;
+        }
+
+        if (checklistTotals) {
+          const skuEntries = Array.from(skuTotals.entries())
+            .filter(([, qty]) => Number.isFinite(qty) && qty > 0)
+            .sort((a, b) => b[1] - a[1]);
+          checklistTotals.textContent = skuEntries.length
+            ? skuEntries.map(([sku, qty]) => `${sku}: ${qty}`).join(' | ')
+            : 'Nenhum SKU encontrado';
+        }
+      } catch (e) {
+        console.error('Erro ao carregar checklist:', e);
+        checklistRows = [];
+        checklistBody.innerHTML = '<tr><td class="p-2 text-center text-red-500" colspan="6">Erro ao carregar</td></tr>';
+        if (checklistTotals) checklistTotals.textContent = 'Erro ao carregar';
+        if (checklistEnvioTotals) checklistEnvioTotals.textContent = 'Erro ao carregar';
+        if (totalAEnviarEl) totalAEnviarEl.textContent = 0;
+        if (totalEnviadoEl) totalEnviadoEl.textContent = 0;
+        if (totalNaoEnviadoEl) totalNaoEnviadoEl.textContent = 0;
+        await calcularTotalPedidosDia();
       }
     }
-
-    rows.forEach(r => {
-      const tr = document.createElement('tr');
-      tr.innerHTML = `<td class="p-2 border">${r.id}</td><td class="p-2 border">${r.loja}</td><td class="p-2 border">${r.sku}</td><td class="p-2 border">${r.data.toLocaleString('pt-BR')}</td><td class="p-2 border">${r.usuario}</td>`;
-      checklistBody.appendChild(tr);
-    });
-
-    if (checklistEnvioTotals) {
-      checklistEnvioTotals.textContent = `Enviados: ${enviados} | Faltam enviar: ${pendentes}`;
-    }
-
-    const totalEnviarEl = document.getElementById('totalAEnviar');
-    const totalEnviadoEl = document.getElementById('totalEnviado');
-    const totalNaoEnviadoEl = document.getElementById('totalNaoEnviado');
-    if (totalEnviarEl) totalEnviarEl.textContent = enviados + pendentes;
-    if (totalEnviadoEl) totalEnviadoEl.textContent = enviados;
-    if (totalNaoEnviadoEl) totalNaoEnviadoEl.textContent = pendentes;
-
-    if (checklistTotals) {
-      const entries = Object.entries(storeTotals).map(([loja, count]) => `${loja || 'Sem loja'}: ${count}`);
-      checklistTotals.textContent = entries.length ? entries.join(' | ') : 'Nenhum pedido';
-    }
-
-    if (!rows.length) {
-      checklistBody.innerHTML = '<tr><td class="p-2 text-center text-gray-500" colspan="5">Nenhum registro</td></tr>';
-    }
-
-  } catch (e) {
-    console.error('Erro ao carregar checklist:', e);
-    checklistBody.innerHTML = '<tr><td class="p-2 text-center text-red-500" colspan="5">Erro ao carregar</td></tr>';
-    if (checklistTotals) checklistTotals.textContent = 'Erro ao carregar';
-    if (checklistEnvioTotals) checklistEnvioTotals.textContent = 'Erro ao carregar';
-  }
-}
 
       function exportarChecklist() {
         if (!checklistRows.length) return;
         const wsData = checklistRows.map(r => ({
-          Pedido: r.id,
-          Loja: r.loja,
-          SKU: r.sku,
-          Data: r.data.toISOString(),
-          Usuario: r.usuario
+          Intervalo: r.etiqueta || '',
+          SKU: r.sku || '',
+          Quantidade: Number.isFinite(r.quantidade) ? r.quantidade : '',
+          Arquivo: r.arquivo || '',
+          Data: r.data && typeof r.data.toISOString === 'function' ? r.data.toISOString() : '',
+          Usuario: r.usuario || ''
         }));
-        const ws = XLSX.utils.json_to_sheet(wsData, { header: ['Pedido', 'Loja', 'SKU', 'Data', 'Usuario'] });
+        const ws = XLSX.utils.json_to_sheet(wsData, { header: ['Intervalo', 'SKU', 'Quantidade', 'Arquivo', 'Data', 'Usuario'] });
         const wb = XLSX.utils.book_new();
         XLSX.utils.book_append_sheet(wb, ws, 'Checklist');
         XLSX.writeFile(wb, 'checklist_expedicao.xlsx');


### PR DESCRIPTION
## Summary
- atualiza o cabeçalho do checklist para refletir intervalo, SKU, quantidade, arquivo, data e usuário
- passa a calcular cards, checklist e exportação com dados de `users/{uid}/etiquetasResumo` no intervalo das 15h30 do dia anterior às 15h20 do dia atual
- reutiliza o resumo das etiquetas para atualizar os cards por usuário da equipe

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8aeb0fbcc832ab21e04c77193c8e1