### PR TITLE
feat: notificar dono ao imprimir ou concluir etiqueta

### DIFF
--- a/atualizacoes-dia.js
+++ b/atualizacoes-dia.js
@@ -39,6 +39,7 @@ onAuthStateChanged(auth, (user) => {
     }
     snap.forEach((doc) => {
       const dados = doc.data();
+      if (dados.tipo === 'status_etiqueta') return;
       const item = document.createElement('div');
       item.className = 'p-4 bg-white rounded shadow';
       const dataHora = dados.createdAt?.toDate

--- a/atualizacoes.js
+++ b/atualizacoes.js
@@ -423,6 +423,7 @@ async function carregarExpedicao() {
     let count = 0;
     snap.forEach((docSnap) => {
       const dados = docSnap.data();
+      if (dados.tipo === 'status_etiqueta') return;
       const dests = dados.destinatarios || [];
       if (
         currentUser &&

--- a/expedicao.html
+++ b/expedicao.html
@@ -1280,6 +1280,10 @@
           <button class="expedicao-card-btn" onclick="visualizar('${url}')">Abrir</button>
           <button class="expedicao-card-btn expedicao-card-btn--danger" onclick="excluirEtiqueta('${doc.id}', this.closest('.pdf-card'))">Excluir</button>
         </div>`;
+      div.dataset.ownerUid = data.ownerUid || '';
+      div.dataset.ownerEmail = data.ownerEmail || '';
+      div.dataset.fileName = name;
+      div.dataset.status = statusKey;
       return div;
     }
 
@@ -1329,7 +1333,67 @@
             <button class="expedicao-card-btn expedicao-card-btn--success" onclick="marcarConcluido('${doc.id}', this.closest('.pdf-card'))">Concluir</button>
           </div>
         </div>`;
+      div.dataset.ownerUid = data.ownerUid || '';
+      div.dataset.ownerEmail = data.ownerEmail || '';
+      div.dataset.fileName = name;
+      div.dataset.status = statusKey;
       return div;
+    }
+
+    async function notifyEtiquetaStatusChange({ id, newStatus, card, docData }) {
+      try {
+        if (!currentUser) return;
+        const perfilAtual = (window.userPerfil || '').toLowerCase();
+        if (perfilAtual !== 'expedicao') return;
+        if (!['impresso', 'concluido'].includes(newStatus)) return;
+
+        let ownerUids = [];
+        const docOwner = docData?.ownerUid;
+        if (Array.isArray(docOwner)) {
+          ownerUids = docOwner.filter(Boolean);
+        } else if (docOwner) {
+          ownerUids = [docOwner];
+        }
+
+        if (!ownerUids.length && card?.dataset?.ownerUid) {
+          ownerUids = card.dataset.ownerUid
+            .split(',')
+            .map(uid => uid.trim())
+            .filter(Boolean);
+        }
+
+        ownerUids = Array.from(
+          new Set(ownerUids.filter(uid => uid && uid !== currentUser.uid))
+        );
+        if (!ownerUids.length) return;
+
+        const arquivoNome =
+          docData?.name ||
+          docData?.arquivoNome ||
+          (card?.dataset?.fileName || 'Etiqueta');
+        const statusLabel =
+          docData?.statusLabel ||
+          (newStatus === 'impresso'
+            ? 'Impresso'
+            : newStatus === 'concluido'
+            ? 'Concluído'
+            : newStatus);
+
+        await db.collection('expedicaoMensagens').add({
+          tipo: 'status_etiqueta',
+          arquivoId: id,
+          arquivoNome,
+          status: newStatus,
+          statusLabel,
+          gestorUid: currentUser.uid,
+          gestorEmail: currentUser.email || '',
+          gestorNome: currentUserName || currentUser.displayName || currentUser.email || '',
+          destinatarios: ownerUids,
+          createdAt: firebase.firestore.FieldValue.serverTimestamp()
+        });
+      } catch (e) {
+        console.error('Erro ao notificar status da etiqueta:', e);
+      }
     }
 
     const pdfModal = document.getElementById('pdfModal');
@@ -1366,6 +1430,7 @@
 
     async function toggleImpresso(id, checkbox, card) {
       const checked = checkbox.checked;
+      const previousStatus = card?.dataset?.status || (checked ? 'nao_impresso' : 'impresso');
       const confirmMsg = `Deseja ${checked ? 'marcar como impresso' : 'marcar como não impresso'}?`;
       if (!confirm(confirmMsg)) {
         checkbox.checked = !checked;
@@ -1375,14 +1440,19 @@
       if (card) {
         card.classList.remove('expedicao-pdf-card--pending', 'expedicao-pdf-card--printed', 'expedicao-pdf-card--done');
         card.classList.add(checked ? 'expedicao-pdf-card--printed' : 'expedicao-pdf-card--pending');
+        card.dataset.status = checked ? 'impresso' : 'nao_impresso';
       }
       showToast('Status atualizado');
+      if (checked && previousStatus !== 'impresso') {
+        await notifyEtiquetaStatusChange({ id, newStatus: 'impresso', card });
+      }
     }
     window.toggleImpresso = toggleImpresso;
 
     async function toggleImpressoCard(id, button, card) {
       const current = button.dataset.status || 'nao_impresso';
       const newStatus = current === 'impresso' ? 'nao_impresso' : 'impresso';
+      const previousStatus = current;
       const confirmMsg = `Deseja marcar como ${newStatus === 'impresso' ? 'impresso' : 'não impresso'}?`;
       if (!confirm(confirmMsg)) return;
 
@@ -1435,11 +1505,16 @@
       }
 
       showToast('Status atualizado');
+      if (card) card.dataset.status = newStatus;
+      if (newStatus === 'impresso' && previousStatus !== 'impresso') {
+        await notifyEtiquetaStatusChange({ id, newStatus: 'impresso', card });
+      }
     }
     window.toggleImpressoCard = toggleImpressoCard;
 
     async function updateStatus(id, select, card) {
       const newStatus = select.value;
+      const previousStatus = card?.dataset?.status || '';
       await db.collection('pdfDocs').doc(id).update({ status: newStatus });
       const badge = card.querySelector('.status-badge');
       const statusInfo = {
@@ -1454,7 +1529,11 @@
       if (newStatus === 'concluido' && currentFilter === 'all') {
         card.remove();
       }
+      if (card) card.dataset.status = newStatus;
       showToast('Status atualizado');
+      if (['impresso', 'concluido'].includes(newStatus) && previousStatus !== newStatus) {
+        await notifyEtiquetaStatusChange({ id, newStatus, card });
+      }
       carregarEtiquetas();
     }
     window.updateStatus = updateStatus;
@@ -1464,6 +1543,7 @@
         const docRef = db.collection('pdfDocs').doc(id);
         const snap = await docRef.get();
         const data = snap.data() || {};
+        const previousStatus = data.status || 'nao_impresso';
 
         if (data.status !== 'impresso') {
           const items = (data.skus || data.skuList || []).map(s => ({ sku: s, quantidade: 1 }));
@@ -1500,7 +1580,13 @@
         }
 
         await docRef.update({ status: 'concluido' });
-        if (card) card.remove();
+        if (previousStatus !== 'concluido') {
+          await notifyEtiquetaStatusChange({ id, newStatus: 'concluido', card, docData: data });
+        }
+        if (card) {
+          card.dataset.status = 'concluido';
+          card.remove();
+        }
         showToast('Marcado como concluído');
       } catch (e) {
         console.error('Erro ao concluir etiqueta:', e);

--- a/login.js
+++ b/login.js
@@ -895,7 +895,37 @@ function initNotificationListener(uid) {
       expNotifs = [];
       snap.forEach((docSnap) => {
         const d = docSnap.data();
-        const texto = `${d.gestorEmail || ''} - ${d.quantidade || 0} etiqueta(s) não enviadas: ${d.motivo || ''}`;
+        let texto = '';
+        if (d.tipo === 'status_etiqueta') {
+          const autor = (d.gestorNome || d.gestorEmail || 'Expedição')
+            .toString()
+            .trim();
+          const arquivo = (d.arquivoNome || 'Etiqueta').toString().trim();
+          const statusRaw = (
+            d.statusLabel ||
+            d.status ||
+            'Atualizado'
+          ).toString();
+          const statusLower = statusRaw.toLowerCase();
+          const statusLabel =
+            statusLower === 'impresso'
+              ? 'Impresso'
+              : statusLower === 'concluido'
+                ? 'Concluído'
+                : statusRaw;
+          texto = `${autor} marcou "${arquivo}" como ${statusLabel}.`;
+        } else {
+          const quantidadeNum =
+            typeof d.quantidade === 'number'
+              ? d.quantidade
+              : Number(d.quantidade || 0);
+          const quantidade = Number.isFinite(quantidadeNum) ? quantidadeNum : 0;
+          const motivo = (d.motivo || '').toString().trim();
+          const autor = (d.gestorEmail || '').toString().trim();
+          texto = `${autor} - ${quantidade} etiqueta(s) não enviadas: ${motivo}`;
+        }
+        texto = texto.trim();
+        if (!texto) return;
         expNotifs.push({
           id: `exp:${docSnap.id}`,
           text: texto,

--- a/shared.js
+++ b/shared.js
@@ -540,7 +540,7 @@ document.addEventListener('navbarLoaded', () => {
       return;
     }
     if (!searchPages.length) collectSearchPages();
-        const manualMatches = manualSearchEntries.filter((entry) =>
+    const manualMatches = manualSearchEntries.filter((entry) =>
       entry.keywords.some((keyword) =>
         normalizedQuery.includes(normalizeSearchTerm(keyword)),
       ),
@@ -548,7 +548,7 @@ document.addEventListener('navbarLoaded', () => {
     const filtered = searchPages.filter((p) =>
       normalizeSearchTerm(p.title).includes(normalizedQuery),
     );
- const manualTitleMatches = manualSearchEntries.filter((entry) =>
+    const manualTitleMatches = manualSearchEntries.filter((entry) =>
       normalizeSearchTerm(entry.title).includes(normalizedQuery),
     );
     const combined = uniqueByHref([


### PR DESCRIPTION
## Summary
- adiciona rastreamento do dono das etiquetas e envia mensagem de expedição quando um perfil de expedição marca o arquivo como impresso ou concluído
- ajusta o listener do sininho e as páginas de atualizações para lidar com o novo tipo de notificação
- corrige a indentação do helper de busca do navbar para manter a formatação padrão

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9a5b30474832a99fc12c9f34e1156