### PR TITLE
Fix expedition manager sidebar visibility

### DIFF
--- a/login.js
+++ b/login.js
@@ -409,10 +409,20 @@ function restoreSidebar() {
 }
 
 function normalizePerfil(perfil) {
-  const p = (perfil || '').toLowerCase().trim();
-  if (['adm', 'admin', 'administrador'].includes(p)) return 'adm';
-  if (['usuario completo', 'usuario'].includes(p)) return 'usuario';
-  if (['usuario basico', 'cliente'].includes(p)) return 'cliente';
+  const raw = (perfil || '').toString().toLowerCase().trim();
+  if (!raw) return raw;
+
+  const sanitized = raw
+    .normalize('NFD')
+    .replace(new RegExp('[\\u0300-\\u036f]', 'g'), '');
+
+  if (['gestor expedicao', 'gestor de expedicao'].includes(sanitized)) {
+    return 'gestor expedicao';
+  }
+
+  if (['adm', 'admin', 'administrador'].includes(sanitized)) return 'adm';
+  if (['usuario completo', 'usuario'].includes(sanitized)) return 'usuario';
+  if (['usuario basico', 'cliente'].includes(sanitized)) return 'cliente';
   if (
     [
       'gestor',
@@ -420,10 +430,10 @@ function normalizePerfil(perfil) {
       'responsavel',
       'gestor financeiro',
       'responsavel financeiro',
-    ].includes(p)
+    ].includes(sanitized)
   )
     return 'gestor';
-  return p;
+  return sanitized;
 }
 function applyPerfilRestrictions(perfil) {
   const currentPerfil = normalizePerfil(perfil);
@@ -499,13 +509,21 @@ function applyPerfilRestrictions(perfil) {
     });
   }
 
+  const aliasPerfis = {
+    'gestor expedicao': ['gestor', 'usuario'],
+  };
+
   document.querySelectorAll('[data-perfil]').forEach((el) => {
     const allowedPerfis = (el.getAttribute('data-perfil') || '')
       .toLowerCase()
       .split(',')
       .map((p) => normalizePerfil(p));
     const show =
-      currentPerfil === 'adm' || allowedPerfis.includes(currentPerfil);
+      currentPerfil === 'adm' ||
+      allowedPerfis.includes(currentPerfil) ||
+      (aliasPerfis[currentPerfil] || []).some((alias) =>
+        allowedPerfis.includes(alias),
+      );
     if (!show) {
       el.classList.add('hidden');
     } else {


### PR DESCRIPTION
## Summary
- normalize user profiles to handle expedition manager labels with and without accents
- ensure expedition manager sidebar links remain visible by allowing shared data-perfil aliases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c989ed993c832a901f13ac3794efe4