### PR TITLE
Notify shipping managers when labels are uploaded

### DIFF
--- a/atualizacoes.js
+++ b/atualizacoes.js
@@ -436,10 +436,29 @@ async function carregarExpedicao() {
       if (!dataHora || dataHora < limiteData) return;
       const item = document.createElement('div');
       item.className = 'p-2 border rounded';
-      item.innerHTML =
-        `<div>Qtd não expedida: ${dados.quantidade}</div>` +
-        `${dados.motivo ? `<div>Motivo: ${dados.motivo}</div>` : ''}` +
-        `<div class="text-xs text-gray-500">${dataHora.toLocaleString('pt-BR')}</div>`;
+      if (dados.tipo === 'nova-etiqueta') {
+        const autor =
+          dados.autorNome || dados.autorEmail || dados.gestorEmail || 'Usuário';
+        const quantidade = Number.isFinite(dados.totalEtiquetas)
+          ? `${Number(dados.totalEtiquetas)} etiqueta(s)`
+          : 'um novo arquivo de etiquetas';
+        const arquivoLinha = dados.arquivoNome
+          ? `<div>Arquivo: ${dados.arquivoNome}</div>`
+          : '';
+        const foraHorarioLinha = dados.foraHorario
+          ? '<div class="text-xs text-red-500 font-medium">Fora do horário previsto</div>'
+          : '';
+        item.innerHTML =
+          `<div>${autor} enviou ${quantidade}.</div>` +
+          arquivoLinha +
+          foraHorarioLinha +
+          `<div class="text-xs text-gray-500">${dataHora.toLocaleString('pt-BR')}</div>`;
+      } else {
+        item.innerHTML =
+          `<div>Qtd não expedida: ${dados.quantidade}</div>` +
+          `${dados.motivo ? `<div>Motivo: ${dados.motivo}</div>` : ''}` +
+          `<div class="text-xs text-gray-500">${dataHora.toLocaleString('pt-BR')}</div>`;
+      }
       container.appendChild(item);
       count++;
     });

--- a/etiquetas-ocr.html
+++ b/etiquetas-ocr.html
@@ -214,6 +214,55 @@ firebase.auth().onAuthStateChanged(async u => {
       });
     }
 
+    async function resolveExpedicaoDestinatarios(emails) {
+      const destinatarios = new Set();
+      if (responsavelExpedicaoUid) {
+        destinatarios.add(responsavelExpedicaoUid);
+      }
+      const lista = Array.isArray(emails) ? emails : [];
+      const buscas = lista
+        .map(email => (email || '').trim())
+        .filter(Boolean)
+        .map(async email => {
+          try {
+            const snap = await db.collection('uid').where('email', '==', email).limit(1).get();
+            if (!snap.empty) {
+              destinatarios.add(snap.docs[0].id);
+            }
+          } catch (err) {
+            console.error('Erro ao buscar UID do gestor de expedição:', email, err);
+          }
+        });
+      await Promise.all(buscas);
+      return Array.from(destinatarios);
+    }
+
+    async function notifyGestorNovaEtiqueta({ arquivoNome, totalEtiquetas, foraHorario, destinatariosEmails }) {
+      if (!currentUser) return;
+      try {
+        const destinatarios = await resolveExpedicaoDestinatarios(destinatariosEmails);
+        if (!destinatarios.length) return;
+        const payload = {
+          tipo: 'nova-etiqueta',
+          arquivoNome: arquivoNome || '',
+          foraHorario: Boolean(foraHorario),
+          autorUid: currentUser.uid,
+          autorEmail: currentUser.email || '',
+          autorNome: currentUser.displayName || '',
+          gestorUid: currentUser.uid,
+          gestorEmail: currentUser.email || '',
+          destinatarios,
+          createdAt: firebase.firestore.FieldValue.serverTimestamp()
+        };
+        if (Number.isFinite(totalEtiquetas)) {
+          payload.totalEtiquetas = Number(totalEtiquetas);
+        }
+        await db.collection('expedicaoMensagens').add(payload);
+      } catch (err) {
+        console.error('Erro ao notificar gestor de expedição:', err);
+      }
+    }
+
     async function extractSkuQuantitiesFromCanvas(canvas, info) {
       const ctxInfo = info || {};
       console.groupCollapsed('[OCR] Iniciando reconhecimento', ctxInfo);
@@ -593,6 +642,16 @@ firebase.auth().onAuthStateChanged(async u => {
             foraHorario: foraHorarioAtual
           });
         }
