### PR TITLE
Adicionar calendário de reuniões ao painel geral

### DIFF
--- a/painel-atualizacoes-gerais.html
+++ b/painel-atualizacoes-gerais.html
@@ -136,6 +136,64 @@
           <section class="card p-5 space-y-5">
             <div class="flex items-center justify-between flex-wrap gap-2">
               <h2 class="text-xl font-semibold flex items-center gap-2">
+                <span class="text-indigo-500"><i class="fa-solid fa-calendar-days"></i></span>
+                Calendário de reuniões
+              </h2>
+              <span id="reunioesStatus" class="text-sm text-gray-500"></span>
+            </div>
+            <p class="text-sm text-gray-600">
+              Clique em uma data para agendar uma reunião e selecionar os participantes conectados.
+            </p>
+            <div class="grid gap-4 lg:grid-cols-3">
+              <div class="lg:col-span-2 space-y-4">
+                <div>
+                  <h3
+                    id="calendarioReunioesAtualTitulo"
+                    class="text-xs font-semibold uppercase tracking-wide text-gray-500"
+                  ></h3>
+                  <div
+                    id="calendarioReunioesAtual"
+                    class="mt-3 rounded-lg border border-gray-200 bg-white p-3 shadow-sm"
+                  ></div>
+                </div>
+              </div>
+              <div class="space-y-4">
+                <div>
+                  <h3
+                    id="calendarioReunioesAnteriorTitulo"
+                    class="text-xs font-semibold uppercase tracking-wide text-gray-500"
+                  ></h3>
+                  <div
+                    id="calendarioReunioesAnterior"
+                    class="mt-2 rounded-lg border border-gray-200 bg-white p-2 shadow-sm"
+                  ></div>
+                </div>
+                <div>
+                  <h3
+                    id="calendarioReunioesProximoTitulo"
+                    class="text-xs font-semibold uppercase tracking-wide text-gray-500"
+                  ></h3>
+                  <div
+                    id="calendarioReunioesProximo"
+                    class="mt-2 rounded-lg border border-gray-200 bg-white p-2 shadow-sm"
+                  ></div>
+                </div>
+              </div>
+            </div>
+            <div>
+              <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">
+                Próximas reuniões
+              </h3>
+              <div id="listaReunioes" class="mt-3 space-y-3"></div>
+              <p id="reunioesVazio" class="text-sm text-gray-500 hidden">
+                Nenhuma reunião agendada até o momento.
+              </p>
+            </div>
+          </section>
+
+          <section class="card p-5 space-y-5">
+            <div class="flex items-center justify-between flex-wrap gap-2">
+              <h2 class="text-xl font-semibold flex items-center gap-2">
                 <span class="text-emerald-500"><i class="fa-solid fa-cubes"></i></span>
                 Peças em linha
               </h2>
@@ -213,6 +271,86 @@
     <script src="shared.js"></script>
     <script type="module" src="firebase-config.js"></script>
     <script type="module" src="painel-atualizacoes-gerais.js"></script>
+  </div>
+
+  <div
+    id="modalReuniao"
+    class="fixed inset-0 z-50 hidden items-center justify-center bg-black bg-opacity-40 p-4"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="modalReuniaoTitulo"
+  >
+    <div class="w-full max-w-xl rounded-lg bg-white shadow-lg">
+      <div class="flex items-center justify-between border-b px-5 py-3">
+        <div>
+          <h3 id="modalReuniaoTitulo" class="text-lg font-semibold text-gray-800">
+            Agendar reunião
+          </h3>
+          <p id="modalReuniaoData" class="text-sm text-gray-500"></p>
+        </div>
+        <button
+          type="button"
+          id="modalReuniaoFechar"
+          class="text-gray-400 transition hover:text-gray-600"
+          aria-label="Fechar"
+        >
+          <i class="fa-solid fa-xmark text-xl"></i>
+        </button>
+      </div>
+      <form id="formReuniao" class="space-y-4 px-5 py-4">
+        <div class="grid gap-4 md:grid-cols-2">
+          <div class="space-y-2">
+            <label for="reuniaoHorario" class="text-sm font-medium text-gray-700">
+              Horário da reunião
+            </label>
+            <input
+              id="reuniaoHorario"
+              type="time"
+              class="w-full rounded-lg border border-gray-300 p-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              required
+            />
+          </div>
+          <div class="space-y-2">
+            <label for="reuniaoDescricao" class="text-sm font-medium text-gray-700">
+              Assunto (opcional)
+            </label>
+            <input
+              id="reuniaoDescricao"
+              type="text"
+              class="w-full rounded-lg border border-gray-300 p-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+              placeholder="Ex: alinhamento semanal"
+            />
+          </div>
+        </div>
+        <div class="space-y-2">
+          <p class="text-sm font-medium text-gray-700">Participantes conectados</p>
+          <div
+            id="reuniaoParticipantesLista"
+            class="max-h-56 space-y-2 overflow-y-auto rounded-lg border border-gray-200 bg-gray-50 p-3"
+          ></div>
+          <p id="reuniaoParticipantesVazio" class="text-xs text-gray-500 hidden">
+            Nenhum participante disponível para seleção.
+          </p>
+        </div>
+        <p id="reuniaoModalStatus" class="text-sm text-red-600"></p>
+        <div class="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            id="reuniaoCancelar"
+            class="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100"
+          >
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            id="reuniaoSalvar"
+            class="btn btn-primary px-4 py-2 text-sm"
+          >
+            Agendar reunião
+          </button>
+        </div>
+      </form>
+    </div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Resumo
- adiciona um card de calendário de reuniões ao painel de atualizações gerais com visão do mês atual, anterior e próximo
- implementa fluxo completo para agendar reuniões via modal, incluindo seleção de participantes e armazenamento no Firestore
- integra as novas reuniões às notificações do sininho para alertar participantes

## Testes
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9eccdb5e4832ab897c8e0cdc2cacc