### PR TITLE
Fix mobile visibility of notification bell

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1484,6 +1484,9 @@ input:checked + .toggle-slider:before {
   .navbar .menu-item {
     display: none;
   }
+  .navbar .menu-item.show-on-mobile {
+    display: inline-flex;
+  }
   .navbar .hamburger {
     display: block;
   }

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -26,7 +26,11 @@
   </div>
   <div class="navbar-right">
     <div id="notificationWrapper" class="relative">
-      <button id="notificationBtn" class="menu-item relative" title="Notificações">
+      <button
+        id="notificationBtn"
+        class="menu-item relative show-on-mobile"
+        title="Notificações"
+      >
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082A23.86 23.86 0 0 0 20.312 15.772 8.966 8.966 0 0 1 18 9.75V9a6 6 0 1 0-12 0v.75a8.966 8.966 0 0 1-2.312 6.021A23.86 23.86 0 0 0 9.143 17.082M14.857 17.082c.092.29.143.599.143.918a3 3 0 1 1-6 0c0-.319.051-.628.143-.918" />
         </svg>


### PR DESCRIPTION
## Summary
- mark the notification button so it remains visible on narrow viewports
- adjust mobile navbar styles to keep the notification bell displayed while hiding other menu items

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9a80832c8832aaeca7efd1e4c4cc9