### PR TITLE
Ensure finance managers can access product pricing tab

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -582,6 +582,7 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-painel-atualizacoes-mentorados',
     'menu-comunicacao',
     'menu-saques',
+    'menu-produtos-precos',
     'menu-acompanhamento-gestor',
     'menu-mentoria',
     'menu-perfil-mentorado',


### PR DESCRIPTION
## Summary
- include the Produtos/Preços menu id in the gestor/financeiro sidebar allowlist
- ensure the finance sidebar group renders the Produtos/Preços submenu for financial managers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c944acf344832a8595351dc69682f9