### PR TITLE
Adicionar notificações de status das etiquetas

### DIFF
--- a/atualizacoes-dia.js
+++ b/atualizacoes-dia.js
@@ -41,14 +41,46 @@ onAuthStateChanged(auth, (user) => {
       const dados = doc.data();
       const item = document.createElement('div');
       item.className = 'p-4 bg-white rounded shadow';
+      const tipo = dados.tipo || 'sobras';
+      if (tipo === 'status') {
+        const texto = document.createElement('div');
+        texto.className = 'text-sm text-gray-700';
+        const statusChave = dados.status || '';
+        const statusLabel =
+          dados.statusLabel ||
+          (statusChave === 'impresso'
+            ? 'Impresso'
+            : statusChave === 'concluido'
+              ? 'Concluído'
+              : statusChave);
+        const responsavel =
+          dados.responsavelNome ||
+          dados.gestorNome ||
+          dados.responsavelEmail ||
+          dados.gestorEmail ||
+          'Equipe de expedição';
+        const arquivoNome = dados.arquivoNome || dados.arquivoId || 'Etiqueta';
+        texto.textContent = `${responsavel} marcou a etiqueta ${arquivoNome} como ${statusLabel}.`;
+        item.appendChild(texto);
+      } else {
+        const quantidade = document.createElement('div');
+        quantidade.className = 'text-sm text-gray-700';
+        quantidade.textContent = `Qtd não expedida: ${dados.quantidade || 0}`;
+        item.appendChild(quantidade);
+        if (dados.motivo) {
+          const motivo = document.createElement('div');
+          motivo.className = 'text-sm text-gray-700';
+          motivo.textContent = `Motivo: ${dados.motivo}`;
+          item.appendChild(motivo);
+        }
+      }
       const dataHora = dados.createdAt?.toDate
         ? dados.createdAt.toDate().toLocaleString('pt-BR')
         : '';
-      item.innerHTML = `
-        <div class="text-sm text-gray-700">Qtd não expedida: ${dados.quantidade}</div>
-        <div class="text-sm text-gray-700">Motivo: ${dados.motivo || ''}</div>
-        <div class="text-xs text-gray-500 mt-1">${dataHora}</div>
-      `;
+      const dataInfo = document.createElement('div');
+      dataInfo.className = 'text-xs text-gray-500 mt-1';
+      dataInfo.textContent = dataHora;
+      item.appendChild(dataInfo);
       lista.appendChild(item);
     });
   });

--- a/atualizacoes.js
+++ b/atualizacoes.js
@@ -436,10 +436,43 @@ async function carregarExpedicao() {
       if (!dataHora || dataHora < limiteData) return;
       const item = document.createElement('div');
       item.className = 'p-2 border rounded';
-      item.innerHTML =
-        `<div>Qtd não expedida: ${dados.quantidade}</div>` +
-        `${dados.motivo ? `<div>Motivo: ${dados.motivo}</div>` : ''}` +
-        `<div class="text-xs text-gray-500">${dataHora.toLocaleString('pt-BR')}</div>`;
+      const tipo = dados.tipo || 'sobras';
+      if (tipo === 'status') {
+        const texto = document.createElement('div');
+        texto.className = 'text-sm text-gray-700';
+        const statusChave = dados.status || '';
+        const statusLabel =
+          dados.statusLabel ||
+          (statusChave === 'impresso'
+            ? 'Impresso'
+            : statusChave === 'concluido'
+              ? 'Concluído'
+              : statusChave);
+        const responsavel =
+          dados.responsavelNome ||
+          dados.gestorNome ||
+          dados.responsavelEmail ||
+          dados.gestorEmail ||
+          'Equipe de expedição';
+        const arquivoNome = dados.arquivoNome || dados.arquivoId || 'Etiqueta';
+        texto.textContent = `${responsavel} marcou a etiqueta ${arquivoNome} como ${statusLabel}.`;
+        item.appendChild(texto);
+      } else {
+        const quantidade = document.createElement('div');
+        quantidade.className = 'text-sm text-gray-700';
+        quantidade.textContent = `Qtd não expedida: ${dados.quantidade || 0}`;
+        item.appendChild(quantidade);
+        if (dados.motivo) {
+          const motivo = document.createElement('div');
+          motivo.className = 'text-sm text-gray-700';
+          motivo.textContent = `Motivo: ${dados.motivo}`;
+          item.appendChild(motivo);
+        }
+      }
+      const dataInfo = document.createElement('div');
+      dataInfo.className = 'text-xs text-gray-500';
+      dataInfo.textContent = dataHora.toLocaleString('pt-BR');
+      item.appendChild(dataInfo);
       container.appendChild(item);
       count++;
     });

