### PR TITLE
Enable saques tab for user and client profiles

### DIFF
--- a/login.js
+++ b/login.js
@@ -475,6 +475,7 @@ function applyPerfilRestrictions(perfil) {
     ],
     cliente: [
       'menu-vendas',
+      'menu-saques',
       'menu-etiquetas',
       'menu-precificacao',
       'menu-expedicao',

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -166,7 +166,7 @@
         href="/saques.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-saques"
-        data-perfil="gestor"
+        data-perfil="gestor,usuario,cliente"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -463,7 +463,7 @@
         href="/saques.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-saques"
-        data-perfil="gestor"
+        data-perfil="gestor,usuario,cliente"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary
- allow the Saques sidebar link to render for gestor, usuario, and cliente profiles
- include the Saques menu in the cliente navigation permissions so it stays visible after login

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c99cc7f57c832abf8be6b0078d4aac