### PR TITLE
Exibe saques no menu para clientes e usuários

### DIFF
--- a/login.js
+++ b/login.js
@@ -475,6 +475,7 @@ function applyPerfilRestrictions(perfil) {
     ],
     cliente: [
       'menu-vendas',
+      'menu-saques',
       'menu-etiquetas',
       'menu-precificacao',
       'menu-expedicao',

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -166,7 +166,7 @@
         href="/saques.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-saques"
-        data-perfil="gestor"
+        data-perfil="gestor,usuario,cliente"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -463,7 +463,7 @@
         href="/saques.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-saques"
-        data-perfil="gestor"
+        data-perfil="gestor,usuario,cliente"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/shared.js
+++ b/shared.js
@@ -597,6 +597,7 @@ document.addEventListener('sidebarLoaded', async () => {
         'menu-comunicacao',
         'menu-painel-atualizacoes-gerais',
         'menu-painel-atualizacoes-mentorados',
+        'menu-saques',
       ].includes(id),
   );
 
@@ -604,6 +605,7 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-painel-atualizacoes-gerais',
     'menu-painel-atualizacoes-mentorados',
     'menu-vendas',
+    'menu-saques',
     'menu-etiquetas',
     'menu-precificacao',
     'menu-expedicao',


### PR DESCRIPTION
## Summary
- libera a aba de saques no sidebar para usuários e clientes
- ajusta a aplicação das permissões do sidebar para manter saques visível nesse perfil
- inclui o item de saques na lista de menus permitidos para clientes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c99cc7f57c832abf8be6b0078d4aac