--- a/expedicao.html
+++ b/expedicao.html
@@ -1007,8 +1007,10 @@
         }
         if (!destinatarios.length) return;
         await db.collection('expedicaoMensagens').add({
+          tipo: 'sobras',
           gestorUid: currentUser.uid,
           gestorEmail: currentUser.email,
+          gestorNome: currentUserName || currentUser.email,
           quantidade: qtd,
           motivo,
           destinatarios,
@@ -1016,6 +1018,53 @@
         });
       } catch (e) {
         console.error('Erro ao notificar usuários de sobras:', e);
+      }
+    }
+
+    async function notificarStatusEtiqueta(docId, dadosEtiqueta, novoStatus, statusAnterior = null) {
+      if (!currentUser) return;
+      const statusLegiveis = {
+        impresso: 'Impresso',
+        concluido: 'Concluído'
+      };
+      if (!statusLegiveis[novoStatus]) return;
+      try {
+        let destinatarioUid = dadosEtiqueta.ownerUid || null;
+        if (!destinatarioUid && dadosEtiqueta.ownerEmail) {
+          try {
+            const snap = await db
+              .collection('uid')
+              .where('email', '==', dadosEtiqueta.ownerEmail)
+              .limit(1)
+              .get();
+            if (!snap.empty) destinatarioUid = snap.docs[0].id;
+          } catch (err) {
+            console.error('Erro ao buscar UID do dono da etiqueta:', err);
+          }
+        }
+        if (!destinatarioUid || destinatarioUid === currentUser.uid) return;
+        const anterior = statusAnterior ?? dadosEtiqueta.status ?? 'nao_impresso';
+        if (anterior === novoStatus) return;
+        const destinatarios = [destinatarioUid];
+        await db.collection('expedicaoMensagens').add({
+          tipo: 'status',
+          status: novoStatus,
+          statusLabel: statusLegiveis[novoStatus],
+          arquivoId: docId,
+          arquivoNome: dadosEtiqueta.name || '',
+          arquivoUrl: dadosEtiqueta.url || '',
+          ownerUid: destinatarioUid,
+          ownerEmail: dadosEtiqueta.ownerEmail || '',
+          gestorUid: currentUser.uid,
+          gestorEmail: currentUser.email,
+          responsavelUid: currentUser.uid,
+          responsavelEmail: currentUser.email,
+          responsavelNome: currentUserName || currentUser.email,
+          destinatarios,
+          createdAt: firebase.firestore.FieldValue.serverTimestamp()
+        });
+      } catch (e) {
+        console.error('Erro ao notificar status da etiqueta:', e);
       }
     }
 
@@ -1371,10 +1420,28 @@
         checkbox.checked = !checked;
         return;
       }
-      await db.collection('pdfDocs').doc(id).update({ status: checked ? 'impresso' : 'nao_impresso' });
+      const novoStatus = checked ? 'impresso' : 'nao_impresso';
+      const docRef = db.collection('pdfDocs').doc(id);
+      let dadosEtiqueta = null;
+      let statusAnterior = null;
+      if (novoStatus === 'impresso') {
+        try {
+          const snap = await docRef.get();
+          if (snap.exists) {
+            dadosEtiqueta = snap.data() || {};
+            statusAnterior = dadosEtiqueta.status || 'nao_impresso';
+          }
+        } catch (e) {
+          console.error('Erro ao obter etiqueta para notificação:', e);
+        }
+      }
+      await docRef.update({ status: novoStatus });
       if (card) {
         card.classList.remove('expedicao-pdf-card--pending', 'expedicao-pdf-card--printed', 'expedicao-pdf-card--done');
         card.classList.add(checked ? 'expedicao-pdf-card--printed' : 'expedicao-pdf-card--pending');
+      }
+      if (novoStatus === 'impresso' && dadosEtiqueta) {
+        await notificarStatusEtiqueta(id, dadosEtiqueta, novoStatus, statusAnterior);
       }
       showToast('Status atualizado');
     }
@@ -1386,7 +1453,22 @@
       const confirmMsg = `Deseja marcar como ${newStatus === 'impresso' ? 'impresso' : 'não impresso'}?`;
       if (!confirm(confirmMsg)) return;
 
-      await db.collection('pdfDocs').doc(id).update({ status: newStatus });
+      const docRef = db.collection('pdfDocs').doc(id);
+      let dadosEtiqueta = null;
+      let statusAnterior = null;
+      if (newStatus === 'impresso') {
+        try {
+          const snap = await docRef.get();
+          if (snap.exists) {
+            dadosEtiqueta = snap.data() || {};
+            statusAnterior = dadosEtiqueta.status || 'nao_impresso';
+          }
+        } catch (e) {
+          console.error('Erro ao obter etiqueta para notificação:', e);
+        }
+      }
+
+      await docRef.update({ status: newStatus });
 
       button.dataset.status = newStatus;
       const statusMap = {
@@ -1434,13 +1516,29 @@
         }
       }
 
