### PR TITLE
Unify sidebar styling configuration

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -10,10 +10,6 @@
   --nav-hover: rgba(255, 255, 255, 0.1);
   --nav-text: #000000;
   --nav-border: #000000;
-  --sidebar-bg: var(--primary);
-  --sidebar-text: #ffffff;
-  --sidebar-border: #000000;
-  --sidebar-width: 18rem;
   --success: #4caf50;
   --error: #f44336;
   --background: #ffffff;
@@ -68,7 +64,4 @@ body.dark-mode {
   --nav-bg: #1f2937;
   --nav-text: #f9fafb;
   --nav-border: #1f2937;
-  --sidebar-bg: #1f2937;
-  --sidebar-text: #f9fafb;
-  --sidebar-border: #f9fafb;
 }

--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -1,9 +1,27 @@
+/* Sidebar design tokens */
+:root {
+  --sidebar-width: 18rem;
+  --sidebar-bg: var(--primary);
+  --sidebar-text: #ffffff;
+  --sidebar-border: #000000;
+  --sidebar-hover-bg: rgba(255, 255, 255, 0.1);
+  --sidebar-active-bg: rgba(255, 255, 255, 0.2);
+  --sidebar-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
+  --sidebar-text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+}
+
+body.dark-mode {
+  --sidebar-bg: #1f2937;
+  --sidebar-text: #f9fafb;
+  --sidebar-border: #f9fafb;
+}
+
 /* Sidebar container & overlay */
 #sidebar-container {
   position: fixed;
   top: 0;
   left: 0;
-  width: var(--sidebar-width, 18rem);
+  width: var(--sidebar-width);
   height: 100%;
   transform: translateX(-100%);
   transition: transform 0.3s ease;
@@ -33,18 +51,16 @@
 
 /* Layout adjustments when sidebar is present */
 body.has-sidebar .navbar {
-  left: var(--sidebar-width, 18rem);
+  left: var(--sidebar-width);
 }
 
-body.has-sidebar .content-wrapper {
-  margin-left: var(--sidebar-width, 18rem);
-}
-
+body.has-sidebar .content-wrapper,
 .main-content {
-  margin-left: var(--sidebar-width, 18rem);
+  margin-left: var(--sidebar-width);
 }
 
 @media (max-width: 1023px) {
+  body.has-sidebar .content-wrapper,
   .main-content {
     margin-left: 0;
   }
@@ -81,18 +97,17 @@ body.has-sidebar .content-wrapper {
   overflow-x: hidden;
   background-color: var(--sidebar-bg);
   color: var(--sidebar-text) !important;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
-  width: var(--sidebar-width, 18rem);
+  text-shadow: var(--sidebar-text-shadow);
+  width: var(--sidebar-width);
   min-height: 100vh;
   padding-top: 1rem;
   border-right: 1px solid var(--sidebar-border);
-  box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--sidebar-shadow);
   font-family: 'Poppins', 'Inter', sans-serif;
 }
 
-/* Subtle text and icon shadow for better contrast */
 .sidebar-link {
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  text-shadow: var(--sidebar-text-shadow);
   font-weight: 500;
 }
 
@@ -100,6 +115,8 @@ body.has-sidebar .content-wrapper {
   color: var(--sidebar-text) !important;
   stroke: var(--sidebar-text) !important;
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.25));
+  flex-shrink: 0;
+  display: block;
 }
 
 .sidebar input,
@@ -121,6 +138,9 @@ body.has-sidebar .content-wrapper {
 }
 
 .submenu-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: none;
   border: none;
   color: var(--sidebar-text) !important;
@@ -139,16 +159,18 @@ body.has-sidebar .content-wrapper {
   text-decoration: none;
   font-size: 0.95rem;
   border-radius: 0.375rem;
-  transition: background-color 0.2s;
   border-left: 4px solid var(--sidebar-border);
+  transition:
+    background-color 0.2s,
+    border-left-color 0.2s;
 }
 
 .sidebar-link:hover {
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: var(--sidebar-hover-bg);
 }
 
 .sidebar-link.active {
-  background-color: rgba(255, 255, 255, 0.2);
+  background-color: var(--sidebar-active-bg);
   color: var(--sidebar-text) !important;
   border-left-color: var(--sidebar-border);
 }
@@ -162,11 +184,11 @@ body.has-sidebar .content-wrapper {
 }
 
 .submenu-link {
-  color: inherit;
+  color: var(--sidebar-text) !important;
   text-decoration: none;
   display: block;
   transition: color 0.2s;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  text-shadow: var(--sidebar-text-shadow);
 }
 
 .submenu-link:hover {
@@ -181,52 +203,17 @@ body.has-sidebar .content-wrapper {
   transform: rotate(180deg);
 }
 
-/* Client sidebar layout */
-.sidebar.client-layout {
-  background: var(--sidebar-bg);
-}
-.sidebar.client-layout .sidebar-link {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 12px;
-  width: 100%;
-  padding: 0.8rem 1.5rem;
-  background: transparent;
-  color: var(--sidebar-text) !important;
-  border-radius: 0.375rem;
-  border-left: 4px solid var(--sidebar-border);
-}
-.sidebar.client-layout .sidebar-link:hover {
-  background-color: rgba(255, 255, 255, 0.1);
-}
-.sidebar.client-layout .sidebar-link.active {
-  background-color: rgba(255, 255, 255, 0.2);
-  border-left-color: var(--sidebar-border);
-}
-.sidebar.client-layout .sidebar-link svg {
-  display: block;
-}
-.sidebar.client-layout .submenu-toggle {
-  display: block;
-}
-
 /* Mobile-specific sidebar rules */
 @media (max-width: 768px) {
-  .sidebar {
-    width: var(--sidebar-width, 18rem);
-  }
   .sidebar .link-text {
     display: inline;
   }
+
   .sidebar-link {
     justify-content: flex-start;
   }
+
   .sidebar-link .mr-3 {
     margin-right: 0.75rem;
-  }
-  .content-wrapper,
-  body.has-sidebar .content-wrapper {
-    margin-left: 0;
   }
 }


### PR DESCRIPTION
## Summary
- move sidebar visual variables out of `base.css` and define them with dedicated sidebar design tokens
- streamline `sidebar.css` to reuse the shared tokens across layout, hover, and active states while removing redundant client-layout rules
- keep the responsive layout logic aligned with the unified sidebar width variable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9513aebc8832ab11cf6037d31659a