### PR TITLE
Ajusta largura do sidebar para clientes e usuários

### DIFF
--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -40,12 +40,12 @@ body.has-sidebar .content-wrapper {
   margin-left: var(--sidebar-width);
 }
 
-.main-content {
+body.has-sidebar .main-content {
   margin-left: var(--sidebar-width);
 }
 
 @media (max-width: 1023px) {
-  .main-content {
+  body.has-sidebar .main-content {
     margin-left: 0;
   }
 }

--- a/shared.js
+++ b/shared.js
@@ -335,10 +335,8 @@ async function loadPartial(selector, path) {
     el.id = id;
     if (id === 'sidebar-container') {
       el.className =
-        'fixed inset-y-0 left-0 w-64 max-w-[80vw] overflow-auto z-40 transition-transform duration-200 ease-out shadow-lg';
+        'fixed inset-y-0 left-0 max-w-[80vw] overflow-auto z-40 transition-transform duration-200 ease-out shadow-lg';
       document.body.prepend(el);
-      // garante margem do conteúdo no desktop
-      document.querySelector('.main-content')?.classList.add('lg:ml-64');
     } else {
       // navbar acima do main
       document.body.insertBefore(el, document.querySelector('main') || null);
@@ -349,7 +347,6 @@ async function loadPartial(selector, path) {
         'fixed',
         'inset-y-0',
         'left-0',
-        'w-64',
         'max-w-[80vw]',
         'overflow-auto',
         'z-40',
@@ -358,7 +355,6 @@ async function loadPartial(selector, path) {
         'ease-out',
         'shadow-lg',
       );
-      document.querySelector('.main-content')?.classList.add('lg:ml-64');
     }
   }
 


### PR DESCRIPTION
## Summary
- remove a largura fixa do Tailwind no container do sidebar para respeitar `--sidebar-width`
- aplica o deslocamento do conteúdo apenas quando o body possui sidebar para manter o alinhamento dos clientes/usuários

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c940f356f4832a8fdc7640c4538f77