### PR TITLE
Fix expedition cards stretching in grid view

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -241,6 +241,24 @@
   gap: 0.75rem;
 }
 
+#labelsList.grid {
+  align-items: flex-start;
+  align-items: start;
+  justify-items: center;
+}
+
+#labelsList.grid .expedicao-pdf-card {
+  width: 100%;
+  max-width: 320px;
+  align-self: flex-start;
+  align-self: start;
+}
+
+#labelsList.grid .ticket-card {
+  align-self: flex-start;
+  align-self: start;
+}
+
 .expedicao-pdf-header {
   display: flex;
   justify-content: space-between;
@@ -462,6 +480,7 @@
 .expedicao-pdf-card--list {
   gap: 1.5rem;
   width: 100%;
+  max-width: none;
 }
 
 .expedicao-pdf-list-content {


### PR DESCRIPTION
## Summary
- prevent expedition card grid items from stretching across the full track width
- center the cards within the grid and cap their width to keep a compact ticket layout
- ensure the list view keeps full-width cards by removing the width cap in that mode

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c970de7e78832abecb1bd0e9bfcd01