### PR TITLE
Ajusta alinhamento dos cards na aba Expedição

### DIFF
--- a/expedicao.html
+++ b/expedicao.html
@@ -81,7 +81,7 @@
       <button class="view-btn px-4 py-2 rounded-full bg-indigo-600 text-white text-sm font-medium" data-view="cards" title="Exibição em cartões"><i class="fas fa-th"></i></button>
       <button class="view-btn px-4 py-2 rounded-full bg-gray-100 text-gray-700 text-sm font-medium hover:bg-gray-200 transition" data-view="list" title="Exibição em lista"><i class="fas fa-list"></i></button>
     </div>
-    <div id="labelsList" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6"></div>
+    <div id="labelsList" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 items-start"></div>
   </div>
 
   <div id="pdfModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
@@ -840,7 +840,7 @@
         });
       } else {
         list.className = viewMode === 'cards'
-          ? 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6'
+          ? 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 items-start'
           : 'flex flex-col gap-4';
         for (const r of results) {
           const item = viewMode === 'cards' ? createPdfCard(r.doc, r.ownerName) : createPdfListItem(r.doc, r.ownerName);


### PR DESCRIPTION
## Summary
- garante que o grid de etiquetas na aba Expedição alinhe os cartões pelo topo para evitar que estiquem com conteúdos maiores
- aplica a mesma configuração sempre que a visualização em cartões é reativada

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8b1e75934832a833315799a2a99c0