### PR TITLE
Unify sidebar styling

### DIFF
--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -77,6 +77,8 @@ body.has-sidebar .content-wrapper {
 
 /* Base sidebar styles */
 .sidebar {
+  display: flex;
+  flex-direction: column;
   overflow-y: auto;
   overflow-x: hidden;
   background-color: var(--sidebar-bg);
@@ -90,10 +92,58 @@ body.has-sidebar .content-wrapper {
   font-family: 'Poppins', 'Inter', sans-serif;
 }
 
-/* Subtle text and icon shadow for better contrast */
-.sidebar-link {
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
-  font-weight: 500;
+.sidebar-logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem 1rem;
+}
+
+.sidebar-logo-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.75rem;
+  color: inherit;
+  background-color: transparent;
+  text-decoration: none;
+  transition:
+    background-color 0.2s ease,
+    transform 0.2s ease;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+}
+
+.sidebar-logo-link:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  transform: translateY(-2px);
+}
+
+.sidebar-logo-link--profile {
+  background-color: var(--white);
+  color: var(--text);
+  box-shadow: none;
+}
+
+.sidebar-logo-link--profile svg {
+  color: var(--text);
+  stroke: var(--text);
+}
+
+.sidebar-logo-link--home {
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3);
+}
+
+.sidebar-logo-icon {
+  width: 1.75rem;
+  height: 1.75rem;
+}
+
+.sidebar-logo-icon--home {
+  width: 2rem;
+  height: 2rem;
 }
 
 .sidebar svg {
@@ -114,18 +164,20 @@ body.has-sidebar .content-wrapper {
   padding: 0;
 }
 
+.sidebar-menu {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 1rem 0;
+}
+
 .sidebar-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-}
