### PR TITLE
Rename Gestor Expedicao profile to Expedicao

### DIFF
--- a/login.js
+++ b/login.js
@@ -305,7 +305,7 @@ async function showUserArea(user) {
     applyPerfilRestrictions(perfil);
 
     // 2) verifica associação com expedição (gestor ou responsável)
-    if (perfil !== 'gestor expedicao') {
+    if (perfil !== 'expedicao') {
       await checkExpedicao(user);
     }
 
@@ -427,7 +427,7 @@ function normalizePerfil(perfil) {
 }
 function applyPerfilRestrictions(perfil) {
   const currentPerfil = normalizePerfil(perfil);
-  if (!currentPerfil || currentPerfil === 'expedicao') return;
+  if (!currentPerfil) return;
   const sidebar = document.getElementById('sidebar');
   if (!sidebar) return;
 
@@ -478,7 +478,7 @@ function applyPerfilRestrictions(perfil) {
       'menu-sku-associado',
       'menu-desempenho',
     ],
-    'gestor expedicao': [
+    expedicao: [
       'menu-expedicao',
       'menu-configuracoes',
       'menu-comunicacao',

--- a/painel-usuarios.html
+++ b/painel-usuarios.html
@@ -57,7 +57,7 @@
             <select id="perfil" class="w-full p-2 border rounded">
               <option value="Usuario Completo">Usuário Completo</option>
               <option value="Usuario Basico">Usuário Básico</option>
-              <option value="Gestor Expedicao">Gestor Expedição</option>
+              <option value="Expedicao">Expedição</option>
               <option value="Responsavel Financeiro">
                 Responsável Financeiro
               </option>


### PR DESCRIPTION
## Summary
- rename the Gestor Expedição profile option to Expedicao in the user management panel
- update login profile checks so the Expedicao profile keeps the intended sidebar restrictions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c98bf432fc832aba0068ec14ca5877