### PR TITLE
Notify expedition managers about new label uploads

### DIFF
--- a/etiquetas-ocr.html
+++ b/etiquetas-ocr.html
@@ -12,6 +12,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-storage-compat.js"></script>
+  <script src="expedicao-notifier.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/pdf-lib/dist/pdf-lib.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>
@@ -580,6 +581,29 @@ firebase.auth().onAuthStateChanged(async u => {
           contadorFinal
         };
         await db.collection('users').doc(currentUser.uid).collection('etiquetaenvio').add({ ...record });
+        if (
+          window.ExpedicaoNotifier &&
+          typeof window.ExpedicaoNotifier.notifyNovaEtiqueta === 'function'
+        ) {
+          await window.ExpedicaoNotifier.notifyNovaEtiqueta({
+            db,
+            firebase,
+            currentUser,
+            destinatarioEmails: selecionado,
+            destinatarioUids: responsavelExpedicaoUid
+              ? [responsavelExpedicaoUid]
+              : [],
+            arquivoNome: fileName,
+            totalPaginas,
+            foraHorario: foraHorarioAtual,
+            origem: 'Etiquetas PDF (OCR)',
+            pdfDocId: docRef.id,
+            additionalData: {
+              contadorInicial,
+              contadorFinal,
+            },
+          });
+        }
         await savePrintedSkuQuantities(items);
         if (Array.isArray(extraMeta.paginasResumo)) {
           await saveLabelSummary({
@@ -973,6 +997,25 @@ firebase.auth().onAuthStateChanged(async u => {
             createdAt: firebase.firestore.FieldValue.serverTimestamp()
           };
           await db.collection('users').doc(responsavelExpedicaoUid).collection('etiquetaenvio').add({ ...respRecord });
+        }
+        if (
+          window.ExpedicaoNotifier &&
+          typeof window.ExpedicaoNotifier.notifyNovaEtiqueta === 'function'
+        ) {
+          await window.ExpedicaoNotifier.notifyNovaEtiqueta({
+            db,
+            firebase,
+            currentUser,
+            destinatarioEmails: selecionado,
+            destinatarioUids: responsavelExpedicaoUid
+              ? [responsavelExpedicaoUid]
+              : [],
+            arquivoNome: fileName,
+            totalEtiquetas: allItems.length,
+            foraHorario: foraDoHorario(),
+            origem: 'Etiquetas Mercado Livre',
+            pdfDocId: docRef.id,
+          });
         }
       }
 

--- a/expedicao-notifier.js
+++ b/expedicao-notifier.js
@@ -1,0 +1,121 @@
+(function () {
+  const emailUidCache = new Map();
+
+  function normalizeEmail(email) {
+    return typeof email === 'string' ? email.trim().toLowerCase() : '';
+  }
+
+  async function resolveUidsByEmail(db, emails) {
+    if (!db || !Array.isArray(emails) || !emails.length) return [];
+    const results = [];
+    const seen = new Set();
+
+    for (const rawEmail of emails) {
+      const trimmed = typeof rawEmail === 'string' ? rawEmail.trim() : '';
+      if (!trimmed) continue;
+      const key = normalizeEmail(trimmed);
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      if (emailUidCache.has(key)) {
+        const cached = emailUidCache.get(key);
+        if (cached) results.push(cached);
+        continue;
+      }
+
+      try {
+        const snap = await db
+          .collection('uid')
+          .where('email', '==', trimmed)
+          .limit(1)
+          .get();
+        if (!snap.empty) {
+          const uid = snap.docs[0].id;
+          emailUidCache.set(key, uid);
+          results.push(uid);
+        } else {
+          emailUidCache.set(key, null);
+        }
+      } catch (err) {
+        console.error(
+          '[ExpedicaoNotifier] Erro ao buscar UID para',
+          trimmed,
+          err,
+        );
+      }
+    }
+
+    return results.filter(Boolean);
+  }
+
+  async function notifyNovaEtiqueta(options = {}) {
+    const { db, firebase, currentUser } = options;
+    if (!db || !firebase || !firebase.firestore || !currentUser) {
+      console.warn('[ExpedicaoNotifier] Parâmetros obrigatórios ausentes.');
+      return;
+    }
+
+    try {
+      const emails = Array.isArray(options.destinatarioEmails)
+        ? options.destinatarioEmails
+            .map((email) => (typeof email === 'string' ? email.trim() : ''))
+            .filter(Boolean)
+        : [];
+      const extraUids = Array.isArray(options.destinatarioUids)
+        ? options.destinatarioUids.filter(
+            (uid) => typeof uid === 'string' && uid,
+          )
+        : [];
+
+      const emailUids = await resolveUidsByEmail(db, emails);
+      const destinatarios = Array.from(
+        new Set(
+          [...emailUids, ...extraUids].filter(
+            (uid) => uid && uid !== currentUser.uid,
+          ),
+        ),
+      );
+
+      if (!destinatarios.length) return;
+
+      const payload = {
+        tipo: 'nova-etiqueta',
+        origem: options.origem || 'Sistema de etiquetas',
+        arquivoNome: options.arquivoNome || '',
+        targetUrl: options.targetUrl || 'expedicao.html',
+        destinatarios,
+        autorUid: currentUser.uid,
+        autorEmail: currentUser.email || '',
+        autorNome: currentUser.displayName || currentUser.email || '',
+        gestorEmails: emails,
+        createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+      };
+
+      if (Number.isFinite(options.totalEtiquetas)) {
+        payload.totalEtiquetas = Number(options.totalEtiquetas);
+      }
+      if (Number.isFinite(options.totalPaginas)) {
+        payload.totalPaginas = Number(options.totalPaginas);
+      }
+      if (typeof options.foraHorario === 'boolean') {
+        payload.foraHorario = options.foraHorario;
+      }
+      if (options.pdfDocId) {
+        payload.pdfDocId = options.pdfDocId;
+      }
+      if (
+        options.additionalData &&
+        typeof options.additionalData === 'object'
+      ) {
+        Object.assign(payload, options.additionalData);
+      }
+
+      await db.collection('expedicaoNotificacoes').add(payload);
+    } catch (err) {
+      console.error('[ExpedicaoNotifier] Erro ao registrar notificação:', err);
+    }
+  }
+
+  window.ExpedicaoNotifier = window.ExpedicaoNotifier || {};
+  window.ExpedicaoNotifier.notifyNovaEtiqueta = notifyNovaEtiqueta;
+})();

--- a/expedicao.html
+++ b/expedicao.html
@@ -12,6 +12,7 @@
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-storage-compat.js"></script>
+    <script src="expedicao-notifier.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/tesseract.js@4.0.2/dist/tesseract.min.js"></script>
@@ -1110,6 +1111,7 @@
       }
       try {
         const selecionado = await escolherGestorEmail(gestoresEmails);
+        const foraHorarioAtual = foraDoHorario();
         const docRef = await db.collection('pdfDocs').add({
           ownerUid: currentUser.uid,
           ownerEmail: currentUser.email,
@@ -1118,12 +1120,30 @@
           createdAt: firebase.firestore.FieldValue.serverTimestamp(),
           name: file.name,
           status: 'nao_impresso',
-          foraHorario: foraDoHorario()
+          foraHorario: foraHorarioAtual
         });
         const fileRef = storage.ref().child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
         await fileRef.put(file);
         const url = await fileRef.getDownloadURL();
         await docRef.update({ url: url, storagePath: fileRef.fullPath });
+        if (
+          window.ExpedicaoNotifier &&
+          typeof window.ExpedicaoNotifier.notifyNovaEtiqueta === 'function'
+        ) {
+          await window.ExpedicaoNotifier.notifyNovaEtiqueta({
+            db,
+            firebase,
+            currentUser,
+            destinatarioEmails: selecionado,
+            destinatarioUids: responsavelExpedicaoUid
+              ? [responsavelExpedicaoUid]
+              : [],
+            arquivoNome: file.name,
+            foraHorario: foraHorarioAtual,
+            origem: 'Expedição - Upload manual',
+            pdfDocId: docRef.id,
+          });
+        }
         await processManualLabel(file);
         manualPdfInput.value = '';
         showToast('Etiqueta salva');

--- a/login.js
+++ b/login.js
@@ -113,6 +113,7 @@ const EXPEDICAO_ALLOWED_MENU_IDS = [
 ];
 let notifUnsub = null;
 let expNotifUnsub = null;
+let expLabelNotifUnsub = null;
 let updNotifUnsub = null;
 let painelGeralNotifUnsub = null;
 let painelMentNotifUnsub = null;
@@ -583,12 +584,14 @@ function initNotificationListener(uid) {
   if (!btn || !badge || !list) return;
   if (notifUnsub) notifUnsub();
   if (expNotifUnsub) expNotifUnsub();
+  if (expLabelNotifUnsub) expLabelNotifUnsub();
   if (updNotifUnsub) updNotifUnsub();
   if (painelGeralNotifUnsub) painelGeralNotifUnsub();
   if (painelMentNotifUnsub) painelMentNotifUnsub();
 
   let finNotifs = [];
   let expNotifs = [];
+  let expLabelNotifs = [];
   let updNotifs = [];
   let painelGeralNotifs = [];
   let painelMentNotifs = [];
@@ -639,11 +642,35 @@ function initNotificationListener(uid) {
     return updated;
   };
 
+  const formatLabelNotification = (data) => {
+    if (!data) return 'Novo arquivo de etiquetas disponível.';
+    const autor = data.autorNome || data.autorEmail || 'Usuário';
+    const origem = data.origem || 'sistema de etiquetas';
+    const arquivo = data.arquivoNome || data.fileName || 'arquivo';
+    const totalEtiquetas = Number.isFinite(data.totalEtiquetas)
+      ? Number(data.totalEtiquetas)
+      : null;
+    const totalPaginas = Number.isFinite(data.totalPaginas)
+      ? Number(data.totalPaginas)
+      : null;
+    let quantidadeTexto = 'um arquivo de etiquetas';
+    if (totalEtiquetas !== null) {
+      quantidadeTexto =
+        totalEtiquetas === 1 ? '1 etiqueta' : `${totalEtiquetas} etiquetas`;
+    } else if (totalPaginas !== null && totalPaginas > 0) {
+      quantidadeTexto =
+        totalPaginas === 1 ? '1 página' : `${totalPaginas} páginas`;
+    }
+    const foraHorario = data.foraHorario ? ' (fora do horário padrão)' : '';
+    return `${autor} enviou ${quantidadeTexto}${foraHorario} via ${origem}: ${arquivo}`;
+  };
+
   const render = () => {
     list.innerHTML = '';
     const all = [
       ...finNotifs,
       ...expNotifs,
+      ...expLabelNotifs,
       ...updNotifs,
       ...painelGeralNotifs,
       ...painelMentNotifs,
@@ -910,6 +937,31 @@ function initNotificationListener(uid) {
     },
   );
 
+  const qExpLabels = query(
+    collection(db, 'expedicaoNotificacoes'),
+    where('destinatarios', 'array-contains', uid),
+    limit(50),
+  );
+  expLabelNotifUnsub = onSnapshot(
+    qExpLabels,
+    (snap) => {
+      expLabelNotifs = [];
+      snap.forEach((docSnap) => {
+        const data = docSnap.data() || {};
+        expLabelNotifs.push({
+          id: `explabel:${docSnap.id}`,
+          text: formatLabelNotification(data),
+          ts: data.createdAt?.toDate ? data.createdAt.toDate().getTime() : 0,
+          url: data.targetUrl || data.url || 'expedicao.html',
+        });
+      });
+      render();
+    },
+    (err) => {
+      console.error('Erro no listener de notificações de etiquetas:', err);
+    },
+  );
+
   if (!btn.dataset.notifInitialized) {
     btn.addEventListener('click', () => {
       list.classList.toggle('hidden');
@@ -939,6 +991,10 @@ function checkLogin() {
       if (expNotifUnsub) {
         expNotifUnsub();
         expNotifUnsub = null;
+      }
+      if (expLabelNotifUnsub) {
+        expLabelNotifUnsub();
+        expLabelNotifUnsub = null;
       }
       if (updNotifUnsub) {
         updNotifUnsub();

--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -104,6 +104,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-storage-compat.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
+  <script src="expedicao-notifier.js"></script>
   <script type="module">
   import { firebaseConfig } from './firebase-config.js';
   import { createOcrWorker } from './createWorker.js';
@@ -454,7 +455,7 @@
     console.log('[savePrintedItems] saved for current user');
   }
 
-  async function savePdfRecord(url, storagePath, name, responsavelUid, foraHorario){
+  async function savePdfRecord(url, storagePath, name, responsavelUid, foraHorario, meta = {}){
     console.log('[savePdfRecord] saving record', {name, url, storagePath, responsavelUid, foraHorario});
     const record = {
       name,
@@ -468,6 +469,33 @@
       await db.collection('users').doc(responsavelUid).collection('etiquetaenvio').add(record);
     }
     console.log('[savePdfRecord] record saved');
+    if (
+      window.ExpedicaoNotifier &&
+      typeof window.ExpedicaoNotifier.notifyNovaEtiqueta === 'function'
+    ) {
+      const metaEmails = Array.isArray(meta.destinatarioEmails)
+        ? meta.destinatarioEmails
+        : meta.gestorEmail
+        ? [meta.gestorEmail]
+        : [];
+      await window.ExpedicaoNotifier.notifyNovaEtiqueta({
+        db,
+        firebase,
+        currentUser,
+        destinatarioEmails: metaEmails,
+        destinatarioUids: responsavelUid ? [responsavelUid] : [],
+        arquivoNome: name,
+        totalEtiquetas: Number.isFinite(meta.totalEtiquetas)
+          ? Number(meta.totalEtiquetas)
+          : undefined,
+        totalPaginas: Number.isFinite(meta.totalPaginas)
+          ? Number(meta.totalPaginas)
+          : undefined,
+        foraHorario,
+        origem: meta.origem || 'ZPL Import (OCR)',
+        pdfDocId: meta.pdfDocId || null,
+      });
+    }
   }
 
   // ===== Handler principal =====
@@ -590,7 +618,12 @@
       const url = await ref.getDownloadURL();
       console.log('[btnProcessar] PDF uploaded', url);
       await metaRef.update({ url, storagePath: pdfPath, finishedAt: firebase.firestore.FieldValue.serverTimestamp() });
-      await savePdfRecord(url, pdfPath, name, responsavelUid, foraHorario);
+      await savePdfRecord(url, pdfPath, name, responsavelUid, foraHorario, {
+        destinatarioEmails: gestorEmail ? [gestorEmail] : [],
+        totalEtiquetas: totalLabels,
+        origem: 'ZPL Import (OCR)',
+        pdfDocId: metaRef.id,
+      });
 
       setProgress(100,'Concluído');
       showOk('PDF salvo com sucesso.');

--- a/zpl-import.html
+++ b/zpl-import.html
@@ -81,6 +81,7 @@
   </div>
 </div>
 
+<script src="expedicao-notifier.js"></script>
 <script>
     document.addEventListener('DOMContentLoaded', () => {
         if (!firebase.apps.length) { firebase.initializeApp(firebaseConfig); }
@@ -158,18 +159,19 @@
             });
         }
 
-        async function savePdf(blob, name) {
+        async function savePdf(blob, name, meta = {}) {
             if (!currentUser) return;
             const gestoresRaw = document.getElementById('gestoresEmails').value || '';
             const gestoresEmails = gestoresRaw.split(',').map(e => e.trim()).filter(e => e);
             const selecionado = await escolherGestorEmail(gestoresEmails);
+            const foraHorarioAtual = foraDoHorario();
             const docRef = await db.collection('pdfDocs').add({
                 ownerUid: currentUser.uid,
                 ownerEmail: currentUser.email,
                 gestoresExpedicaoEmails: selecionado,
                 createdAt: firebase.firestore.FieldValue.serverTimestamp(),
                 name: name,
-                foraHorario: foraDoHorario()
+                foraHorario: foraHorarioAtual
             });
             const fileRef = storage.ref().child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
             await fileRef.put(blob);
@@ -190,6 +192,28 @@
                     createdAt: firebase.firestore.FieldValue.serverTimestamp()
                 };
                 await db.collection('users').doc(responsavelExpedicaoUid).collection('etiquetaenvio').add({ ...respRecord });
+            }
+            if (
+              window.ExpedicaoNotifier &&
+              typeof window.ExpedicaoNotifier.notifyNovaEtiqueta === 'function'
+            ) {
+              await window.ExpedicaoNotifier.notifyNovaEtiqueta({
+                db,
+                firebase,
+                currentUser,
+                destinatarioEmails: selecionado,
+                destinatarioUids: [responsavelExpedicaoUid],
+                arquivoNome: name,
+                totalEtiquetas: Number.isFinite(meta.totalEtiquetas)
+                  ? Number(meta.totalEtiquetas)
+                  : undefined,
+                totalPaginas: Number.isFinite(meta.totalPaginas)
+                  ? Number(meta.totalPaginas)
+                  : undefined,
+                foraHorario: foraHorarioAtual,
+                origem: 'ZPL Import (Gemini)',
+                pdfDocId: docRef.id,
+              });
             }
         }
 
@@ -402,7 +426,7 @@
 
                 const fileName = `etiquetas-combinadas-${Date.now()}.pdf`;
 
-                await savePdf(pdfBlob, fileName);
+                await savePdf(pdfBlob, fileName, { totalEtiquetas: totalLabels });
                 await savePrintedSkuQuantities(allExtractedItems);
 
                 successMessage.textContent = 'Processo concluído e salvo.';


### PR DESCRIPTION
## Summary
- add a shared notifier utility to register expedition notifications whenever label files are saved
- invoke the notifier from each label import flow (ZPL, OCR, Mercado Livre, manual) so managers receive bell alerts with context
- extend the navbar notification listener to surface the new expedition notifications and clean up listeners on logout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9a7071854832a9986f6c9ac2db3fd