+        try {
+          await notifyGestorNovaEtiqueta({
+            arquivoNome: fileName,
+            totalEtiquetas: totalPaginas,
+            foraHorario: foraHorarioAtual,
+            destinatariosEmails: selecionado
+          });
+        } catch (err) {
+          console.error('Erro ao enviar notificação de nova etiqueta:', err);
+        }
       } catch (err) {
         console.error('Erro ao enviar PDF para Firebase:', err);
         showMessage('Erro ao enviar PDF. Tente novamente mais tarde.');
@@ -946,13 +1005,14 @@ firebase.auth().onAuthStateChanged(async u => {
         const gestoresEmails = gestoresRaw.split(',').map(e => e.trim()).filter(e => e);
         const fileName = `mercado_livre_${Date.now()}.pdf`;
         const selecionado = await escolherGestorEmail(gestoresEmails);
+        const foraHorarioAtual = foraDoHorario();
         const docRef = await db.collection('pdfDocs').add({
           ownerUid: currentUser.uid,
           ownerEmail: currentUser.email,
           gestoresExpedicaoEmails: selecionado,
           createdAt: firebase.firestore.FieldValue.serverTimestamp(),
           name: fileName,
-          foraHorario: foraDoHorario()
+          foraHorario: foraHorarioAtual
         });
         const fileRef = storage.ref().child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
         await fileRef.put(pdfFile);
@@ -973,6 +1033,16 @@ firebase.auth().onAuthStateChanged(async u => {
             createdAt: firebase.firestore.FieldValue.serverTimestamp()
           };
           await db.collection('users').doc(responsavelExpedicaoUid).collection('etiquetaenvio').add({ ...respRecord });
+        }
+        try {
+          await notifyGestorNovaEtiqueta({
+            arquivoNome: fileName,
+            totalEtiquetas: allItems.length,
+            foraHorario: foraHorarioAtual,
+            destinatariosEmails: selecionado
+          });
+        } catch (err) {
+          console.error('Erro ao enviar notificação de nova etiqueta:', err);
         }
       }
 

--- a/login.js
+++ b/login.js
@@ -895,7 +895,19 @@ function initNotificationListener(uid) {
       expNotifs = [];
       snap.forEach((docSnap) => {
         const d = docSnap.data();
-        const texto = `${d.gestorEmail || ''} - ${d.quantidade || 0} etiqueta(s) não enviadas: ${d.motivo || ''}`;
+        let texto;
+        if (d.tipo === 'nova-etiqueta') {
+          const autor =
+            d.autorNome || d.autorEmail || d.gestorEmail || 'Usuário';
+          const quantidadeTexto = Number.isFinite(d.totalEtiquetas)
+            ? `${Number(d.totalEtiquetas)} etiqueta(s)`
+            : 'um novo arquivo de etiquetas';
+          const arquivoParte = d.arquivoNome ? ` (${d.arquivoNome})` : '';
+          const foraHorarioParte = d.foraHorario ? ' - fora do horário' : '';
+          texto = `${autor} enviou ${quantidadeTexto}${arquivoParte}${foraHorarioParte}`;
+        } else {
+          texto = `${d.gestorEmail || ''} - ${d.quantidade || 0} etiqueta(s) não enviadas: ${d.motivo || ''}`;
+        }
         expNotifs.push({
           id: `exp:${docSnap.id}`,
           text: texto,

--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -433,6 +433,53 @@
     console.warn('[findUidByEmail] no UID for email', email);
     return null;
   }
+  async function resolveExpedicaoDestinatarios(emails, responsavelUid){
+    const destinatarios = new Set();
+    if(responsavelUid){
+      destinatarios.add(responsavelUid);
+    }
+    const lista = Array.isArray(emails) ? emails : [];
+    const buscas = lista
+      .map(email => (email || '').trim())
+      .filter(Boolean)
+      .map(async email => {
+        try{
+          const uid = await findUidByEmail(email);
+          if(uid){
+            destinatarios.add(uid);
+          }
+        }catch(err){
+          console.error('Erro ao buscar UID do gestor de expedição:', email, err);
+        }
+      });
+    await Promise.all(buscas);
+    return Array.from(destinatarios);
+  }
+  async function notifyGestorNovaEtiqueta({ nomeArquivo, totalEtiquetas, foraHorario, destinatariosEmails, responsavelUid }){
+    if(!currentUser) return;
+    try{
+      const destinatarios = await resolveExpedicaoDestinatarios(destinatariosEmails, responsavelUid);
+      if(!destinatarios.length) return;
+      const payload = {
+        tipo: 'nova-etiqueta',
+        arquivoNome: nomeArquivo || '',
+        foraHorario: Boolean(foraHorario),
+        autorUid: currentUser.uid,
+        autorEmail: currentUser.email || '',
+        autorNome: currentUser.displayName || '',
+        gestorUid: currentUser.uid,
+        gestorEmail: currentUser.email || '',
+        destinatarios,
+        createdAt: firebase.firestore.FieldValue.serverTimestamp()
+      };
+      if(Number.isFinite(totalEtiquetas)){
+        payload.totalEtiquetas = Number(totalEtiquetas);
+      }
+      await db.collection('expedicaoMensagens').add(payload);
+    }catch(err){
+      console.error('Erro ao notificar gestor de expedição:', err);
+    }
+  }
   async function savePrintedItems(items, meta){
     console.log('[savePrintedItems] items:', items, 'meta:', meta);
     const batch = db.batch();
@@ -454,7 +501,7 @@
     console.log('[savePrintedItems] saved for current user');
   }
 
-  async function savePdfRecord(url, storagePath, name, responsavelUid, foraHorario){
+  async function savePdfRecord(url, storagePath, name, responsavelUid, foraHorario, meta = {}){
     console.log('[savePdfRecord] saving record', {name, url, storagePath, responsavelUid, foraHorario});
     const record = {
       name,
@@ -468,6 +515,20 @@
       await db.collection('users').doc(responsavelUid).collection('etiquetaenvio').add(record);
     }
     console.log('[savePdfRecord] record saved');
+    try{
+      const destinatariosEmails = Array.isArray(meta.destinatariosEmails)
+        ? meta.destinatariosEmails
+        : (meta.gestorEmail ? [meta.gestorEmail] : []);
+      await notifyGestorNovaEtiqueta({
+        nomeArquivo: name,
+        totalEtiquetas: meta.totalEtiquetas,
+        foraHorario,
+        destinatariosEmails,
+        responsavelUid
+      });
+    }catch(err){
+      console.error('Erro ao enviar notificação de nova etiqueta:', err);
+    }
   }
 
   // ===== Handler principal =====
@@ -590,7 +651,10 @@
       const url = await ref.getDownloadURL();
       console.log('[btnProcessar] PDF uploaded', url);
       await metaRef.update({ url, storagePath: pdfPath, finishedAt: firebase.firestore.FieldValue.serverTimestamp() });
-      await savePdfRecord(url, pdfPath, name, responsavelUid, foraHorario);
+      await savePdfRecord(url, pdfPath, name, responsavelUid, foraHorario, {
+        totalEtiquetas: totalLabels,
+        destinatariosEmails: gestorEmail ? [gestorEmail] : []
+      });
 
       setProgress(100,'Concluído');
       showOk('PDF salvo com sucesso.');

--- a/zpl-import.html
+++ b/zpl-import.html
@@ -158,18 +158,68 @@
             });
         }
 
-        async function savePdf(blob, name) {
+        async function resolveExpedicaoDestinatarios(emails) {
+            const destinatarios = new Set();
+            if (responsavelExpedicaoUid) {
+                destinatarios.add(responsavelExpedicaoUid);
+            }
+            const lista = Array.isArray(emails) ? emails : [];
+            const buscas = lista
+                .map(email => (email || '').trim())
+                .filter(Boolean)
+                .map(async email => {
+                    try {
+                        const snap = await db.collection('uid').where('email', '==', email).limit(1).get();
+                        if (!snap.empty) {
+                            destinatarios.add(snap.docs[0].id);
+                        }
+                    } catch (err) {
+                        console.error('Erro ao buscar UID do gestor de expedição:', email, err);
+                    }
+                });
+            await Promise.all(buscas);
+            return Array.from(destinatarios);
+        }
+
+        async function notifyGestorNovaEtiqueta({ arquivoNome, totalEtiquetas, foraHorario, destinatariosEmails }) {
+            if (!currentUser) return;
+            try {
+                const destinatarios = await resolveExpedicaoDestinatarios(destinatariosEmails);
+                if (!destinatarios.length) return;
+                const payload = {
+                    tipo: 'nova-etiqueta',
+                    arquivoNome: arquivoNome || '',
+                    foraHorario: Boolean(foraHorario),
+                    autorUid: currentUser.uid,
+                    autorEmail: currentUser.email || '',
+                    autorNome: currentUser.displayName || '',
+                    gestorUid: currentUser.uid,
+                    gestorEmail: currentUser.email || '',
+                    destinatarios,
+                    createdAt: firebase.firestore.FieldValue.serverTimestamp()
+                };
+                if (Number.isFinite(totalEtiquetas)) {
+                    payload.totalEtiquetas = Number(totalEtiquetas);
+                }
+                await db.collection('expedicaoMensagens').add(payload);
+            } catch (err) {
+                console.error('Erro ao notificar gestor de expedição:', err);
+            }
+        }
+
+        async function savePdf(blob, name, meta = {}) {
             if (!currentUser) return;
             const gestoresRaw = document.getElementById('gestoresEmails').value || '';
             const gestoresEmails = gestoresRaw.split(',').map(e => e.trim()).filter(e => e);
             const selecionado = await escolherGestorEmail(gestoresEmails);
+            const foraHorarioAtual = foraDoHorario();
             const docRef = await db.collection('pdfDocs').add({
                 ownerUid: currentUser.uid,
                 ownerEmail: currentUser.email,
                 gestoresExpedicaoEmails: selecionado,
                 createdAt: firebase.firestore.FieldValue.serverTimestamp(),
                 name: name,
-                foraHorario: foraDoHorario()
+                foraHorario: foraHorarioAtual
             });
             const fileRef = storage.ref().child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
             await fileRef.put(blob);
@@ -190,6 +240,16 @@
                     createdAt: firebase.firestore.FieldValue.serverTimestamp()
                 };
                 await db.collection('users').doc(responsavelExpedicaoUid).collection('etiquetaenvio').add({ ...respRecord });
+            }
+            try {
+                await notifyGestorNovaEtiqueta({
+                    arquivoNome: name,
+                    totalEtiquetas: meta.totalEtiquetas,
+                    foraHorario: foraHorarioAtual,
+                    destinatariosEmails: selecionado
+                });
+            } catch (err) {
+                console.error('Erro ao enviar notificação de nova etiqueta:', err);
             }
         }
 
@@ -402,7 +462,7 @@
 
                 const fileName = `etiquetas-combinadas-${Date.now()}.pdf`;
 
-                await savePdf(pdfBlob, fileName);
+                await savePdf(pdfBlob, fileName, { totalEtiquetas: totalLabels });
                 await savePrintedSkuQuantities(allExtractedItems);
 
                 successMessage.textContent = 'Processo concluído e salvo.';


### PR DESCRIPTION
## Summary
- send expedition notifications whenever a new label file is saved across the Shopee, Mercado Livre and ZPL upload flows
- resolve responsible shipping managers by UID/email and store notification metadata alongside existing label records
- update the navbar bell and expedition dashboard to render the new "nova etiqueta" notifications for recipients

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9a7071854832a9986f6c9ac2db3fd