### PR TITLE
Add targeted recipient selection to update panels

### DIFF
--- a/painel-atualizacoes-gerais.html
+++ b/painel-atualizacoes-gerais.html
@@ -25,155 +25,185 @@
         <div id="painelStatus" class="text-sm text-gray-500"></div>
       </header>
 
-      <section class="card p-5 space-y-4">
-        <div class="flex items-center justify-between flex-wrap gap-2">
-          <h2 class="text-xl font-semibold flex items-center gap-2">
-            <span class="text-blue-600"><i class="fa-solid fa-comments"></i></span>
-            Atualizações rápidas
-          </h2>
-          <span id="mensagemStatus" class="text-sm text-gray-500"></span>
-        </div>
-        <form id="formMensagem" class="space-y-3">
-          <label class="block text-sm font-medium text-gray-700" for="mensagemTexto">
-            Compartilhe uma mensagem com a sua equipe
-          </label>
-          <textarea
-            id="mensagemTexto"
-            class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
-            rows="3"
-            placeholder="Ex: Ajustes de preços aplicados a partir de amanhã."
-            required
-          ></textarea>
-          <div class="flex items-center justify-between text-xs text-gray-500">
-            <span id="mensagemEscopo" class="italic"></span>
-            <button
-              type="submit"
-              class="btn btn-primary text-sm px-4 py-2"
-            >Enviar mensagem</button>
-          </div>
-        </form>
-        <div>
-          <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Últimas mensagens</h3>
-          <div id="listaMensagens" class="mt-3 space-y-3"></div>
-          <p id="mensagensVazio" class="text-sm text-gray-500 hidden">
-            Nenhuma mensagem registrada até o momento.
-          </p>
-        </div>
-      </section>
+      <div class="grid gap-6 lg:grid-cols-4">
+        <div class="lg:col-span-3 space-y-6">
+          <section class="card p-5 space-y-4">
+            <div class="flex items-center justify-between flex-wrap gap-2">
+              <h2 class="text-xl font-semibold flex items-center gap-2">
+                <span class="text-blue-600"><i class="fa-solid fa-comments"></i></span>
+                Atualizações rápidas
+              </h2>
+              <span id="mensagemStatus" class="text-sm text-gray-500"></span>
+            </div>
+            <form id="formMensagem" class="space-y-3">
+              <label class="block text-sm font-medium text-gray-700" for="mensagemTexto">
+                Compartilhe uma mensagem com a sua equipe
+              </label>
+              <textarea
+                id="mensagemTexto"
+                class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                rows="3"
+                placeholder="Ex: Ajustes de preços aplicados a partir de amanhã."
+                required
+              ></textarea>
+              <div class="flex items-center justify-between text-xs text-gray-500">
+                <span id="mensagemEscopo" class="italic"></span>
+                <button
+                  type="submit"
+                  class="btn btn-primary text-sm px-4 py-2"
+                >Enviar mensagem</button>
+              </div>
+            </form>
+            <div>
+              <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Últimas mensagens</h3>
+              <div id="listaMensagens" class="mt-3 space-y-3"></div>
+              <p id="mensagensVazio" class="text-sm text-gray-500 hidden">
+                Nenhuma mensagem registrada até o momento.
+              </p>
+            </div>
+          </section>
 
-      <section class="card p-5 space-y-5">
-        <div class="flex items-center justify-between flex-wrap gap-2">
-          <h2 class="text-xl font-semibold flex items-center gap-2">
-            <span class="text-amber-500"><i class="fa-solid fa-triangle-exclamation"></i></span>
-            Problemas por setor
-          </h2>
-          <span id="problemaStatus" class="text-sm text-gray-500"></span>
-        </div>
-        <form id="formProblema" class="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <div class="space-y-2">
-            <label for="problemaTitulo" class="text-sm font-medium text-gray-700">Descrição do problema</label>
-            <textarea
-              id="problemaTitulo"
-              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
-              rows="3"
-              placeholder="Ex: Falta de matéria-prima no setor de corte"
-              required
-            ></textarea>
-          </div>
-          <div class="space-y-2">
-            <label for="problemaSolucao" class="text-sm font-medium text-gray-700">Solução (opcional)</label>
-            <textarea
-              id="problemaSolucao"
-              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
-              rows="3"
-              placeholder="Ex: Solicitar reposição urgente ao fornecedor"
-            ></textarea>
-          </div>
-          <div class="space-y-2">
-            <label for="problemaSetor" class="text-sm font-medium text-gray-700">Setor</label>
-            <input
-              id="problemaSetor"
-              type="text"
-              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
-              placeholder="Ex: Corte"
-              required
-            />
-          </div>
-          <div class="space-y-2">
-            <label for="problemaResponsavel" class="text-sm font-medium text-gray-700">Responsável</label>
-            <input
-              id="problemaResponsavel"
-              type="text"
-              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
-              placeholder="Quem está acompanhando a resolução?"
-              required
-            />
-          </div>
-          <div class="space-y-2">
-            <label for="problemaData" class="text-sm font-medium text-gray-700">Data do registro</label>
-            <input
-              id="problemaData"
-              type="date"
-              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
-              required
-            />
-          </div>
-          <div class="flex items-end">
-            <button type="submit" class="btn btn-primary text-sm px-4 py-2 w-full md:w-auto">Registrar problema</button>
-          </div>
-        </form>
-        <div>
-          <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Histórico de problemas</h3>
-          <div id="listaProblemas" class="mt-3 space-y-3"></div>
-          <p id="problemasVazio" class="text-sm text-gray-500 hidden">
-            Nenhum problema registrado.
-          </p>
-        </div>
-      </section>
+          <section class="card p-5 space-y-5">
+            <div class="flex items-center justify-between flex-wrap gap-2">
+              <h2 class="text-xl font-semibold flex items-center gap-2">
+                <span class="text-amber-500"><i class="fa-solid fa-triangle-exclamation"></i></span>
+                Problemas por setor
+              </h2>
+              <span id="problemaStatus" class="text-sm text-gray-500"></span>
+            </div>
+            <form id="formProblema" class="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div class="space-y-2">
+                <label for="problemaTitulo" class="text-sm font-medium text-gray-700">Descrição do problema</label>
+                <textarea
+                  id="problemaTitulo"
+                  class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                  rows="3"
+                  placeholder="Ex: Falta de matéria-prima no setor de corte"
+                  required
+                ></textarea>
+              </div>
+              <div class="space-y-2">
+                <label for="problemaSolucao" class="text-sm font-medium text-gray-700">Solução (opcional)</label>
+                <textarea
+                  id="problemaSolucao"
+                  class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                  rows="3"
+                  placeholder="Ex: Solicitar reposição urgente ao fornecedor"
+                ></textarea>
+              </div>
+              <div class="space-y-2">
+                <label for="problemaSetor" class="text-sm font-medium text-gray-700">Setor</label>
+                <input
+                  id="problemaSetor"
+                  type="text"
+                  class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                  placeholder="Ex: Corte"
+                  required
+                />
+              </div>
+              <div class="space-y-2">
+                <label for="problemaResponsavel" class="text-sm font-medium text-gray-700">Responsável</label>
+                <input
+                  id="problemaResponsavel"
+                  type="text"
+                  class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                  placeholder="Quem está acompanhando a resolução?"
+                  required
+                />
+              </div>
+              <div class="space-y-2">
+                <label for="problemaData" class="text-sm font-medium text-gray-700">Data do registro</label>
+                <input
+                  id="problemaData"
+                  type="date"
+                  class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                  required
+                />
+              </div>
+              <div class="flex items-end">
+                <button type="submit" class="btn btn-primary text-sm px-4 py-2 w-full md:w-auto">Registrar problema</button>
+              </div>
+            </form>
+            <div>
+              <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Histórico de problemas</h3>
+              <div id="listaProblemas" class="mt-3 space-y-3"></div>
+              <p id="problemasVazio" class="text-sm text-gray-500 hidden">
+                Nenhum problema registrado.
+              </p>
+            </div>
+          </section>
 
