### PR TITLE
Ajusta altura dos cards de expedição

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -151,6 +151,7 @@
   border: 1px solid #e5e7eb;
   border-radius: 0.75rem;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  align-self: flex-start;
 }
 
 .ticket-card::before,

--- a/expedicao.html
+++ b/expedicao.html
@@ -1176,7 +1176,7 @@
         concluido: { text: 'Concluído', icon: 'fa-check', color: 'text-green-600', border: 'border-green-500' }
       };
       const div = document.createElement('div');
-      div.className = 'pdf-card ticket-card p-4 flex flex-col h-full' + (attention ? ' border-red-500 border-2' : '');
+      div.className = 'pdf-card ticket-card p-4 flex flex-col' + (attention ? ' border-red-500 border-2' : '');
       div.innerHTML = `
         <div class="flex justify-between items-center mb-4">
           <span class="font-semibold text-gray-800">${owner}</span>


### PR DESCRIPTION
## Summary
- impede que os cards da aba de expedição estiquem ao alinhar o ticket ao topo
- remove a altura forçada dos cartões gerados para etiquetas

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8b1e75934832a833315799a2a99c0