+      if (newStatus === 'impresso' && dadosEtiqueta) {
+        await notificarStatusEtiqueta(id, dadosEtiqueta, newStatus, statusAnterior);
+      }
+
       showToast('Status atualizado');
     }
     window.toggleImpressoCard = toggleImpressoCard;
 
     async function updateStatus(id, select, card) {
       const newStatus = select.value;
-      await db.collection('pdfDocs').doc(id).update({ status: newStatus });
+      const docRef = db.collection('pdfDocs').doc(id);
+      let dadosEtiqueta = null;
+      let statusAnterior = null;
+      try {
+        const snap = await docRef.get();
+        if (snap.exists) {
+          dadosEtiqueta = snap.data() || {};
+          statusAnterior = dadosEtiqueta.status || 'nao_impresso';
+        }
+      } catch (e) {
+        console.error('Erro ao obter etiqueta para atualização de status:', e);
+      }
+      await docRef.update({ status: newStatus });
       const badge = card.querySelector('.status-badge');
       const statusInfo = {
         nao_impresso: { text: 'Não impresso', color: 'bg-yellow-500' },
@@ -1454,6 +1552,9 @@
       if (newStatus === 'concluido' && currentFilter === 'all') {
         card.remove();
       }
+      if (dadosEtiqueta && (newStatus === 'impresso' || newStatus === 'concluido')) {
+        await notificarStatusEtiqueta(id, dadosEtiqueta, newStatus, statusAnterior);
+      }
       showToast('Status atualizado');
       carregarEtiquetas();
     }
@@ -1464,6 +1565,7 @@
         const docRef = db.collection('pdfDocs').doc(id);
         const snap = await docRef.get();
         const data = snap.data() || {};
+        const statusAnterior = data.status || 'nao_impresso';
 
         if (data.status !== 'impresso') {
           const items = (data.skus || data.skuList || []).map(s => ({ sku: s, quantidade: 1 }));
@@ -1500,6 +1602,7 @@
         }
 
         await docRef.update({ status: 'concluido' });
+        await notificarStatusEtiqueta(id, data, 'concluido', statusAnterior);
         if (card) card.remove();
         showToast('Marcado como concluído');
       } catch (e) {

--- a/login.js
+++ b/login.js
@@ -894,13 +894,43 @@ function initNotificationListener(uid) {
     (snap) => {
       expNotifs = [];
       snap.forEach((docSnap) => {
-        const d = docSnap.data();
-        const texto = `${d.gestorEmail || ''} - ${d.quantidade || 0} etiqueta(s) não enviadas: ${d.motivo || ''}`;
+        const d = docSnap.data() || {};
+        const tipo = d.tipo || 'sobras';
+        const ts = d.createdAt?.toDate ? d.createdAt.toDate().getTime() : 0;
+        let texto = '';
+        let url = 'expedicao.html';
+        if (tipo === 'status') {
+          const statusChave = d.status || '';
+          const statusLabel =
+            d.statusLabel ||
+            (statusChave === 'impresso'
+              ? 'Impresso'
+              : statusChave === 'concluido'
+                ? 'Concluído'
+                : statusChave || 'Atualizado');
+          const responsavel =
+            d.responsavelNome ||
+            d.gestorNome ||
+            d.responsavelEmail ||
+            d.gestorEmail ||
+            'Equipe de expedição';
+          const arquivoNome = d.arquivoNome || d.arquivoId || 'sua etiqueta';
+          texto = `${responsavel} marcou a etiqueta ${arquivoNome} como ${statusLabel}.`;
+          if (d.arquivoUrl) {
+            url = d.arquivoUrl;
+          } else if (d.arquivoId) {
+            url = `expedicao.html?etiqueta=${d.arquivoId}`;
+          }
+        } else {
+          const gestor = d.gestorNome || d.gestorEmail || 'Expedição';
+          const motivo = d.motivo ? ` Motivo: ${d.motivo}` : '';
+          texto = `${gestor} - ${d.quantidade || 0} etiqueta(s) não enviadas.${motivo}`;
+        }
         expNotifs.push({
           id: `exp:${docSnap.id}`,
           text: texto,
-          ts: d.createdAt?.toDate ? d.createdAt.toDate().getTime() : 0,
-          url: 'expedicao.html',
+          ts,
+          url,
         });
       });
       render();

--- a/shared.js
+++ b/shared.js
@@ -540,7 +540,7 @@ document.addEventListener('navbarLoaded', () => {
       return;
     }
     if (!searchPages.length) collectSearchPages();
-        const manualMatches = manualSearchEntries.filter((entry) =>
+    const manualMatches = manualSearchEntries.filter((entry) =>
       entry.keywords.some((keyword) =>
         normalizedQuery.includes(normalizeSearchTerm(keyword)),
       ),
@@ -548,7 +548,7 @@ document.addEventListener('navbarLoaded', () => {
     const filtered = searchPages.filter((p) =>
       normalizeSearchTerm(p.title).includes(normalizedQuery),
     );
- const manualTitleMatches = manualSearchEntries.filter((entry) =>
+    const manualTitleMatches = manualSearchEntries.filter((entry) =>
       normalizeSearchTerm(entry.title).includes(normalizedQuery),
     );
     const combined = uniqueByHref([


### PR DESCRIPTION
## Resumo
- adiciona criação de notificações em `expedicao.html` sempre que uma etiqueta for marcada como impressa ou concluída
- exibe o novo tipo de atualização nas telas de atualizações gerais e diárias e adapta o sino de notificações no `login.js`
- corrige indentação do bloco de busca manual em `shared.js`

## Testes
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9a5b30474832a99fc12c9f34e1156