-      <section class="card p-5 space-y-5">
-        <div class="flex items-center justify-between flex-wrap gap-2">
-          <h2 class="text-xl font-semibold flex items-center gap-2">
-            <span class="text-emerald-500"><i class="fa-solid fa-cubes"></i></span>
-            Peças em linha
-          </h2>
-          <span id="produtoStatus" class="text-sm text-gray-500"></span>
+          <section class="card p-5 space-y-5">
+            <div class="flex items-center justify-between flex-wrap gap-2">
+              <h2 class="text-xl font-semibold flex items-center gap-2">
+                <span class="text-emerald-500"><i class="fa-solid fa-cubes"></i></span>
+                Peças em linha
+              </h2>
+              <span id="produtoStatus" class="text-sm text-gray-500"></span>
+            </div>
+            <p id="produtosAviso" class="text-sm text-gray-500 hidden">
+              Apenas gestores ou responsáveis financeiros podem cadastrar novos produtos.
+            </p>
+            <form id="formProduto" class="grid grid-cols-1 gap-4 md:grid-cols-3 hidden">
+              <div class="md:col-span-1 space-y-2">
+                <label for="produtoNome" class="text-sm font-medium text-gray-700">Produto / Peça</label>
+                <input
+                  id="produtoNome"
+                  type="text"
+                  class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                  placeholder="Ex: Kit móvel 4 portas"
+                  required
+                />
+              </div>
+              <div class="md:col-span-2 space-y-2">
+                <label for="produtoObs" class="text-sm font-medium text-gray-700">Observações (opcional)</label>
+                <textarea
+                  id="produtoObs"
+                  class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                  rows="2"
+                  placeholder="Detalhes sobre estoque, priorização ou datas"
+                ></textarea>
+              </div>
+              <div class="md:col-span-3 flex justify-end">
+                <button type="submit" class="btn btn-primary text-sm px-4 py-2">Adicionar produto</button>
+              </div>
+            </form>
+            <div>
+              <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Produtos cadastrados</h3>
+              <div id="listaProdutos" class="mt-3 space-y-3"></div>
+              <p id="produtosVazio" class="text-sm text-gray-500 hidden">
+                Nenhum produto em linha cadastrado até o momento.
+              </p>
+            </div>
+          </section>
         </div>
-        <p id="produtosAviso" class="text-sm text-gray-500 hidden">
-          Apenas gestores ou responsáveis financeiros podem cadastrar novos produtos.
-        </p>
-        <form id="formProduto" class="grid grid-cols-1 gap-4 md:grid-cols-3 hidden">
-          <div class="md:col-span-1 space-y-2">
-            <label for="produtoNome" class="text-sm font-medium text-gray-700">Produto / Peça</label>
-            <input
-              id="produtoNome"
-              type="text"
-              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-              placeholder="Ex: Kit móvel 4 portas"
-              required
-            />
-          </div>
-          <div class="md:col-span-2 space-y-2">
-            <label for="produtoObs" class="text-sm font-medium text-gray-700">Observações (opcional)</label>
-            <textarea
-              id="produtoObs"
-              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-              rows="2"
-              placeholder="Detalhes sobre estoque, priorização ou datas"
-            ></textarea>
-          </div>
-          <div class="md:col-span-3 flex justify-end">
-            <button type="submit" class="btn btn-primary text-sm px-4 py-2">Adicionar produto</button>
-          </div>
-        </form>
-        <div>
-          <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Produtos cadastrados</h3>
-          <div id="listaProdutos" class="mt-3 space-y-3"></div>
-          <p id="produtosVazio" class="text-sm text-gray-500 hidden">
-            Nenhum produto em linha cadastrado até o momento.
-          </p>
-        </div>
-      </section>
+
+        <aside class="lg:col-span-1 space-y-6">
+          <section class="card p-5 space-y-4" aria-labelledby="destinatariosTitulo">
+            <div class="flex items-center justify-between gap-2 flex-wrap">
+              <h2 id="destinatariosTitulo" class="text-lg font-semibold flex items-center gap-2">
+                <span class="text-blue-600"><i class="fa-solid fa-user-group"></i></span>
+                Destinatários conectados
+              </h2>
+              <button
+                id="limparParticipantesBtn"
+                type="button"
+                class="text-xs font-medium text-blue-600 hover:text-blue-700 focus:outline-none"
+              >
+                Limpar seleção
+              </button>
+            </div>
+            <p class="text-xs text-gray-500 leading-relaxed">
+              Selecione quem deve receber as próximas atualizações. Deixe todos desmarcados para alcançar toda a equipe conectada.
+            </p>
+            <div id="participantesResumo" class="text-xs font-medium text-gray-600"></div>
+            <div id="participantesLista" class="space-y-2 max-h-80 overflow-y-auto pr-1"></div>
+            <p id="participantesVazio" class="text-xs text-gray-500 hidden">
+              Nenhum participante conectado foi encontrado.
+            </p>
+          </section>
+        </aside>
+      </div>
     </main>
 
     <script>

