### PR TITLE
Add mentorados updates panel

### DIFF
--- a/login.js
+++ b/login.js
@@ -450,6 +450,7 @@ function applyPerfilRestrictions(perfil) {
       'menu-configuracoes',
       'menu-comunicacao',
       'menu-painel-atualizacoes-gerais',
+      'menu-painel-atualizacoes-mentorados',
     ],
     cliente: [
       'menu-vendas',
@@ -459,10 +460,12 @@ function applyPerfilRestrictions(perfil) {
       'menu-configuracoes',
       'menu-comunicacao',
       'menu-painel-atualizacoes-gerais',
+      'menu-painel-atualizacoes-mentorados',
     ],
     gestor: [
       'menu-atualizacoes',
       'menu-painel-atualizacoes-gerais',
+      'menu-painel-atualizacoes-mentorados',
       'menu-financeiro',
       'menu-saques',
       'menu-gestao',

--- a/painel-atualizacoes-gerais.js
+++ b/painel-atualizacoes-gerais.js
@@ -28,6 +28,49 @@ const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app);
 
+function normalizePerfil(valor) {
+  if (!valor) return '';
+  return String(valor)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toLowerCase();
+}
+
+const defaultConfig = {
+  collectionName: 'painelAtualizacoesGerais',
+  blockedPerfis: [],
+  noAccessMessage: 'Você não tem permissão para acessar este painel.',
+};
+
+const rawConfig = window.PAINEL_ATUALIZACOES_CONFIG || {};
+const config = {
+  ...defaultConfig,
+  ...rawConfig,
+};
+
+config.collectionName =
+  typeof config.collectionName === 'string' && config.collectionName.trim()
+    ? config.collectionName.trim()
+    : defaultConfig.collectionName;
+
+config.noAccessMessage =
+  typeof config.noAccessMessage === 'string' && config.noAccessMessage.trim()
+    ? config.noAccessMessage
+    : defaultConfig.noAccessMessage;
+
+const blockedPerfisSet = new Set(
+  (config.blockedPerfis || [])
+    .map((perfil) => normalizePerfil(perfil))
+    .filter((perfil) => perfil),
+);
+
+try {
+  delete window.PAINEL_ATUALIZACOES_CONFIG;
+} catch (err) {
+  window.PAINEL_ATUALIZACOES_CONFIG = undefined;
+}
+
 const formMensagem = document.getElementById('formMensagem');
 const formProblema = document.getElementById('formProblema');
 const formProduto = document.getElementById('formProduto');
@@ -52,6 +95,7 @@ const produtoStatusEl = document.getElementById('produtoStatus');
 const painelStatusEl = document.getElementById('painelStatus');
 const produtosAvisoEl = document.getElementById('produtosAviso');
 const mensagemEscopoEl = document.getElementById('mensagemEscopo');
+const painelSections = Array.from(document.querySelectorAll('main .card'));
 
 let currentUser = null;
 let participantesCompartilhamento = [];
@@ -59,6 +103,38 @@ let mensagensUnsub = null;
 let problemasUnsub = null;
 let produtosUnsub = null;
 let nomeResponsavel = '';
+
+function isPerfilBloqueado(perfil) {
+  if (!blockedPerfisSet.size) return false;
+  const normalizado = normalizePerfil(perfil);
+  return Boolean(normalizado) && blockedPerfisSet.has(normalizado);
+}
+
+function aplicarRestricaoAcesso(mensagem) {
+  painelSections.forEach((section) => section.classList.add('hidden'));
+  setStatus(painelStatusEl, '');
+  [mensagemStatusEl, problemaStatusEl, produtoStatusEl].forEach((el) => {
+    setStatus(el, '');
+  });
+  const avisoExistente = document.getElementById('painelRestricaoAviso');
+  if (avisoExistente?.parentElement) {
+    avisoExistente.parentElement.removeChild(avisoExistente);
+  }
+  const aviso = document.createElement('div');
+  aviso.id = 'painelRestricaoAviso';
+  aviso.className =
+    'mt-4 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700';
+  aviso.textContent = mensagem || config.noAccessMessage;
+  const main = document.querySelector('main');
+  if (main) {
+    const header = main.querySelector('header');
+    if (header) {
+      header.insertAdjacentElement('afterend', aviso);
+    } else {
+      main.prepend(aviso);
+    }
+  }
+}
 
 function setStatus(element, message = '', isError = false) {
   if (!element) return;
@@ -485,7 +561,7 @@ function carregarMensagens() {
   if (!currentUser) return;
   mensagensUnsub?.();
   const mensagensRef = query(
-    collection(db, 'painelAtualizacoesGerais'),
+    collection(db, config.collectionName),
     where('categoria', '==', 'mensagem'),
     where('participantes', 'array-contains', currentUser.uid),
     orderBy('createdAt', 'desc'),
@@ -517,7 +593,7 @@ function carregarProblemas() {
   if (!currentUser) return;
   problemasUnsub?.();
   const problemasRef = query(
-    collection(db, 'painelAtualizacoesGerais'),
+    collection(db, config.collectionName),
     where('categoria', '==', 'problema'),
     where('participantes', 'array-contains', currentUser.uid),
     orderBy('createdAt', 'desc'),
@@ -547,7 +623,7 @@ function carregarProdutos() {
   if (!currentUser) return;
   produtosUnsub?.();
   const produtosRef = query(
-    collection(db, 'painelAtualizacoesGerais'),
+    collection(db, config.collectionName),
     where('categoria', '==', 'produto'),
     where('participantes', 'array-contains', currentUser.uid),
     orderBy('createdAt', 'desc'),
@@ -595,7 +671,7 @@ async function enviarMensagem(event) {
     return;
   }
   try {
-    await addDoc(collection(db, 'painelAtualizacoesGerais'), {
+    await addDoc(collection(db, config.collectionName), {
       categoria: 'mensagem',
       texto,
       autorUid: currentUser.uid,
@@ -637,7 +713,7 @@ async function registrarProblema(event) {
     return;
   }
   try {
-    await addDoc(collection(db, 'painelAtualizacoesGerais'), {
+    await addDoc(collection(db, config.collectionName), {
       categoria: 'problema',
       problema,
       solucao: solucao || '',
@@ -675,7 +751,7 @@ async function registrarProduto(event) {
     return;
   }
   try {
-    await addDoc(collection(db, 'painelAtualizacoesGerais'), {
+    await addDoc(collection(db, config.collectionName), {
       categoria: 'produto',
       nome,
       observacoes: observacoes || '',
@@ -709,7 +785,16 @@ onAuthStateChanged(auth, async (user) => {
   nomeResponsavel = user.displayName || user.email || 'Usuário';
   setStatus(painelStatusEl, 'Carregando configurações da equipe...');
   try {
-    const { participantes } = await montarEscopoCompartilhamento(user);
+    const { participantes, perfil } = await montarEscopoCompartilhamento(user);
+    const perfilNormalizado = normalizePerfil(perfil);
+    const perfilGlobal = normalizePerfil(window.userPerfil);
+    if (
+      isPerfilBloqueado(perfilNormalizado) ||
+      isPerfilBloqueado(perfilGlobal)
+    ) {
+      aplicarRestricaoAcesso(config.noAccessMessage);
+      return;
+    }
     participantesCompartilhamento = participantes.length
       ? participantes
       : [user.uid];

--- a/painel-atualizacoes-mentorados.html
+++ b/painel-atualizacoes-mentorados.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Painel de Atualizações Vendedores/Mentorados</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/styles.css?v=20240826" />
+</head>
+<body class="bg-gray-100 text-gray-800">
+  <div class="app-container">
+    <div id="sidebar-container"></div>
+    <div id="navbar-container"></div>
+
+    <main class="main-content p-4 space-y-6">
+      <header class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 class="text-2xl font-bold">Painel de Atualizações - Vendedores/Mentorados</h1>
+          <p class="text-sm text-gray-600">
+            Centralize comunicados rápidos, organize problemas em aberto e compartilhe quais peças estão em linha com os vendedores e mentorados.
+          </p>
+        </div>
+        <div id="painelStatus" class="text-sm text-gray-500"></div>
+      </header>
+
+      <section class="card p-5 space-y-4">
+        <div class="flex items-center justify-between flex-wrap gap-2">
+          <h2 class="text-xl font-semibold flex items-center gap-2">
+            <span class="text-blue-600"><i class="fa-solid fa-comments"></i></span>
+            Atualizações rápidas
+          </h2>
+          <span id="mensagemStatus" class="text-sm text-gray-500"></span>
+        </div>
+        <form id="formMensagem" class="space-y-3">
+          <label class="block text-sm font-medium text-gray-700" for="mensagemTexto">
+            Compartilhe uma mensagem com a sua equipe de vendedores e mentorados
+          </label>
+          <textarea
+            id="mensagemTexto"
+            class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            rows="3"
+            placeholder="Ex: Ajustes de comissão aplicados a partir de amanhã."
+            required
+          ></textarea>
+          <div class="flex items-center justify-between text-xs text-gray-500">
+            <span id="mensagemEscopo" class="italic"></span>
+            <button
+              type="submit"
+              class="btn btn-primary text-sm px-4 py-2"
+            >Enviar mensagem</button>
+          </div>
+        </form>
+        <div>
+          <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Últimas mensagens</h3>
+          <div id="listaMensagens" class="mt-3 space-y-3"></div>
+          <p id="mensagensVazio" class="text-sm text-gray-500 hidden">
+            Nenhuma mensagem registrada até o momento.
+          </p>
+        </div>
+      </section>
+
+      <section class="card p-5 space-y-5">
+        <div class="flex items-center justify-between flex-wrap gap-2">
+          <h2 class="text-xl font-semibold flex items-center gap-2">
+            <span class="text-amber-500"><i class="fa-solid fa-triangle-exclamation"></i></span>
+            Problemas por área
+          </h2>
+          <span id="problemaStatus" class="text-sm text-gray-500"></span>
+        </div>
+        <form id="formProblema" class="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div class="space-y-2">
+            <label for="problemaTitulo" class="text-sm font-medium text-gray-700">Descrição do problema</label>
+            <textarea
+              id="problemaTitulo"
+              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+              rows="3"
+              placeholder="Ex: Erros no cadastro do produto no canal de vendas"
+              required
+            ></textarea>
+          </div>
+          <div class="space-y-2">
+            <label for="problemaSolucao" class="text-sm font-medium text-gray-700">Solução (opcional)</label>
+            <textarea
+              id="problemaSolucao"
+              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+              rows="3"
+              placeholder="Ex: Realizar atualização em massa das ofertas"
+            ></textarea>
+          </div>
+          <div class="space-y-2">
+            <label for="problemaSetor" class="text-sm font-medium text-gray-700">Área/Setor</label>
+            <input
+              id="problemaSetor"
+              type="text"
+              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+              placeholder="Ex: Time de Vendas"
+              required
+            />
+          </div>
+          <div class="space-y-2">
+            <label for="problemaResponsavel" class="text-sm font-medium text-gray-700">Responsável</label>
+            <input
+              id="problemaResponsavel"
+              type="text"
+              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+              placeholder="Quem está acompanhando a resolução?"
+              required
+            />
+          </div>
+          <div class="space-y-2">
+            <label for="problemaData" class="text-sm font-medium text-gray-700">Data do registro</label>
+            <input
+              id="problemaData"
+              type="date"
+              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+              required
+            />
+          </div>
+          <div class="flex items-end">
+            <button type="submit" class="btn btn-primary text-sm px-4 py-2 w-full md:w-auto">Registrar problema</button>
+          </div>
+        </form>
+        <div>
+          <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Histórico de problemas</h3>
+          <div id="listaProblemas" class="mt-3 space-y-3"></div>
+          <p id="problemasVazio" class="text-sm text-gray-500 hidden">
+            Nenhum problema registrado.
+          </p>
+        </div>
+      </section>
+
+      <section class="card p-5 space-y-5">
+        <div class="flex items-center justify-between flex-wrap gap-2">
+          <h2 class="text-xl font-semibold flex items-center gap-2">
+            <span class="text-emerald-500"><i class="fa-solid fa-cubes"></i></span>
+            Peças em linha
+          </h2>
+          <span id="produtoStatus" class="text-sm text-gray-500"></span>
+        </div>
+        <p id="produtosAviso" class="text-sm text-gray-500 hidden">
+          Apenas gestores ou responsáveis financeiros podem cadastrar novos produtos.
+        </p>
+        <form id="formProduto" class="grid grid-cols-1 gap-4 md:grid-cols-3 hidden">
+          <div class="md:col-span-1 space-y-2">
+            <label for="produtoNome" class="text-sm font-medium text-gray-700">Produto / Peça</label>
+            <input
+              id="produtoNome"
+              type="text"
+              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              placeholder="Ex: Kit de fotos atualizado"
+              required
+            />
+          </div>
+          <div class="md:col-span-2 space-y-2">
+            <label for="produtoObs" class="text-sm font-medium text-gray-700">Observações (opcional)</label>
+            <textarea
+              id="produtoObs"
+              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              rows="2"
+              placeholder="Detalhes sobre estoque, priorização ou datas"
+            ></textarea>
+          </div>
+          <div class="md:col-span-3 flex justify-end">
+            <button type="submit" class="btn btn-primary text-sm px-4 py-2">Adicionar produto</button>
+          </div>
+        </form>
+        <div>
+          <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Produtos cadastrados</h3>
+          <div id="listaProdutos" class="mt-3 space-y-3"></div>
+          <p id="produtosVazio" class="text-sm text-gray-500 hidden">
+            Nenhum produto em linha cadastrado até o momento.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';
+      window.CUSTOM_NAVBAR_PATH = '/partials/navbar.html';
+      window.PAINEL_ATUALIZACOES_CONFIG = {
+        collectionName: 'painelAtualizacoesMentorados',
+        blockedPerfis: ['gestor expedicao'],
+        noAccessMessage:
+          'Este painel é exclusivo para vendedores, mentorados e gestores responsáveis.',
+      };
+    </script>
+    <script src="shared.js"></script>
+    <script type="module" src="firebase-config.js"></script>
+    <script type="module" src="painel-atualizacoes-gerais.js"></script>
+  </div>
+</body>
+</html>

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -139,6 +139,29 @@
     </li>
     <li>
       <a
+        href="/painel-atualizacoes-mentorados.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-painel-atualizacoes-mentorados"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M2.25 7.5l9.75-4.5 9.75 4.5-9.75 4.5-9.75-4.5Zm0 9l9.75 4.5 9.75-4.5m-19.5-9v9m19.5-9v9"
+          />
+        </svg>
+        <span class="link-text">Atualizações Mentorados</span>
+      </a>
+    </li>
+    <li>
+      <a
         href="/saques.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-saques"


### PR DESCRIPTION
## Summary
- add a dedicated Vendedores/Mentorados updates page that reuses the general updates UI with custom copy
- allow the shared updates script to target different collections and block specific profiles from accessing a panel
- expose the new panel in the sidebar and menu permissions for eligible profiles

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8b281348c832aa2b2127fe3d59b75