### PR TITLE
Padroniza layout do sidebar entre perfis

### DIFF
--- a/css/sidebar.css
+++ b/css/sidebar.css
@@ -3,7 +3,8 @@
   position: fixed;
   top: 0;
   left: 0;
-  width: var(--sidebar-width, 18rem);
+  width: min(var(--sidebar-width, 18rem), 80vw);
+  max-width: min(var(--sidebar-width, 18rem), 80vw);
   height: 100%;
   transform: translateX(-100%);
   transition: transform 0.3s ease;
@@ -179,36 +180,6 @@ body.has-sidebar .content-wrapper {
 
 .submenu-toggle.open svg {
   transform: rotate(180deg);
-}
-
-/* Client sidebar layout */
-.sidebar.client-layout {
-  background: var(--sidebar-bg);
-}
-.sidebar.client-layout .sidebar-link {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 12px;
-  width: 100%;
-  padding: 0.8rem 1.5rem;
-  background: transparent;
-  color: var(--sidebar-text) !important;
-  border-radius: 0.375rem;
-  border-left: 4px solid var(--sidebar-border);
-}
-.sidebar.client-layout .sidebar-link:hover {
-  background-color: rgba(255, 255, 255, 0.1);
-}
-.sidebar.client-layout .sidebar-link.active {
-  background-color: rgba(255, 255, 255, 0.2);
-  border-left-color: var(--sidebar-border);
-}
-.sidebar.client-layout .sidebar-link svg {
-  display: block;
-}
-.sidebar.client-layout .submenu-toggle {
-  display: block;
 }
 
 /* Mobile-specific sidebar rules */

--- a/shared.js
+++ b/shared.js
@@ -335,31 +335,30 @@ async function loadPartial(selector, path) {
     el.id = id;
     if (id === 'sidebar-container') {
       el.className =
-        'fixed inset-y-0 left-0 w-64 max-w-[80vw] overflow-auto z-40 transition-transform duration-200 ease-out shadow-lg';
+        'fixed inset-y-0 left-0 overflow-auto z-40 transition-transform duration-200 ease-out shadow-lg';
       document.body.prepend(el);
-      // garante margem do conteúdo no desktop
-      document.querySelector('.main-content')?.classList.add('lg:ml-64');
     } else {
       // navbar acima do main
       document.body.insertBefore(el, document.querySelector('main') || null);
     }
-  } else {
-    if (id === 'sidebar-container') {
-      el.classList.add(
-        'fixed',
-        'inset-y-0',
-        'left-0',
-        'w-64',
-        'max-w-[80vw]',
-        'overflow-auto',
-        'z-40',
-        'transition-transform',
-        'duration-200',
-        'ease-out',
-        'shadow-lg',
-      );
-      document.querySelector('.main-content')?.classList.add('lg:ml-64');
-    }
+  } else if (id === 'sidebar-container') {
+    el.classList.add(
+      'fixed',
+      'inset-y-0',
+      'left-0',
+      'overflow-auto',
+      'z-40',
+      'transition-transform',
+      'duration-200',
+      'ease-out',
+      'shadow-lg',
+    );
+    el.classList.remove('w-64', 'max-w-[80vw]');
+  }
+
+  if (id === 'sidebar-container') {
+    const main = document.querySelector('.main-content');
+    main?.classList.remove('lg:ml-64');
   }
 
   // sempre força rede p/ evitar cache velho do SW
@@ -724,7 +723,7 @@ document.addEventListener('sidebarLoaded', async () => {
     const sidebar = document.getElementById('sidebar');
     if (!sidebar) return;
 
-    sidebar.classList.add('client-layout');
+    sidebar.classList.remove('client-layout');
 
     const menu = sidebar.querySelector('.sidebar-menu');
     if (!menu) return;


### PR DESCRIPTION
## Summary
- remove as classes utilitárias que reduziam a largura do sidebar apenas para usuários/clientes e garante que o container respeite `--sidebar-width`
- elimina o estilo específico de `client-layout` para reutilizar o mesmo visual do sidebar dos gestores

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c96f5934e4832aba109379f9f9c12f