--- a/painel-atualizacoes-gerais.js
+++ b/painel-atualizacoes-gerais.js
@@ -16,6 +16,7 @@ import {
   orderBy,
   limit,
   serverTimestamp,
+  documentId,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
 import {
   getAuth,
@@ -52,6 +53,12 @@ const produtoStatusEl = document.getElementById('produtoStatus');
 const painelStatusEl = document.getElementById('painelStatus');
 const produtosAvisoEl = document.getElementById('produtosAviso');
 const mensagemEscopoEl = document.getElementById('mensagemEscopo');
+const participantesListaEl = document.getElementById('participantesLista');
+const participantesResumoEl = document.getElementById('participantesResumo');
+const participantesVazioEl = document.getElementById('participantesVazio');
+const limparParticipantesBtn = document.getElementById(
+  'limparParticipantesBtn',
+);
 
 let currentUser = null;
 let participantesCompartilhamento = [];
@@ -59,6 +66,9 @@ let mensagensUnsub = null;
 let problemasUnsub = null;
 let produtosUnsub = null;
 let nomeResponsavel = '';
+let participantesDetalhes = [];
+let participantesPorUid = new Map();
+let participantesSelecionados = new Set();
 
 function setStatus(element, message = '', isError = false) {
   if (!element) return;
@@ -111,6 +121,236 @@ function formatDate(value, includeTime = true) {
         minute: '2-digit',
       })
     : date.toLocaleDateString('pt-BR');
+}
+
+function montarDetalhesParticipante(uid, data = {}) {
+  const nomeFonte =
+    data.nomeCompleto ||
+    data.nome ||
+    data.displayName ||
+    data.nomeFantasia ||
+    data.razaoSocial ||
+    data.fantasia ||
+    data.usuario ||
+    data.email ||
+    '';
+  const papelFonte =
+    data.perfil ||
+    data.funcao ||
+    data.cargo ||
+    data.papel ||
+    data.tipo ||
+    data.role ||
+    data.departamento ||
+    '';
+  const emailFonte =
+    data.email ||
+    data.usuarioEmail ||
+    data.loginEmail ||
+    data.contatoEmail ||
+    '';
+
+  const nome = String(nomeFonte || '').trim() || `Usuário ${uid.slice(0, 6)}`;
+  const papel = String(papelFonte || '').trim();
+  const email = String(emailFonte || '').trim();
+
+  return {
+    uid,
+    nome,
+    papel,
+    email,
+    isAtual: currentUser?.uid === uid,
+  };
+}
+
+async function carregarDetalhesParticipantes(uids = []) {
+  const validos = Array.from(
+    new Set((uids || []).filter((uid) => typeof uid === 'string' && uid)),
+  );
+
+  const detalhesMap = new Map();
+  const buscarEmColecao = async (colecao, ids) => {
+    for (let i = 0; i < ids.length; i += 10) {
+      const lote = ids.slice(i, i + 10);
+      if (!lote.length) continue;
+      try {
+        const snap = await getDocs(
+          query(collection(db, colecao), where(documentId(), 'in', lote)),
+        );
+        snap.forEach((docSnap) => {
+          const uid = docSnap.id;
+          const data = docSnap.data() || {};
+          detalhesMap.set(uid, montarDetalhesParticipante(uid, data));
+        });
+      } catch (err) {
+        console.error(
+          `Erro ao carregar participantes (${colecao}) para seleção:`,
+          err,
+        );
+      }
+    }
+  };
+
+  if (validos.length) {
+    await buscarEmColecao('usuarios', validos);
+    const faltantes = validos.filter((uid) => !detalhesMap.has(uid));
+    if (faltantes.length) {
+      await buscarEmColecao('uid', faltantes);
+    }
+    const aindaFaltando = validos.filter((uid) => !detalhesMap.has(uid));
+    aindaFaltando.forEach((uid) => {
+      detalhesMap.set(uid, {
+        uid,
+        nome: `Usuário ${uid.slice(0, 6)}`,
+        papel: 'Perfil não identificado',
+        email: '',
+        isAtual: currentUser?.uid === uid,
+      });
+    });
+  }
+
+  participantesPorUid = detalhesMap;
+  participantesDetalhes = Array.from(detalhesMap.values()).sort((a, b) => {
+    if (a.isAtual && !b.isAtual) return -1;
+    if (!a.isAtual && b.isAtual) return 1;
+    return a.nome.localeCompare(b.nome, 'pt-BR', { sensitivity: 'base' });
+  });
+
+  participantesSelecionados = new Set(
+    Array.from(participantesSelecionados).filter((uid) =>
+      participantesPorUid.has(uid),
+    ),
+  );
+
+  renderizarParticipantesDisponiveis();
+}
+
+function renderizarParticipantesDisponiveis() {
+  if (!participantesListaEl) {
+    atualizarResumoDestinatarios();
+    return;
+  }
+
+  participantesListaEl.innerHTML = '';
+
+  if (!participantesDetalhes.length) {
+    participantesVazioEl?.classList.remove('hidden');
+    atualizarResumoDestinatarios();
+    return;
+  }
+
+  participantesVazioEl?.classList.add('hidden');
+  const frag = document.createDocumentFragment();
+
+  participantesDetalhes.forEach((info) => {
+    const item = document.createElement('label');
+    item.className =
+      'flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition hover:border-blue-300';
+    item.dataset.uid = info.uid;
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.className =
+      'mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500';
+    checkbox.checked = participantesSelecionados.has(info.uid);
+    checkbox.addEventListener('change', (event) => {
+      if (event.target.checked) {
+        participantesSelecionados.add(info.uid);
+      } else {
+        participantesSelecionados.delete(info.uid);
+      }
+      atualizarResumoDestinatarios();
+    });
+
+    const content = document.createElement('div');
+    content.className = 'flex-1 min-w-0';
+
+    const nomeEl = document.createElement('p');
+    nomeEl.className = 'text-sm font-medium text-gray-800';
+    if (info.isAtual) {
+      nomeEl.textContent = `${info.nome || 'Você'} (você)`;
+    } else {
+      nomeEl.textContent = info.nome || 'Usuário';
+    }
+
+    const detalheEl = document.createElement('p');
+    detalheEl.className = 'text-xs text-gray-500';
+    if (info.papel && info.email) {
+      detalheEl.textContent = `${info.papel} • ${info.email}`;
+    } else if (info.papel) {
+      detalheEl.textContent = info.papel;
+    } else if (info.email) {
+      detalheEl.textContent = info.email;
+    } else {
+      detalheEl.textContent = 'Sem detalhes adicionais';
+    }
+
+    content.appendChild(nomeEl);
+    content.appendChild(detalheEl);
+
+    item.appendChild(checkbox);
+    item.appendChild(content);
+    frag.appendChild(item);
+  });
+
+  participantesListaEl.appendChild(frag);
+  atualizarResumoDestinatarios();
+}
+
+function atualizarResumoDestinatarios() {
+  const selecionados = Array.from(participantesSelecionados);
+  const totalDisponiveis = participantesDetalhes.length;
+
+  if (participantesResumoEl) {
+    if (!totalDisponiveis) {
+      participantesResumoEl.textContent =
+        'Nenhum participante disponível para seleção.';
+    } else if (!selecionados.length) {
+      participantesResumoEl.textContent = `Nenhum destinatário selecionado. As atualizações alcançarão todos os ${totalDisponiveis} integrantes conectados.`;
+    } else if (selecionados.length === 1) {
+      const info = participantesPorUid.get(selecionados[0]);
+      const nome = info?.nome || '1 usuário';
+      participantesResumoEl.textContent = `Enviando somente para ${nome}.`;
+    } else {
+      participantesResumoEl.textContent = `Enviando para ${selecionados.length} destinatários selecionados.`;
+    }
+  }
+
+  if (mensagemEscopoEl) {
+    if (!selecionados.length) {
+      mensagemEscopoEl.textContent =
+        'Compartilhado com todos os perfis conectados.';
+    } else if (selecionados.length === 1) {
+      const info = participantesPorUid.get(selecionados[0]);
+      const nome = info?.nome || '1 usuário';
+      mensagemEscopoEl.textContent = `Compartilhado somente com ${nome}.`;
+    } else {
+      mensagemEscopoEl.textContent = `Compartilhado com ${selecionados.length} destinatários selecionados.`;
+    }
+  }
+}
+
+function obterParticipantesParaEnvio() {
+  if (!participantesSelecionados.size) {
+    return participantesCompartilhamento;
+  }
+  const destino = new Set(participantesSelecionados);
+  if (currentUser?.uid) destino.add(currentUser.uid);
+  return Array.from(destino);
+}
+
+function limparSelecaoDestinatarios() {
+  if (!participantesSelecionados.size) {
+    atualizarResumoDestinatarios();
+    return;
+  }
+  participantesSelecionados.clear();
+  participantesListaEl
+    ?.querySelectorAll('input[type="checkbox"]')
+    .forEach((input) => {
+      input.checked = false;
+    });
+  atualizarResumoDestinatarios();
 }
 
 async function montarEscopoCompartilhamento(user) {
@@ -348,16 +588,8 @@ async function montarEscopoCompartilhamento(user) {
   return { participantes: Array.from(participantes), perfil };
 }
 
-function atualizarEscopoMensagem(participantes) {
-  if (!mensagemEscopoEl) return;
-  if (!participantes || participantes.length === 0) {
-    mensagemEscopoEl.textContent = '';
-    return;
-  }
-  const quantidade = participantes.length;
-  mensagemEscopoEl.textContent = `Compartilhado com ${quantidade} integrante${
-    quantidade > 1 ? 's' : ''
-  } da equipe.`;
+function atualizarEscopoMensagem() {
+  atualizarResumoDestinatarios();
 }
 
 function renderMensagem(docSnap) {
@@ -595,6 +827,7 @@ async function enviarMensagem(event) {
     return;
   }
   try {
+    const participantesDestino = obterParticipantesParaEnvio();
     await addDoc(collection(db, 'painelAtualizacoesGerais'), {
       categoria: 'mensagem',
       texto,
@@ -602,7 +835,7 @@ async function enviarMensagem(event) {
       autorNome: nomeResponsavel,
       responsavelUid: currentUser.uid,
       responsavelNome: nomeResponsavel,
-      participantes: participantesCompartilhamento,
+      participantes: participantesDestino,
       createdAt: serverTimestamp(),
     });
     mensagemInput.value = '';
@@ -637,6 +870,7 @@ async function registrarProblema(event) {
     return;
   }
   try {
+    const participantesDestino = obterParticipantesParaEnvio();
     await addDoc(collection(db, 'painelAtualizacoesGerais'), {
       categoria: 'problema',
       problema,
@@ -646,7 +880,7 @@ async function registrarProblema(event) {
       dataOcorrencia,
       autorUid: currentUser.uid,
       autorNome: nomeResponsavel,
-      participantes: participantesCompartilhamento,
+      participantes: participantesDestino,
       createdAt: serverTimestamp(),
     });
     formProblema.reset();
@@ -675,13 +909,14 @@ async function registrarProduto(event) {
     return;
   }
   try {
+    const participantesDestino = obterParticipantesParaEnvio();
     await addDoc(collection(db, 'painelAtualizacoesGerais'), {
       categoria: 'produto',
       nome,
       observacoes: observacoes || '',
       autorUid: currentUser.uid,
       autorNome: nomeResponsavel,
-      participantes: participantesCompartilhamento,
+      participantes: participantesDestino,
       createdAt: serverTimestamp(),
     });
     formProduto?.reset();
@@ -699,6 +934,7 @@ async function registrarProduto(event) {
 formMensagem?.addEventListener('submit', enviarMensagem);
 formProblema?.addEventListener('submit', registrarProblema);
 formProduto?.addEventListener('submit', registrarProduto);
+limparParticipantesBtn?.addEventListener('click', limparSelecaoDestinatarios);
 
 onAuthStateChanged(auth, async (user) => {
   if (!user) {
@@ -710,10 +946,10 @@ onAuthStateChanged(auth, async (user) => {
   setStatus(painelStatusEl, 'Carregando configurações da equipe...');
   try {
     const { participantes } = await montarEscopoCompartilhamento(user);
-    participantesCompartilhamento = participantes.length
-      ? participantes
-      : [user.uid];
-    atualizarEscopoMensagem(participantesCompartilhamento);
+    const baseParticipantes = participantes.length ? participantes : [user.uid];
+    participantesCompartilhamento = Array.from(new Set(baseParticipantes));
+    await carregarDetalhesParticipantes(participantesCompartilhamento);
+    atualizarEscopoMensagem();
     setStatus(painelStatusEl, '');
 
     try {
@@ -743,5 +979,8 @@ onAuthStateChanged(auth, async (user) => {
       'Não foi possível carregar o compartilhamento da equipe.',
       true,
     );
+    participantesCompartilhamento = currentUser?.uid ? [currentUser.uid] : [];
+    await carregarDetalhesParticipantes(participantesCompartilhamento);
+    atualizarEscopoMensagem();
   }
 });

--- a/painel-atualizacoes-mentorados.html
+++ b/painel-atualizacoes-mentorados.html
@@ -40,241 +40,279 @@
           <div id="painelStatus" class="text-sm text-gray-500"></div>
         </header>
 
-        <section class="card p-5 space-y-4">
-          <div class="flex items-center justify-between flex-wrap gap-2">
-            <h2 class="text-xl font-semibold flex items-center gap-2">
-              <span class="text-blue-600"
-                ><i class="fa-solid fa-comments"></i
-              ></span>
-              Atualizações rápidas
-            </h2>
-            <span id="mensagemStatus" class="text-sm text-gray-500"></span>
-          </div>
-          <form id="formMensagem" class="space-y-3">
-            <label
-              class="block text-sm font-medium text-gray-700"
-              for="mensagemTexto"
-            >
-              Compartilhe uma mensagem com a sua equipe
-            </label>
-            <textarea
-              id="mensagemTexto"
-              class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              rows="3"
-              placeholder="Ex: Ajustes de preços aplicados a partir de amanhã."
-              required
-            ></textarea>
-            <div
-              class="flex items-center justify-between text-xs text-gray-500"
-            >
-              <span id="mensagemEscopo" class="italic"></span>
-              <button type="submit" class="btn btn-primary text-sm px-4 py-2">
-                Enviar mensagem
-              </button>
-            </div>
-          </form>
-          <div class="quick-messages-board">
-            <div class="quick-messages-board__header">
-              <div>
-                <h3 class="quick-messages-board__title">Últimas mensagens</h3>
-                <p class="quick-messages-board__subtitle">
-                  Atualizações internas compartilhadas recentemente.
+        <div class="grid gap-6 lg:grid-cols-4">
+          <div class="lg:col-span-3 space-y-6">
+            <section class="card p-5 space-y-4">
+              <div class="flex items-center justify-between flex-wrap gap-2">
+                <h2 class="text-xl font-semibold flex items-center gap-2">
+                  <span class="text-blue-600"
+                    ><i class="fa-solid fa-comments"></i
+                  ></span>
+                  Atualizações rápidas
+                </h2>
+                <span id="mensagemStatus" class="text-sm text-gray-500"></span>
+              </div>
+              <form id="formMensagem" class="space-y-3">
+                <label
+                  class="block text-sm font-medium text-gray-700"
+                  for="mensagemTexto"
+                >
+                  Compartilhe uma mensagem com a sua equipe
+                </label>
+                <textarea
+                  id="mensagemTexto"
+                  class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  rows="3"
+                  placeholder="Ex: Ajustes de preços aplicados a partir de amanhã."
+                  required
+                ></textarea>
+                <div
+                  class="flex items-center justify-between text-xs text-gray-500"
+                >
+                  <span id="mensagemEscopo" class="italic"></span>
+                  <button type="submit" class="btn btn-primary text-sm px-4 py-2">
+                    Enviar mensagem
+                  </button>
+                </div>
+              </form>
+              <div class="quick-messages-board">
+                <div class="quick-messages-board__header">
+                  <div>
+                    <h3 class="quick-messages-board__title">Últimas mensagens</h3>
+                    <p class="quick-messages-board__subtitle">
+                      Atualizações internas compartilhadas recentemente.
+                    </p>
+                  </div>
+                  <span class="quick-messages-board__tag">
+                    <i class="fa-solid fa-building-columns"></i>
+                    Quadro interno
+                  </span>
+                </div>
+                <div id="listaMensagens" class="quick-messages-board__grid"></div>
+                <p id="mensagensVazio" class="quick-messages-board__empty hidden">
+                  Nenhuma mensagem registrada até o momento.
                 </p>
               </div>
-              <span class="quick-messages-board__tag">
-                <i class="fa-solid fa-building-columns"></i>
-                Quadro interno
-              </span>
-            </div>
-            <div id="listaMensagens" class="quick-messages-board__grid"></div>
-            <p id="mensagensVazio" class="quick-messages-board__empty hidden">
-              Nenhuma mensagem registrada até o momento.
-            </p>
-          </div>
-        </section>
+            </section>
 
-        <section class="card p-5 space-y-5">
-          <div class="flex items-center justify-between flex-wrap gap-2">
-            <h2 class="text-xl font-semibold flex items-center gap-2">
-              <span class="text-amber-500"
-                ><i class="fa-solid fa-triangle-exclamation"></i
-              ></span>
-              Problemas por setor
-            </h2>
-            <span id="problemaStatus" class="text-sm text-gray-500"></span>
-          </div>
-          <form id="formProblema" class="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <div class="space-y-2">
-              <label
-                for="problemaTitulo"
-                class="text-sm font-medium text-gray-700"
-                >Descrição do problema</label
-              >
-              <textarea
-                id="problemaTitulo"
-                class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
-                rows="3"
-                placeholder="Ex: Falta de matéria-prima no setor de corte"
-                required
-              ></textarea>
-            </div>
-            <div class="space-y-2">
-              <label
-                for="problemaSolucao"
-                class="text-sm font-medium text-gray-700"
-                >Solução (opcional)</label
-              >
-              <textarea
-                id="problemaSolucao"
-                class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
-                rows="3"
-                placeholder="Ex: Solicitar reposição urgente ao fornecedor"
-              ></textarea>
-            </div>
-            <div class="space-y-2">
-              <label
-                for="problemaSetor"
-                class="text-sm font-medium text-gray-700"
-                >Setor</label
-              >
-              <input
-                id="problemaSetor"
-                type="text"
-                class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
-                placeholder="Ex: Corte"
-                required
-              />
-            </div>
-            <div class="space-y-2">
-              <label
-                for="problemaResponsavel"
-                class="text-sm font-medium text-gray-700"
-                >Responsável</label
-              >
-              <input
-                id="problemaResponsavel"
-                type="text"
-                class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
-                placeholder="Quem está acompanhando a resolução?"
-                required
-              />
-            </div>
-            <div class="space-y-2">
-              <label
-                for="problemaData"
-                class="text-sm font-medium text-gray-700"
-                >Data do registro</label
-              >
-              <input
-                id="problemaData"
-                type="date"
-                class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
-                required
-              />
-            </div>
-            <div class="flex items-end">
-              <button
-                type="submit"
-                class="btn btn-primary text-sm px-4 py-2 w-full md:w-auto"
-              >
-                Registrar problema
-              </button>
-            </div>
-          </form>
-          <div>
-            <h3
-              class="text-sm font-semibold uppercase tracking-wide text-gray-500"
-            >
-              Histórico de problemas
-            </h3>
-            <div id="listaProblemas" class="mt-3 space-y-3"></div>
-            <p id="problemasVazio" class="text-sm text-gray-500 hidden">
-              Nenhum problema registrado.
-            </p>
-          </div>
-        </section>
+            <section class="card p-5 space-y-5">
+              <div class="flex items-center justify-between flex-wrap gap-2">
+                <h2 class="text-xl font-semibold flex items-center gap-2">
+                  <span class="text-amber-500"
+                    ><i class="fa-solid fa-triangle-exclamation"></i
+                  ></span>
+                  Problemas por setor
+                </h2>
+                <span id="problemaStatus" class="text-sm text-gray-500"></span>
+              </div>
+              <form id="formProblema" class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div class="space-y-2">
+                  <label
+                    for="problemaTitulo"
+                    class="text-sm font-medium text-gray-700"
+                    >Descrição do problema</label
+                  >
+                  <textarea
+                    id="problemaTitulo"
+                    class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                    rows="3"
+                    placeholder="Ex: Falta de matéria-prima no setor de corte"
+                    required
+                  ></textarea>
+                </div>
+                <div class="space-y-2">
+                  <label
+                    for="problemaSolucao"
+                    class="text-sm font-medium text-gray-700"
+                    >Solução (opcional)</label
+                  >
+                  <textarea
+                    id="problemaSolucao"
+                    class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                    rows="3"
+                    placeholder="Ex: Solicitar reposição urgente ao fornecedor"
+                  ></textarea>
+                </div>
+                <div class="space-y-2">
+                  <label
+                    for="problemaSetor"
+                    class="text-sm font-medium text-gray-700"
+                    >Setor</label
+                  >
+                  <input
+                    id="problemaSetor"
+                    type="text"
+                    class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                    placeholder="Ex: Corte"
+                    required
+                  />
+                </div>
+                <div class="space-y-2">
+                  <label
+                    for="problemaResponsavel"
+                    class="text-sm font-medium text-gray-700"
+                    >Responsável</label
+                  >
+                  <input
+                    id="problemaResponsavel"
+                    type="text"
+                    class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                    placeholder="Quem está acompanhando a resolução?"
+                    required
+                  />
+                </div>
+                <div class="space-y-2">
+                  <label
+                    for="problemaData"
+                    class="text-sm font-medium text-gray-700"
+                    >Data do registro</label
+                  >
+                  <input
+                    id="problemaData"
+                    type="date"
+                    class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                    required
+                  />
+                </div>
+                <div class="flex items-end">
+                  <button
+                    type="submit"
+                    class="btn btn-primary text-sm px-4 py-2 w-full md:w-auto"
+                  >
+                    Registrar problema
+                  </button>
+                </div>
+              </form>
+              <div>
+                <h3
+                  class="text-sm font-semibold uppercase tracking-wide text-gray-500"
+                >
+                  Histórico de problemas
+                </h3>
+                <div id="listaProblemas" class="mt-3 space-y-3"></div>
+                <p id="problemasVazio" class="text-sm text-gray-500 hidden">
+                  Nenhum problema registrado.
+                </p>
+              </div>
+            </section>
 
-        <section class="card p-5 space-y-5">
-          <div class="flex items-center justify-between flex-wrap gap-2">
-            <h2 class="text-xl font-semibold flex items-center gap-2">
-              <span class="text-emerald-500"
-                ><i class="fa-solid fa-cubes"></i
-              ></span>
-              Peças em linha
-            </h2>
-            <span id="produtoStatus" class="text-sm text-gray-500"></span>
+            <section class="card p-5 space-y-5">
+              <div class="flex items-center justify-between flex-wrap gap-2">
+                <h2 class="text-xl font-semibold flex items-center gap-2">
+                  <span class="text-emerald-500"
+                    ><i class="fa-solid fa-cubes"></i
+                  ></span>
+                  Peças em linha
+                </h2>
+                <span id="produtoStatus" class="text-sm text-gray-500"></span>
+              </div>
+              <p id="produtosAviso" class="text-sm text-gray-500 hidden">
+                Apenas gestores ou responsáveis financeiros podem cadastrar novos
+                produtos.
+              </p>
+              <form
+                id="formProduto"
+                class="grid grid-cols-1 gap-4 md:grid-cols-3 hidden"
+              >
+                <div class="md:col-span-1 space-y-2">
+                  <label for="produtoNome" class="text-sm font-medium text-gray-700"
+                    >Produto / Peça</label
+                  >
+                  <input
+                    id="produtoNome"
+                    type="text"
+                    class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                    placeholder="Ex: Kit móvel 4 portas"
+                    required
+                  />
+                </div>
+                <div class="md:col-span-2 space-y-2">
+                  <label for="produtoObs" class="text-sm font-medium text-gray-700"
+                    >Observações (opcional)</label
+                  >
+                  <textarea
+                    id="produtoObs"
+                    class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                    rows="2"
+                    placeholder="Detalhes sobre estoque, priorização ou datas"
+                  ></textarea>
+                </div>
+                <div class="md:col-span-3 flex justify-end">
+                  <button type="submit" class="btn btn-primary text-sm px-4 py-2">
+                    Adicionar produto
+                  </button>
+                </div>
+              </form>
+              <div>
+                <div class="flex flex-wrap items-center justify-between gap-2">
+                  <h3
+                    class="text-sm font-semibold uppercase tracking-wide text-gray-500"
+                  >
+                    Produtos cadastrados
+                  </h3>
+                  <div class="flex flex-wrap gap-2">
+                    <button
+                      id="exportarPecasBtn"
+                      type="button"
+                      class="px-4 py-2 text-sm font-medium text-emerald-700 bg-emerald-100 hover:bg-emerald-200 rounded-lg transition focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-1 disabled:opacity-60 disabled:cursor-not-allowed"
+                    >
+                      <i class="fa-solid fa-file-excel mr-2"></i>
+                      Exportar Excel
+                    </button>
+                    <button
+                      id="sincronizarCustosBtn"
+                      type="button"
+                      class="px-4 py-2 text-sm font-medium text-white bg-emerald-600 hover:bg-emerald-700 rounded-lg transition focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-1 disabled:opacity-60 disabled:cursor-not-allowed"
+                    >
+                      <i class="fa-solid fa-arrows-rotate mr-2"></i>
+                      Atualizar custos
+                    </button>
+                  </div>
+                </div>
+                <div id="listaProdutos" class="mt-3 space-y-3"></div>
+                <p id="produtosVazio" class="text-sm text-gray-500 hidden">
+                  Nenhum produto em linha cadastrado até o momento.
+                </p>
+              </div>
+            </section>
           </div>
-          <p id="produtosAviso" class="text-sm text-gray-500 hidden">
-            Apenas gestores ou responsáveis financeiros podem cadastrar novos
-            produtos.
-          </p>
-          <form
-            id="formProduto"
-            class="grid grid-cols-1 gap-4 md:grid-cols-3 hidden"
-          >
-            <div class="md:col-span-1 space-y-2">
-              <label for="produtoNome" class="text-sm font-medium text-gray-700"
-                >Produto / Peça</label
-              >
-              <input
-                id="produtoNome"
-                type="text"
-                class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-                placeholder="Ex: Kit móvel 4 portas"
-                required
-              />
-            </div>
-            <div class="md:col-span-2 space-y-2">
-              <label for="produtoObs" class="text-sm font-medium text-gray-700"
-                >Observações (opcional)</label
-              >
-              <textarea
-                id="produtoObs"
-                class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-                rows="2"
-                placeholder="Detalhes sobre estoque, priorização ou datas"
-              ></textarea>
-            </div>
-            <div class="md:col-span-3 flex justify-end">
-              <button type="submit" class="btn btn-primary text-sm px-4 py-2">
-                Adicionar produto
-              </button>
-            </div>
-          </form>
-          <div>
-            <div
-              class="flex flex-wrap items-center justify-between gap-2"
-            >
-              <h3
-                class="text-sm font-semibold uppercase tracking-wide text-gray-500"
-              >
-                Produtos cadastrados
-              </h3>
-              <div class="flex flex-wrap gap-2">
-                <button
-                  id="exportarPecasBtn"
-                  type="button"
-                  class="px-4 py-2 text-sm font-medium text-emerald-700 bg-emerald-100 hover:bg-emerald-200 rounded-lg transition focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-1 disabled:opacity-60 disabled:cursor-not-allowed"
+
+          <aside class="lg:col-span-1 space-y-6">
+            <section class="card p-5 space-y-4" aria-labelledby="destinatariosTitulo">
+              <div class="flex items-center justify-between gap-2 flex-wrap">
+                <h2
+                  id="destinatariosTitulo"
+                  class="text-lg font-semibold flex items-center gap-2"
                 >
-                  <i class="fa-solid fa-file-excel mr-2"></i>
-                  Exportar Excel
-                </button>
+                  <span class="text-blue-600"
+                    ><i class="fa-solid fa-user-group"></i
+                  ></span>
+                  Destinatários conectados
+                </h2>
                 <button
-                  id="sincronizarCustosBtn"
+                  id="limparParticipantesBtn"
                   type="button"
-                  class="px-4 py-2 text-sm font-medium text-white bg-emerald-600 hover:bg-emerald-700 rounded-lg transition focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-1 disabled:opacity-60 disabled:cursor-not-allowed"
+                  class="text-xs font-medium text-blue-600 hover:text-blue-700 focus:outline-none"
                 >
-                  <i class="fa-solid fa-arrows-rotate mr-2"></i>
-                  Atualizar custos
+                  Limpar seleção
                 </button>
               </div>
-            </div>
-            <div id="listaProdutos" class="mt-3 space-y-3"></div>
-            <p id="produtosVazio" class="text-sm text-gray-500 hidden">
-              Nenhum produto em linha cadastrado até o momento.
-            </p>
-          </div>
-        </section>
+              <p class="text-xs text-gray-500 leading-relaxed">
+                Escolha quem deve receber as próximas mensagens e atualizações.
+                Deixe todos desmarcados para compartilhar com toda a equipe
+                conectada.
+              </p>
+              <div id="participantesResumo" class="text-xs font-medium text-gray-600"></div>
+              <div
+                id="participantesLista"
+                class="space-y-2 max-h-80 overflow-y-auto pr-1"
+              ></div>
+              <p id="participantesVazio" class="text-xs text-gray-500 hidden">
+                Nenhum participante conectado foi encontrado.
+              </p>
+            </section>
+          </aside>
+        </div>
       </main>
 
       <script>

--- a/painel-atualizacoes-mentorados.js
+++ b/painel-atualizacoes-mentorados.js
@@ -17,6 +17,7 @@ import {
   limit,
   serverTimestamp,
   setDoc,
+  documentId,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
 import {
   getAuth,
@@ -56,6 +57,12 @@ const produtosAvisoEl = document.getElementById('produtosAviso');
 const mensagemEscopoEl = document.getElementById('mensagemEscopo');
 const exportarPecasBtn = document.getElementById('exportarPecasBtn');
 const sincronizarCustosBtn = document.getElementById('sincronizarCustosBtn');
+const participantesListaEl = document.getElementById('participantesLista');
+const participantesResumoEl = document.getElementById('participantesResumo');
+const participantesVazioEl = document.getElementById('participantesVazio');
+const limparParticipantesBtn = document.getElementById(
+  'limparParticipantesBtn',
+);
 
 const VISIBILIDADE_GLOBAL_ID = '__todos_conectados__';
 
@@ -72,6 +79,9 @@ let ultimaImportacaoMeta = null;
 let manualProdutosPronto = false;
 let importadosProdutosPronto = false;
 let nomeResponsavel = '';
+let participantesDetalhes = [];
+let participantesPorUid = new Map();
+let participantesSelecionados = new Set();
 
 function setStatus(element, message = '', isError = false) {
   if (!element) return;
@@ -135,6 +145,241 @@ function formatCurrency(value) {
     currency: 'BRL',
     minimumFractionDigits: 2,
   });
+}
+
+function montarDetalhesParticipante(uid, data = {}) {
+  const nomeFonte =
+    data.nomeCompleto ||
+    data.nome ||
+    data.displayName ||
+    data.nomeFantasia ||
+    data.razaoSocial ||
+    data.fantasia ||
+    data.usuario ||
+    data.email ||
+    '';
+  const papelFonte =
+    data.perfil ||
+    data.funcao ||
+    data.cargo ||
+    data.papel ||
+    data.tipo ||
+    data.role ||
+    data.departamento ||
+    '';
+  const emailFonte =
+    data.email ||
+    data.usuarioEmail ||
+    data.loginEmail ||
+    data.contatoEmail ||
+    '';
+
+  const nome = String(nomeFonte || '').trim() || `Usuário ${uid.slice(0, 6)}`;
+  const papel = String(papelFonte || '').trim();
+  const email = String(emailFonte || '').trim();
+
+  return {
+    uid,
+    nome,
+    papel,
+    email,
+    isAtual: currentUser?.uid === uid,
+  };
+}
+
+async function carregarDetalhesParticipantes(uids = []) {
+  const validos = Array.from(
+    new Set(
+      (uids || []).filter(
+        (uid) =>
+          typeof uid === 'string' && uid && uid !== VISIBILIDADE_GLOBAL_ID,
+      ),
+    ),
+  );
+
+  const detalhesMap = new Map();
+  const buscarEmColecao = async (colecao, ids) => {
+    for (let i = 0; i < ids.length; i += 10) {
+      const lote = ids.slice(i, i + 10);
+      if (!lote.length) continue;
+      try {
+        const snap = await getDocs(
+          query(collection(db, colecao), where(documentId(), 'in', lote)),
+        );
+        snap.forEach((docSnap) => {
+          const uid = docSnap.id;
+          const data = docSnap.data() || {};
+          detalhesMap.set(uid, montarDetalhesParticipante(uid, data));
+        });
+      } catch (err) {
+        console.error(
+          `Erro ao carregar participantes (${colecao}) para seleção:`,
+          err,
+        );
+      }
+    }
+  };
+
+  if (validos.length) {
+    await buscarEmColecao('usuarios', validos);
+    const faltantes = validos.filter((uid) => !detalhesMap.has(uid));
+    if (faltantes.length) {
+      await buscarEmColecao('uid', faltantes);
+    }
+    const aindaFaltando = validos.filter((uid) => !detalhesMap.has(uid));
+    aindaFaltando.forEach((uid) => {
+      detalhesMap.set(uid, {
+        uid,
+        nome: `Usuário ${uid.slice(0, 6)}`,
+        papel: 'Perfil não identificado',
+        email: '',
+        isAtual: currentUser?.uid === uid,
+      });
+    });
+  }
+
+  participantesPorUid = detalhesMap;
+  participantesDetalhes = Array.from(detalhesMap.values()).sort((a, b) => {
+    if (a.isAtual && !b.isAtual) return -1;
+    if (!a.isAtual && b.isAtual) return 1;
+    return a.nome.localeCompare(b.nome, 'pt-BR', { sensitivity: 'base' });
+  });
+
+  participantesSelecionados = new Set(
+    Array.from(participantesSelecionados).filter((uid) =>
+      participantesPorUid.has(uid),
+    ),
+  );
+
+  renderizarParticipantesDisponiveis();
+}
+
+function renderizarParticipantesDisponiveis() {
+  if (!participantesListaEl) {
+    atualizarResumoDestinatarios();
+    return;
+  }
+
+  participantesListaEl.innerHTML = '';
+
+  if (!participantesDetalhes.length) {
+    participantesVazioEl?.classList.remove('hidden');
+    atualizarResumoDestinatarios();
+    return;
+  }
+
+  participantesVazioEl?.classList.add('hidden');
+  const frag = document.createDocumentFragment();
+
+  participantesDetalhes.forEach((info) => {
+    const item = document.createElement('label');
+    item.className =
+      'flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition hover:border-blue-300';
+    item.dataset.uid = info.uid;
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.className =
+      'mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500';
+    checkbox.checked = participantesSelecionados.has(info.uid);
+    checkbox.addEventListener('change', (event) => {
+      if (event.target.checked) {
+        participantesSelecionados.add(info.uid);
+      } else {
+        participantesSelecionados.delete(info.uid);
+      }
+      atualizarResumoDestinatarios();
+    });
+
+    const content = document.createElement('div');
+    content.className = 'flex-1 min-w-0';
+
+    const nomeEl = document.createElement('p');
+    nomeEl.className = 'text-sm font-medium text-gray-800';
+    if (info.isAtual) {
+      nomeEl.textContent = `${info.nome || 'Você'} (você)`;
+    } else {
+      nomeEl.textContent = info.nome || 'Usuário';
+    }
+
+    const detalheEl = document.createElement('p');
+    detalheEl.className = 'text-xs text-gray-500';
+    if (info.papel && info.email) {
+      detalheEl.textContent = `${info.papel} • ${info.email}`;
+    } else if (info.papel) {
+      detalheEl.textContent = info.papel;
+    } else if (info.email) {
+      detalheEl.textContent = info.email;
+    } else {
+      detalheEl.textContent = 'Sem detalhes adicionais';
+    }
+
+    content.appendChild(nomeEl);
+    content.appendChild(detalheEl);
+
+    item.appendChild(checkbox);
+    item.appendChild(content);
+    frag.appendChild(item);
+  });
+
+  participantesListaEl.appendChild(frag);
+  atualizarResumoDestinatarios();
+}
+
+function atualizarResumoDestinatarios() {
+  const selecionados = Array.from(participantesSelecionados);
+  const totalDisponiveis = participantesDetalhes.length;
+
+  if (participantesResumoEl) {
+    if (!totalDisponiveis) {
+      participantesResumoEl.textContent =
+        'Nenhum participante disponível para seleção.';
+    } else if (!selecionados.length) {
+      participantesResumoEl.textContent = `Nenhum destinatário selecionado. As atualizações alcançarão os ${totalDisponiveis} usuários conectados.`;
+    } else if (selecionados.length === 1) {
+      const info = participantesPorUid.get(selecionados[0]);
+      const nome = info?.nome || '1 usuário';
+      participantesResumoEl.textContent = `Enviando somente para ${nome}.`;
+    } else {
+      participantesResumoEl.textContent = `Enviando para ${selecionados.length} destinatários selecionados.`;
+    }
+  }
+
+  if (mensagemEscopoEl) {
+    if (!selecionados.length) {
+      mensagemEscopoEl.textContent =
+        'Informações visíveis para todos os perfis conectados.';
+    } else if (selecionados.length === 1) {
+      const info = participantesPorUid.get(selecionados[0]);
+      const nome = info?.nome || '1 usuário';
+      mensagemEscopoEl.textContent = `Informações visíveis apenas para ${nome}.`;
+    } else {
+      mensagemEscopoEl.textContent = `Informações visíveis apenas para ${selecionados.length} destinatários selecionados.`;
+    }
+  }
+}
+
+function obterParticipantesParaEnvio() {
+  if (!participantesSelecionados.size) {
+    return participantesCompartilhamento;
+  }
+  const destino = new Set(participantesSelecionados);
+  if (currentUser?.uid) destino.add(currentUser.uid);
+  return Array.from(destino);
+}
+
+function limparSelecaoDestinatarios() {
+  if (!participantesSelecionados.size) {
+    atualizarResumoDestinatarios();
+    return;
+  }
+  participantesSelecionados.clear();
+  participantesListaEl
+    ?.querySelectorAll('input[type="checkbox"]')
+    .forEach((input) => {
+      input.checked = false;
+    });
+  atualizarResumoDestinatarios();
 }
 
 function obterNomeProduto(item) {
@@ -1100,9 +1345,7 @@ async function montarEscopoCompartilhamento(user) {
 }
 
 function atualizarEscopoMensagem() {
-  if (!mensagemEscopoEl) return;
-  mensagemEscopoEl.textContent =
-    'Informações visíveis para todos os perfis conectados.';
+  atualizarResumoDestinatarios();
 }
 
 function renderMensagem(docSnap) {
@@ -1341,6 +1584,7 @@ async function enviarMensagem(event) {
     return;
   }
   try {
+    const participantesDestino = obterParticipantesParaEnvio();
     await addDoc(collection(db, 'painelAtualizacoesMentorados'), {
       categoria: 'mensagem',
       texto,
@@ -1348,7 +1592,7 @@ async function enviarMensagem(event) {
       autorNome: nomeResponsavel,
       responsavelUid: currentUser.uid,
       responsavelNome: nomeResponsavel,
-      participantes: participantesCompartilhamento,
+      participantes: participantesDestino,
       createdAt: serverTimestamp(),
     });
     mensagemInput.value = '';
@@ -1383,6 +1627,7 @@ async function registrarProblema(event) {
     return;
   }
   try {
+    const participantesDestino = obterParticipantesParaEnvio();
     await addDoc(collection(db, 'painelAtualizacoesMentorados'), {
       categoria: 'problema',
       problema,
@@ -1392,7 +1637,7 @@ async function registrarProblema(event) {
       dataOcorrencia,
       autorUid: currentUser.uid,
       autorNome: nomeResponsavel,
-      participantes: participantesCompartilhamento,
+      participantes: participantesDestino,
       createdAt: serverTimestamp(),
     });
     formProblema.reset();
@@ -1421,13 +1666,14 @@ async function registrarProduto(event) {
     return;
   }
   try {
+    const participantesDestino = obterParticipantesParaEnvio();
     await addDoc(collection(db, 'painelAtualizacoesMentorados'), {
       categoria: 'produto',
       nome,
       observacoes: observacoes || '',
       autorUid: currentUser.uid,
       autorNome: nomeResponsavel,
-      participantes: participantesCompartilhamento,
+      participantes: participantesDestino,
       createdAt: serverTimestamp(),
     });
     formProduto?.reset();
@@ -1447,6 +1693,7 @@ formProblema?.addEventListener('submit', registrarProblema);
 formProduto?.addEventListener('submit', registrarProduto);
 exportarPecasBtn?.addEventListener('click', exportarPecasEmLinha);
 sincronizarCustosBtn?.addEventListener('click', sincronizarCustosComSobras);
+limparParticipantesBtn?.addEventListener('click', limparSelecaoDestinatarios);
 
 onAuthStateChanged(auth, async (user) => {
   if (!user) {
@@ -1475,6 +1722,7 @@ onAuthStateChanged(auth, async (user) => {
   if (currentUser?.uid) participantesSet.add(currentUser.uid);
   participantesSet.add(VISIBILIDADE_GLOBAL_ID);
   participantesCompartilhamento = Array.from(participantesSet);
+  await carregarDetalhesParticipantes(participantesCompartilhamento);
   atualizarEscopoMensagem();
   if (!painelStatusEl?.classList?.contains('text-red-600')) {
     setStatus(painelStatusEl, '');


### PR DESCRIPTION
## Summary
- add a right sidebar card in both update panels so responsáveis can review and choose connected destinatários before sharing mensagens e problemas
- load nomes, papéis e e-mails dos participantes ligados ao usuário autenticado e apresentar checkboxes reutilizáveis para filtrar destinatários
- enviar atualizações apenas para os perfis selecionados (ou para todos quando nada estiver marcado) e atualizar os avisos do escopo conforme a seleção

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9b43decc8832ab4b6cc2461e4b874