### PR TITLE
Padroniza layout do sidebar para clientes e usuários

### DIFF
--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -3,7 +3,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  width: var(--sidebar-width);
+  width: var(--sidebar-width, 18rem);
   height: 100%;
   transform: translateX(-100%);
   transition: transform 0.3s ease;
@@ -33,15 +33,15 @@
 
 /* Layout adjustments when sidebar is present */
 body.has-sidebar .navbar {
-  left: var(--sidebar-width);
+  left: var(--sidebar-width, 18rem);
 }
 
 body.has-sidebar .content-wrapper {
-  margin-left: var(--sidebar-width);
+  margin-left: var(--sidebar-width, 18rem);
 }
 
 .main-content {
-  margin-left: var(--sidebar-width);
+  margin-left: var(--sidebar-width, 18rem);
 }
 
 @media (max-width: 1023px) {
@@ -82,7 +82,7 @@ body.has-sidebar .content-wrapper {
   background-color: var(--sidebar-bg);
   color: var(--sidebar-text) !important;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
-  width: var(--sidebar-width);
+  width: var(--sidebar-width, 18rem);
   min-height: 100vh;
   padding-top: 1rem;
   border-right: 1px solid var(--sidebar-border);
@@ -214,7 +214,7 @@ body.has-sidebar .content-wrapper {
 /* Mobile-specific sidebar rules */
 @media (max-width: 768px) {
   .sidebar {
-    width: var(--sidebar-width);
+    width: var(--sidebar-width, 18rem);
   }
   .sidebar .link-text {
     display: inline;

--- a/shared.js
+++ b/shared.js
@@ -601,6 +601,17 @@ document.addEventListener('sidebarLoaded', async () => {
       ].includes(id),
   );
 
+  const CLIENTE_MENU_ORDER = [
+    'menu-painel-atualizacoes-gerais',
+    'menu-painel-atualizacoes-mentorados',
+    'menu-vendas',
+    'menu-etiquetas',
+    'menu-precificacao',
+    'menu-expedicao',
+    'menu-comunicacao',
+    'menu-configuracoes',
+  ];
+
   function showOnly(ids) {
     document.querySelectorAll('#sidebar .sidebar-link').forEach((a) => {
       const li = a.closest('li') || a.parentElement;
@@ -711,9 +722,38 @@ document.addEventListener('sidebarLoaded', async () => {
 
   function buildClienteSidebarLayout() {
     const sidebar = document.getElementById('sidebar');
-    if (sidebar) {
-      sidebar.classList.add('client-layout');
-    }
+    if (!sidebar) return;
+
+    sidebar.classList.add('client-layout');
+
+    const menu = sidebar.querySelector('.sidebar-menu');
+    if (!menu) return;
+
+    const fragment = document.createDocumentFragment();
+    const appended = new Set();
+
+    CLIENTE_MENU_ORDER.forEach((id) => {
+      const link = document.getElementById(id);
+      const li = link && link.closest('li');
+      if (!li || appended.has(li)) return;
+      if (li.classList.contains('hidden')) return;
+
+      if (li.style.display === 'none') li.style.display = '';
+
+      fragment.appendChild(li);
+      appended.add(li);
+    });
+
+    Array.from(menu.children).forEach((li) => {
+      if (appended.has(li)) return;
+      if (li.classList.contains('hidden')) return;
+      if (li.style.display === 'none') return;
+
+      fragment.appendChild(li);
+    });
+
+    menu.innerHTML = '';
+    menu.appendChild(fragment);
   }
 
   function normalizePerfil(perfil) {


### PR DESCRIPTION
## Sumário
- adiciona valores padrão na largura do sidebar e margens relacionadas para garantir consistência mesmo quando as variáveis CSS não estão disponíveis
- reorganiza o carregamento do menu para perfis de cliente/usuário, mantendo apenas os itens permitidos e ordenando-os de forma consistente com os demais perfis

## Testes
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c94af38110832abeb3d47738ec42b4