### PR TITLE
Restrict expedition sidebar to required tabs

### DIFF
--- a/login.js
+++ b/login.js
@@ -106,6 +106,11 @@ let wasLoggedIn = false;
 let authListenerRegistered = false;
 let explicitLogout = false;
 let isExpedicao = false;
+const EXPEDICAO_ALLOWED_MENU_IDS = [
+  'menu-expedicao',
+  'menu-configuracoes',
+  'menu-painel-atualizacoes-gerais',
+];
 let notifUnsub = null;
 let expNotifUnsub = null;
 let updNotifUnsub = null;
@@ -370,16 +375,15 @@ function hideUserArea() {
   restoreSidebar();
 }
 
-function applyExpedicaoSidebar() {
+function applyExpedicaoSidebar(extraAllowedIds = []) {
+  const allowedIds = Array.from(
+    new Set([...EXPEDICAO_ALLOWED_MENU_IDS, ...extraAllowedIds]),
+  );
+
   const filter = () => {
     const sidebar = document.getElementById('sidebar');
     if (!sidebar) return;
 
-    const allowedIds = [
-      'menu-expedicao',
-      'menu-configuracoes',
-      'menu-comunicacao',
-    ];
     const allowedLis = allowedIds
       .map((id) => document.getElementById(id)?.closest('li'))
       .filter(Boolean);
@@ -396,6 +400,11 @@ function applyExpedicaoSidebar() {
     const submenu = document.getElementById('menuExpedicao');
     if (submenu) {
       submenu.style.maxHeight = submenu.scrollHeight + 'px';
+    }
+
+    const configMenu = document.getElementById('menuConfiguracoes');
+    if (configMenu) {
+      configMenu.style.maxHeight = configMenu.scrollHeight + 'px';
     }
   };
 
@@ -435,7 +444,11 @@ function normalizePerfil(perfil) {
 }
 function applyPerfilRestrictions(perfil) {
   const currentPerfil = normalizePerfil(perfil);
-  if (!currentPerfil || currentPerfil === 'expedicao') return;
+  if (!currentPerfil) return;
+  if (currentPerfil === 'expedicao') {
+    applyExpedicaoSidebar();
+    return;
+  }
   const sidebar = document.getElementById('sidebar');
   if (!sidebar) return;
 
@@ -486,13 +499,7 @@ function applyPerfilRestrictions(perfil) {
       'menu-sku-associado',
       'menu-desempenho',
     ],
-    expedicao: [
-      'menu-expedicao',
-      'menu-configuracoes',
-      'menu-comunicacao',
-      'menu-painel-atualizacoes-gerais',
-      'menu-painel-atualizacoes-mentorados',
-    ],
+    expedicao: EXPEDICAO_ALLOWED_MENU_IDS,
   };
 
   const allowed = nivelMenus[currentPerfil];
@@ -548,7 +555,7 @@ async function checkExpedicao(user) {
     }
     if (!snap.empty) {
       isExpedicao = true;
-      applyExpedicaoSidebar();
+      applyExpedicaoSidebar(['menu-comunicacao']);
       const path = window.location.pathname.toLowerCase();
       if (!path.endsWith('/expedicao.html')) {
         window.location.href = 'expedicao.html';

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -828,7 +828,7 @@
           href="/expedicao.html"
           class="sidebar-link flex items-center py-2 px-4 transition-colors"
           id="menu-expedicao"
-          data-perfil="usuario,gestor"
+          data-perfil="usuario,gestor,expedicao"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -1155,7 +1155,7 @@
           href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=dashboard"
           class="sidebar-link flex items-center py-2 px-4 transition-colors"
           id="menu-configuracoes"
-          data-perfil="usuario,gestor"
+          data-perfil="usuario,gestor,expedicao"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -1206,7 +1206,7 @@
           <a
             href="/painel-usuarios.html"
             class="sidebar-link block py-2 px-4 transition-colors"
-            data-perfil="adm"
+            data-perfil="adm,expedicao"
             >Painel de Usuários</a
           >
         </li>


### PR DESCRIPTION
## Summary
- centralize the list of menus allowed to the expedição profile and reuse it when filtering the sidebar
- ensure the expedição profile applies the sidebar filter while keeping other profiles that manage expedição with communication access
- flag the expedição menu entries in the sidebar markup so the required configuration links stay visible to the profile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9927f1484832aaec85091c4f75277