-
-.submenu-toggle {
-  background: none;
-  border: none;
-  color: var(--sidebar-text) !important;
-  cursor: pointer;
-  padding-right: 1rem;
+  gap: 0.5rem;
+  width: 100%;
 }
 
 .sidebar-link {
@@ -138,9 +190,23 @@ body.has-sidebar .content-wrapper {
   color: var(--sidebar-text) !important;
   text-decoration: none;
   font-size: 0.95rem;
+  font-weight: 500;
   border-radius: 0.375rem;
-  transition: background-color 0.2s;
   border-left: 4px solid var(--sidebar-border);
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.sidebar button.sidebar-link {
+  border: none;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.sidebar-action {
+  justify-content: flex-start;
 }
 
 .sidebar-link:hover {
@@ -153,12 +219,135 @@ body.has-sidebar .content-wrapper {
   border-left-color: var(--sidebar-border);
 }
 
+.sidebar .link-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.sidebar-icon,
+.sidebar-toggle-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+}
+
+.submenu-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--sidebar-text) !important;
+  cursor: pointer;
+  padding: 0.5rem;
+  border-radius: 0.375rem;
+  transition: background-color 0.2s ease;
+}
+
+.submenu-toggle:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.submenu-toggle svg {
+  transition: transform 0.3s ease;
+}
+
+.submenu-toggle.open svg {
+  transform: rotate(180deg);
+}
+
 .submenu {
-  padding-left: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-left: 1.5rem;
+  margin: 0;
+  margin-top: 0.25rem;
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
   overflow: hidden;
   max-height: 0;
   transition: max-height 0.3s ease;
+}
+
+.submenu .sidebar-link {
+  padding: 0.65rem 1.5rem;
+  font-size: 0.9rem;
+  border-left-width: 3px;
+}
+
+.sidebar-setting-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  margin-top: 1.5rem;
+  color: var(--sidebar-text);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.sidebar-setting-label {
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.sidebar-switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.sidebar-switch-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.sidebar-switch-track {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background-color: rgba(255, 255, 255, 0.35);
+  transition: background-color 0.3s ease;
+}
+
+.sidebar-switch-thumb {
+  position: absolute;
+  left: 4px;
+  top: 4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background-color: var(--white);
+  transition: transform 0.3s ease;
+}
+
+.sidebar-switch-input:checked + .sidebar-switch-track {
+  background-color: var(--primary);
+}
+
+.sidebar-switch-input:checked + .sidebar-switch-track + .sidebar-switch-thumb {
+  transform: translateX(20px);
+}
+
+.sidebar-switch-input:focus-visible + .sidebar-switch-track {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  padding: 1.5rem;
+  text-align: center;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--sidebar-text);
+}
+
+.sidebar-footer__brand {
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
 }
 
 .submenu-link {
@@ -171,14 +360,6 @@ body.has-sidebar .content-wrapper {
 
 .submenu-link:hover {
   color: var(--primary-light);
-}
-
-.submenu-toggle svg {
-  transition: transform 0.3s ease;
-}
-
-.submenu-toggle.open svg {
-  transform: rotate(180deg);
 }
 
 /* Client sidebar layout */

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -1,8 +1,8 @@
-<nav id="sidebar" class="sidebar flex flex-col" aria-label="Menu lateral">
-  <div class="sidebar-logo p-4 flex items-center justify-center space-x-4">
+<nav id="sidebar" class="sidebar" aria-label="Menu lateral">
+  <div class="sidebar-logo">
     <a
       href="/configuracao-perfil.html"
-      class="bg-white w-12 h-12 rounded-lg flex items-center justify-center"
+      class="sidebar-logo-link sidebar-logo-link--profile"
       aria-label="Perfil"
     >
       <svg
@@ -11,7 +11,7 @@
         viewBox="0 0 24 24"
         stroke-width="1.5"
         stroke="currentColor"
-        class="w-7 h-7 text-black"
+        class="sidebar-logo-icon"
       >
         <path
           stroke-linecap="round"
@@ -22,7 +22,7 @@
     </a>
     <a
       href="/index.html"
-      class="flex items-center justify-center w-12 h-12"
+      class="sidebar-logo-link sidebar-logo-link--home"
       aria-label="Início"
     >
       <svg
@@ -31,7 +31,7 @@
         viewBox="0 0 24 24"
         stroke-width="1.5"
         stroke="currentColor"
-        class="w-8 h-8"
+        class="sidebar-logo-icon sidebar-logo-icon--home"
       >
         <path
           stroke-linecap="round"
@@ -41,11 +41,11 @@
       </svg>
     </a>
   </div>
-  <ul class="sidebar-menu py-4">
+  <ul class="sidebar-menu">
     <li>
       <a
         href="/gestor.html"
-        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        class="sidebar-link"
         id="menu-gestao"
         data-perfil="gestor"
       >
@@ -55,7 +55,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -69,7 +69,7 @@
     <li>
       <a
         href="/financeiro.html"
-        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        class="sidebar-link"
         id="menu-financeiro"
         data-perfil="gestor"
       >
@@ -79,7 +79,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -93,7 +93,7 @@
     <li>
       <a
         href="/atualizacoes.html"
-        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        class="sidebar-link"
         id="menu-atualizacoes"
         data-perfil="gestor"
       >
@@ -103,7 +103,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -117,7 +117,7 @@
     <li>
       <a
         href="/painel-atualizacoes-gerais.html"
-        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        class="sidebar-link"
         id="menu-painel-atualizacoes-gerais"
       >
         <svg
@@ -126,7 +126,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -140,7 +140,7 @@
     <li>
       <a
         href="/painel-atualizacoes-mentorados.html"
-        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        class="sidebar-link"
         id="menu-painel-atualizacoes-mentorados"
         data-perfil="gestor"
       >
@@ -150,7 +150,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -164,7 +164,7 @@
     <li>
       <a
         href="/saques.html"
-        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        class="sidebar-link"
         id="menu-saques"
         data-perfil="gestor"
       >
@@ -174,7 +174,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -188,7 +188,7 @@
     <li>
       <a
         href="/produtos-precos.html"
-        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        class="sidebar-link"
         id="menu-produtos-precos"
         data-perfil="gestor,responsavel financeiro"
       >
@@ -198,7 +198,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -212,7 +212,7 @@
     <li>
       <a
         href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamentoGestor"
-        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        class="sidebar-link"
         id="menu-acompanhamento-gestor"
         data-perfil="gestor"
       >
@@ -222,7 +222,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -239,7 +239,7 @@
     <li>
       <a
         href="/mentoria.html"
-        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        class="sidebar-link"
         id="menu-mentoria"
         data-perfil="gestor"
       >
@@ -249,7 +249,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -263,7 +263,7 @@
     <li>
       <a
         href="/perfil-mentorado.html"
-        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        class="sidebar-link"
         id="menu-perfil-mentorado"
         data-perfil="gestor"
       >
@@ -273,7 +273,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -287,7 +287,7 @@
     <li>
       <a
         href="/equipes.html"
-        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        class="sidebar-link"
         id="menu-equipes"
         data-perfil="gestor"
       >
@@ -297,7 +297,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -311,7 +311,7 @@
     <li>
       <a
         href="/gestao-produtos.html"
-        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        class="sidebar-link"
         id="menu-produtos"
         data-perfil="gestor"
       >
@@ -321,7 +321,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -335,7 +335,7 @@
     <li>
       <a
         href="/sku-associado.html"
-        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        class="sidebar-link"
         id="menu-sku-associado"
         data-perfil="gestor"
       >
@@ -345,7 +345,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -359,7 +359,7 @@
     <li>
       <a
         href="/desempenho.html"
-        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        class="sidebar-link"
         id="menu-desempenho"
         data-perfil="gestor"
       >
@@ -369,7 +369,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -381,10 +381,10 @@
       </a>
     </li>
     <li>
-      <div class="sidebar-item flex items-center justify-between">
+      <div class="sidebar-item">
         <a
           href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento"
-          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          class="sidebar-link"
           id="menu-vendas"
           data-perfil="usuario,gestor"
         >
@@ -394,7 +394,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5 mr-3"
+            class="sidebar-icon"
           >
             <path
               stroke-linecap="round"
@@ -404,17 +404,14 @@
           </svg>
           <span class="link-text">Vendas</span>
         </a>
-        <button
-          class="submenu-toggle p-2"
-          onclick="toggleMenu('menuVendas', this)"
-        >
+        <button class="submenu-toggle" onclick="toggleMenu('menuVendas', this)">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5"
+            class="sidebar-toggle-icon"
           >
             <path
               stroke-linecap="round"
@@ -424,35 +421,32 @@
           </svg>
         </button>
       </div>
-      <ul
-        id="menuVendas"
-        class="submenu space-y-1 overflow-hidden transition-all duration-300"
-      >
+      <ul id="menuVendas" class="submenu">
         <li>
           <a
             href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento"
-            class="sidebar-link block py-2 px-4 transition-colors"
+            class="sidebar-link"
             >Registrar Faturamento</a
           >
         </li>
         <li>
           <a
             href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=registroFaturamento"
-            class="sidebar-link block py-2 px-4 transition-colors"
+            class="sidebar-link"
             >Acompanhamento Faturamento</a
           >
         </li>
         <li>
           <a
             href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=controleVendas"
-            class="sidebar-link block py-2 px-4 transition-colors"
+            class="sidebar-link"
             >Acompanhamento Vendas</a
           >
         </li>
         <li>
           <a
             href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamento"
-            class="sidebar-link block py-2 px-4 transition-colors"
+            class="sidebar-link"
             >Acompanhamento Mensal</a
           >
         </li>
@@ -461,7 +455,7 @@
     <li>
       <a
         href="/saques.html"
-        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        class="sidebar-link"
         id="menu-saques"
         data-perfil="gestor"
       >
@@ -471,7 +465,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -483,10 +477,10 @@
       </a>
     </li>
     <li>
-      <div class="sidebar-item flex items-center justify-between">
+      <div class="sidebar-item">
         <a
           href="/etiquetas-ocr.html"
-          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          class="sidebar-link"
           id="menu-etiquetas"
           data-perfil="usuario,gestor"
         >
@@ -496,7 +490,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5 mr-3"
+            class="sidebar-icon"
           >
             <path
               stroke-linecap="round"
@@ -512,7 +506,7 @@
           <span class="link-text">Etiquetas</span>
         </a>
         <button
-          class="submenu-toggle p-2"
+          class="submenu-toggle"
           onclick="toggleMenu('menuEtiquetas', this)"
         >
           <svg
@@ -521,7 +515,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5"
+            class="sidebar-toggle-icon"
           >
             <path
               stroke-linecap="round"
@@ -531,38 +525,23 @@
           </svg>
         </button>
       </div>
-      <ul
-        id="menuEtiquetas"
-        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-      >
+      <ul id="menuEtiquetas" class="submenu">
         <li>
-          <a
-            href="/etiquetas-ocr.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
-            >Etiquetas PDF</a
-          >
+          <a href="/etiquetas-ocr.html" class="sidebar-link">Etiquetas PDF</a>
         </li>
         <li>
-          <a
-            href="/zpl-import.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
-            >Etiquetas ZPL</a
-          >
+          <a href="/zpl-import.html" class="sidebar-link">Etiquetas ZPL</a>
         </li>
         <li>
-          <a
-            href="/zpl-import-ocr.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
-            >ZPL Import ocr</a
-          >
+          <a href="/zpl-import-ocr.html" class="sidebar-link">ZPL Import ocr</a>
         </li>
       </ul>
     </li>
     <li>
-      <div class="sidebar-item flex items-center justify-between">
+      <div class="sidebar-item">
         <a
           href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao"
-          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          class="sidebar-link"
           id="menu-precificacao"
           data-perfil="usuario,gestor"
         >
@@ -572,7 +551,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5 mr-3"
+            class="sidebar-icon"
           >
             <path
               stroke-linecap="round"
@@ -588,7 +567,7 @@
           <span class="link-text">Precificação</span>
         </a>
         <button
-          class="submenu-toggle p-2"
+          class="submenu-toggle"
           onclick="toggleMenu('menuPrecificacao', this)"
         >
           <svg
@@ -597,7 +576,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5"
+            class="sidebar-toggle-icon"
           >
             <path
               stroke-linecap="round"
@@ -607,14 +586,11 @@
           </svg>
         </button>
       </div>
-      <ul
-        id="menuPrecificacao"
-        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-      >
+      <ul id="menuPrecificacao" class="submenu">
         <li>
           <a
             href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao"
-            class="sidebar-link block py-2 px-4 transition-colors"
+            class="sidebar-link"
             data-perfil="usuario,cliente,adm"
             >Precificação</a
           >
@@ -622,7 +598,7 @@
         <li>
           <a
             href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=lista-precos"
-            class="sidebar-link block py-2 px-4 transition-colors"
+            class="sidebar-link"
             data-perfil="usuario,cliente,adm"
             >Lista Preços</a
           >
@@ -630,7 +606,7 @@
         <li>
           <a
             href="/SISTEMA%20DE%20CUSTEIO%20DE%20PRODU%C3%87%C3%83O%20E%20PRODUTOS.html#mdf"
-            class="sidebar-link block py-2 px-4 transition-colors"
+            class="sidebar-link"
             data-perfil="usuario,adm"
             >Custeio de Produção</a
           >
@@ -638,7 +614,7 @@
         <li>
           <a
             href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=historico"
-            class="sidebar-link block py-2 px-4 transition-colors"
+            class="sidebar-link"
             data-perfil="usuario,adm"
             >Histórico</a
           >
@@ -646,10 +622,10 @@
       </ul>
     </li>
     <li>
-      <div class="sidebar-item flex items-center justify-between">
+      <div class="sidebar-item">
         <a
           href="/promocoes-shopee.html"
-          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          class="sidebar-link"
           id="menu-marketing"
           data-perfil="usuario,gestor"
         >
@@ -659,7 +635,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5 mr-3"
+            class="sidebar-icon"
           >
             <path
               stroke-linecap="round"
@@ -670,7 +646,7 @@
           <span class="link-text">Marketing</span>
         </a>
         <button
-          class="submenu-toggle p-2"
+          class="submenu-toggle"
           onclick="toggleMenu('menuMarketing', this)"
         >
           <svg
@@ -679,7 +655,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5"
+            class="sidebar-toggle-icon"
           >
             <path
               stroke-linecap="round"
@@ -689,45 +665,30 @@
           </svg>
         </button>
       </div>
-      <ul
-        id="menuMarketing"
-        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-      >
+      <ul id="menuMarketing" class="submenu">
         <li>
-          <a
-            href="/promocoes-shopee.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
+          <a href="/promocoes-shopee.html" class="sidebar-link"
             >Promoções Shopee</a
           >
         </li>
         <li>
-          <a
-            href="/ads.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
-            >Shopee Ads</a
-          >
+          <a href="/ads.html" class="sidebar-link">Shopee Ads</a>
         </li>
         <li>
-          <a
-            href="/ads-lista.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
-            >Anúncios Salvos</a
-          >
+          <a href="/ads-lista.html" class="sidebar-link">Anúncios Salvos</a>
         </li>
         <li>
-          <a
-            href="/acompanhamento-promocoes.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
+          <a href="/acompanhamento-promocoes.html" class="sidebar-link"
             >Acompanhamento Promoções</a
           >
         </li>
       </ul>
     </li>
     <li>
-      <div class="sidebar-item flex items-center justify-between">
+      <div class="sidebar-item">
         <a
           href="/anuncios-tabs/cadastro.html"
-          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          class="sidebar-link"
           id="menu-anuncios"
           data-perfil="usuario,gestor"
         >
@@ -737,7 +698,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5 mr-3"
+            class="sidebar-icon"
           >
             <path
               stroke-linecap="round"
@@ -748,7 +709,7 @@
           <span class="link-text">Anúncios</span>
         </a>
         <button
-          class="submenu-toggle p-2"
+          class="submenu-toggle"
           onclick="toggleMenu('menuAnuncios', this)"
         >
           <svg
@@ -757,7 +718,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5"
+            class="sidebar-toggle-icon"
           >
             <path
               stroke-linecap="round"
@@ -767,66 +728,47 @@
           </svg>
         </button>
       </div>
-      <ul
-        id="menuAnuncios"
-        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-      >
+      <ul id="menuAnuncios" class="submenu">
         <li>
-          <a
-            href="/anuncios-tabs/cadastro.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
+          <a href="/anuncios-tabs/cadastro.html" class="sidebar-link"
             >Cadastro / Atualização</a
           >
         </li>
         <li>
-          <a
-            href="/anuncios-tabs/anuncios.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
+          <a href="/anuncios-tabs/anuncios.html" class="sidebar-link"
             >Anúncios</a
           >
         </li>
         <li>
-          <a
-            href="/anuncios-tabs/analise.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
+          <a href="/anuncios-tabs/analise.html" class="sidebar-link"
             >Análise IA</a
           >
         </li>
         <li>
-          <a
-            href="/anuncios-tabs/evolucao.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
+          <a href="/anuncios-tabs/evolucao.html" class="sidebar-link"
             >Evolução</a
           >
         </li>
         <li>
-          <a
-            href="/anuncios-tabs/criar-ia.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
+          <a href="/anuncios-tabs/criar-ia.html" class="sidebar-link"
             >Criar Anúncio com IA</a
           >
         </li>
         <li>
-          <a
-            href="/anuncios-tabs/planilha-shopee.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
+          <a href="/anuncios-tabs/planilha-shopee.html" class="sidebar-link"
             >Planilha Shopee</a
           >
         </li>
         <li>
-          <a
-            href="/expedicao.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
-            >Expedição</a
-          >
+          <a href="/expedicao.html" class="sidebar-link">Expedição</a>
         </li>
       </ul>
     </li>
     <li>
-      <div class="sidebar-item flex items-center justify-between">
+      <div class="sidebar-item">
         <a
           href="/expedicao.html"
-          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          class="sidebar-link"
           id="menu-expedicao"
           data-perfil="usuario,gestor"
         >
@@ -836,7 +778,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5 mr-3"
+            class="sidebar-icon"
           >
             <path
               stroke-linecap="round"
@@ -847,7 +789,7 @@
           <span class="link-text">Expedição</span>
         </a>
         <button
-          class="submenu-toggle p-2"
+          class="submenu-toggle"
           onclick="toggleMenu('menuExpedicao', this)"
         >
           <svg
@@ -856,7 +798,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5"
+            class="sidebar-toggle-icon"
           >
             <path
               stroke-linecap="round"
@@ -866,59 +808,38 @@
           </svg>
         </button>
       </div>
-      <ul
-        id="menuExpedicao"
-        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-      >
+      <ul id="menuExpedicao" class="submenu">
         <li>
-          <a
-            href="/atualizacoes-dia.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
+          <a href="/atualizacoes-dia.html" class="sidebar-link"
             >Atualizações do Dia</a
           >
         </li>
         <li>
-          <a
-            href="/configuracao-expedicao.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
+          <a href="/configuracao-expedicao.html" class="sidebar-link"
             >Configuração Expedição</a
           >
         </li>
         <li>
-          <a
-            href="/relatorios.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
-            >Relatórios</a
-          >
+          <a href="/relatorios.html" class="sidebar-link">Relatórios</a>
         </li>
         <li>
-          <a
-            href="/coletas.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
-            >Coletas</a
-          >
+          <a href="/coletas.html" class="sidebar-link">Coletas</a>
         </li>
         <li>
-          <a
-            href="/expedicao-historico.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
-            >Histórico</a
-          >
+          <a href="/expedicao-historico.html" class="sidebar-link">Histórico</a>
         </li>
         <li>
-          <a
-            href="/expedicao-pedidosreais.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
+          <a href="/expedicao-pedidosreais.html" class="sidebar-link"
             >Pedidos Reais</a
           >
         </li>
       </ul>
     </li>
     <li>
-      <div class="sidebar-item flex items-center justify-between">
+      <div class="sidebar-item">
         <a
           href="/gestao-contas.html"
-          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          class="sidebar-link"
           id="menu-gestao-contas"
           data-perfil="usuario,gestor"
         >
@@ -928,7 +849,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5 mr-3"
+            class="sidebar-icon"
           >
             <path
               stroke-linecap="round"
@@ -939,7 +860,7 @@
           <span class="link-text">Gestão de Contas</span>
         </a>
         <button
-          class="submenu-toggle p-2"
+          class="submenu-toggle"
           onclick="toggleMenu('menuGestaoContas', this)"
         >
           <svg
@@ -948,7 +869,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5"
+            class="sidebar-toggle-icon"
           >
             <path
               stroke-linecap="round"
@@ -958,31 +879,20 @@
           </svg>
         </button>
       </div>
-      <ul
-        id="menuGestaoContas"
-        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-      >
+      <ul id="menuGestaoContas" class="submenu">
         <li>
-          <a
-            href="/pdf-x-excel.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
-            >PDF X Excel</a
-          >
+          <a href="/pdf-x-excel.html" class="sidebar-link">PDF X Excel</a>
         </li>
         <li>
-          <a
-            href="/gestao-contas.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
-            >Configurações</a
-          >
+          <a href="/gestao-contas.html" class="sidebar-link">Configurações</a>
         </li>
       </ul>
     </li>
     <li>
-      <div class="sidebar-item flex items-center justify-between">
+      <div class="sidebar-item">
         <a
           href="/problemas.html"
-          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          class="sidebar-link"
           id="menu-acompanhamento"
           data-perfil="usuario,gestor"
         >
@@ -992,7 +902,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5 mr-3"
+            class="sidebar-icon"
           >
             <path
               stroke-linecap="round"
@@ -1003,7 +913,7 @@
           <span class="link-text">Acompanhamento</span>
         </a>
         <button
-          class="submenu-toggle p-2"
+          class="submenu-toggle"
           onclick="toggleMenu('menuAcompanhamento', this)"
         >
           <svg
@@ -1012,7 +922,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5"
+            class="sidebar-toggle-icon"
           >
             <path
               stroke-linecap="round"
@@ -1022,52 +932,45 @@
           </svg>
         </button>
       </div>
-      <ul
-        id="menuAcompanhamento"
-        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-      >
+      <ul id="menuAcompanhamento" class="submenu">
         <li>
-          <a
-            href="/problemas.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
-            >Problemas</a
-          >
+          <a href="/problemas.html" class="sidebar-link">Problemas</a>
         </li>
         <li>
           <a
             href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=previsao"
-            class="sidebar-link block py-2 px-4 transition-colors"
+            class="sidebar-link"
             >Previsão</a
           >
         </li>
         <li>
           <a
             href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar"
-            class="sidebar-link block py-2 px-4 transition-colors"
+            class="sidebar-link"
             >Conferir Sobras</a
           >
         </li>
         <li>
           <a
             href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=sobras"
-            class="sidebar-link block py-2 px-4 transition-colors"
+            class="sidebar-link"
             >Sobras</a
           >
         </li>
         <li>
           <a
             href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico"
-            class="sidebar-link block py-2 px-4 transition-colors"
+            class="sidebar-link"
             >Histórico</a
           >
         </li>
       </ul>
     </li>
     <li>
-      <div class="sidebar-item flex items-center justify-between">
+      <div class="sidebar-item">
         <a
           href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=produtos"
-          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          class="sidebar-link"
           id="menu-outros"
           data-perfil="usuario,gestor"
         >
@@ -1077,7 +980,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5 mr-3"
+            class="sidebar-icon"
           >
             <path
               stroke-linecap="round"
@@ -1087,17 +990,14 @@
           </svg>
           <span class="link-text">Outros</span>
         </a>
-        <button
-          class="submenu-toggle p-2"
-          onclick="toggleMenu('menuOutros', this)"
-        >
+        <button class="submenu-toggle" onclick="toggleMenu('menuOutros', this)">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5"
+            class="sidebar-toggle-icon"
           >
             <path
               stroke-linecap="round"
@@ -1107,42 +1007,31 @@
           </svg>
         </button>
       </div>
-      <ul
-        id="menuOutros"
-        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-      >
+      <ul id="menuOutros" class="submenu">
         <li>
           <a
             href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=produtos"
-            class="sidebar-link block py-2 px-4 transition-colors"
+            class="sidebar-link"
             >Produtos</a
           >
         </li>
         <li>
           <a
             href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=metas"
-            class="sidebar-link block py-2 px-4 transition-colors"
+            class="sidebar-link"
             >Cadastro de Sobra</a
           >
         </li>
         <li>
-          <a
-            href="/pedidos-bling.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
-            >Pedidos Bling</a
-          >
+          <a href="/pedidos-bling.html" class="sidebar-link">Pedidos Bling</a>
         </li>
         <li>
-          <a
-            href="/pedidos-shopee.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
-            >Pedidos Shopee</a
-          >
+          <a href="/pedidos-shopee.html" class="sidebar-link">Pedidos Shopee</a>
         </li>
         <li>
           <a
             href="https://matheus-35023.web.app"
-            class="sidebar-link block py-2 px-4 transition-colors"
+            class="sidebar-link"
             target="_blank"
             >Tiny</a
           >
@@ -1150,10 +1039,10 @@
       </ul>
     </li>
     <li>
-      <div class="sidebar-item flex items-center justify-between">
+      <div class="sidebar-item">
         <a
           href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard"
-          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          class="sidebar-link"
           id="menu-configuracoes"
           data-perfil="usuario,gestor"
         >
@@ -1163,7 +1052,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5 mr-3"
+            class="sidebar-icon"
           >
             <path
               stroke-linecap="round"
@@ -1179,7 +1068,7 @@
           <span class="link-text">Configurações</span>
         </a>
         <button
-          class="submenu-toggle p-2"
+          class="submenu-toggle"
           onclick="toggleMenu('menuConfiguracoes', this)"
         >
           <svg
@@ -1188,7 +1077,7 @@
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
-            class="w-5 h-5"
+            class="sidebar-toggle-icon"
           >
             <path
               stroke-linecap="round"
@@ -1198,53 +1087,38 @@
           </svg>
         </button>
       </div>
-      <ul
-        id="menuConfiguracoes"
-        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
-      >
+      <ul id="menuConfiguracoes" class="submenu">
         <li>
-          <a
-            href="/painel-usuarios.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
-            data-perfil="adm"
+          <a href="/painel-usuarios.html" class="sidebar-link" data-perfil="adm"
             >Painel de Usuários</a
           >
         </li>
         <li>
-          <a
-            href="/configuracao-perfil.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
+          <a href="/configuracao-perfil.html" class="sidebar-link"
             >Configuração de Perfil</a
           >
         </li>
         <li>
           <a
             href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=historico"
-            class="sidebar-link block py-2 px-4 transition-colors"
+            class="sidebar-link"
             >Histórico</a
           >
         </li>
         <li>
-          <a
-            href="/email-expedicao.html"
-            class="sidebar-link block py-2 px-4 transition-colors"
+          <a href="/email-expedicao.html" class="sidebar-link"
             >E-mail de Expedição</a
           >
         </li>
         <li>
-          <a
-            href="/manual.html"
-            target="_blank"
-            class="sidebar-link block py-2 px-4 transition-colors"
-            >Manual</a
-          >
+          <a href="/manual.html" target="_blank" class="sidebar-link">Manual</a>
         </li>
       </ul>
     </li>
     <li>
       <a
         href="/comunicacao.html"
-        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        class="sidebar-link"
         id="menu-comunicacao"
         data-perfil="cliente,usuario,gestor"
       >
@@ -1254,7 +1128,7 @@
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -1266,17 +1140,14 @@
       </a>
     </li>
     <li>
-      <button
-        id="startSidebarTourBtn"
-        class="sidebar-link w-full text-left flex items-center py-2 px-4 transition-colors"
-      >
+      <button id="startSidebarTourBtn" class="sidebar-link sidebar-action">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -1288,31 +1159,28 @@
       </button>
     </li>
     <li>
-      <div class="flex items-center justify-between px-4 mt-6">
-        <span class="text-sm">Modo Escuro</span>
-        <label class="relative inline-flex items-center cursor-pointer">
-          <input type="checkbox" id="darkModeToggle" class="sr-only peer" />
-          <div
-            class="w-11 h-6 bg-gray-300 peer-focus:outline-none rounded-full peer peer-checked:bg-orange-500 transition"
-          ></div>
-          <div
-            class="absolute left-1 top-1 bg-white w-4 h-4 rounded-full transition peer-checked:translate-x-full"
-          ></div>
+      <div class="sidebar-setting-row">
+        <span class="sidebar-setting-label">Modo Escuro</span>
+        <label class="sidebar-switch">
+          <input
+            type="checkbox"
+            id="darkModeToggle"
+            class="sidebar-switch-input"
+          />
+          <span class="sidebar-switch-track"></span>
+          <span class="sidebar-switch-thumb"></span>
         </label>
       </div>
     </li>
     <li>
-      <button
-        id="logoutSidebarBtn"
-        class="sidebar-link w-full text-left flex items-center py-2 px-4 transition-colors hidden"
-      >
+      <button id="logoutSidebarBtn" class="sidebar-link sidebar-action hidden">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-5 h-5 mr-3"
+          class="sidebar-icon"
         >
           <path
             stroke-linecap="round"
@@ -1324,7 +1192,7 @@
       </button>
     </li>
   </ul>
-  <div class="p-4 mt-auto text-center">
-    <span class="font-bold text-xl">VendedorPro</span>
+  <div class="sidebar-footer">
+    <span class="sidebar-footer__brand">VendedorPro</span>
   </div>
 </nav>

--- a/shared.js
+++ b/shared.js
@@ -334,32 +334,30 @@ async function loadPartial(selector, path) {
     el = document.createElement(selector.startsWith('#') ? 'div' : 'aside');
     el.id = id;
     if (id === 'sidebar-container') {
-      el.className =
-        'fixed inset-y-0 left-0 w-64 max-w-[80vw] overflow-auto z-40 transition-transform duration-200 ease-out shadow-lg';
       document.body.prepend(el);
-      // garante margem do conteúdo no desktop
-      document.querySelector('.main-content')?.classList.add('lg:ml-64');
     } else {
       // navbar acima do main
       document.body.insertBefore(el, document.querySelector('main') || null);
     }
-  } else {
-    if (id === 'sidebar-container') {
-      el.classList.add(
-        'fixed',
-        'inset-y-0',
-        'left-0',
-        'w-64',
-        'max-w-[80vw]',
-        'overflow-auto',
-        'z-40',
-        'transition-transform',
-        'duration-200',
-        'ease-out',
-        'shadow-lg',
-      );
-      document.querySelector('.main-content')?.classList.add('lg:ml-64');
-    }
+  } else if (id === 'sidebar-container') {
+    el.classList.remove(
+      'fixed',
+      'inset-y-0',
+      'left-0',
+      'w-64',
+      'max-w-[80vw]',
+      'overflow-auto',
+      'z-40',
+      'transition-transform',
+      'duration-200',
+      'ease-out',
+      'shadow-lg',
+      'lg:ml-64',
+    );
+  }
+
+  if (id === 'sidebar-container') {
+    document.querySelector('.main-content')?.classList.remove('lg:ml-64');
   }
 
   // sempre força rede p/ evitar cache velho do SW


### PR DESCRIPTION
## Summary
- centralize sidebar layout and component styling inside `css/sidebar.css`, adding dedicated rules for logo, menu, submenu, action buttons, dark mode toggle, and footer
- rewrite `partials/sidebar.html` to rely on the new sidebar classes instead of utility-class combinations while keeping existing structure and links intact
- stop injecting Tailwind utility classes for the sidebar container in `shared.js`, ensuring the unified stylesheet controls its presentation

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9513aebc8832ab11cf6037d31659a