### PR TITLE
Refatora painel de atualizações gerais com abas e modal de destinatários

### DIFF
--- a/painel-atualizacoes-gerais.html
+++ b/painel-atualizacoes-gerais.html
@@ -1,356 +1,822 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="pt-BR">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Painel de Atualizações Gerais</title>
-  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/styles.css?v=20240826" />
-</head>
-<body class="bg-gray-100 text-gray-800">
-  <div class="app-container">
-    <div id="sidebar-container"></div>
-    <div id="navbar-container"></div>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Painel de Atualizações Gerais</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="css/styles.css?v=20240826" />
+  </head>
+  <body class="bg-gray-100 text-gray-800">
+    <div class="app-container">
+      <div id="sidebar-container"></div>
+      <div id="navbar-container"></div>
 
-    <main class="main-content p-4 space-y-6">
-      <header class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-        <div>
-          <h1 class="text-2xl font-bold">Painel de Atualizações Gerais</h1>
-          <p class="text-sm text-gray-600">
-            Centralize comunicados rápidos, reporte problemas dos setores e mantenha a equipe alinhada com as peças em linha.
-          </p>
-        </div>
-        <div id="painelStatus" class="text-sm text-gray-500"></div>
-      </header>
-
-      <div class="grid gap-6 lg:grid-cols-4">
-        <div class="lg:col-span-3 space-y-6">
-          <section class="card p-5 space-y-4">
-            <div class="flex items-center justify-between flex-wrap gap-2">
-              <h2 class="text-xl font-semibold flex items-center gap-2">
-                <span class="text-blue-600"><i class="fa-solid fa-comments"></i></span>
-                Atualizações rápidas
-              </h2>
-              <span id="mensagemStatus" class="text-sm text-gray-500"></span>
-            </div>
-            <form id="formMensagem" class="space-y-3">
-              <label class="block text-sm font-medium text-gray-700" for="mensagemTexto">
-                Compartilhe uma mensagem com a sua equipe
-              </label>
-              <textarea
-                id="mensagemTexto"
-                class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                rows="3"
-                placeholder="Ex: Ajustes de preços aplicados a partir de amanhã."
-                required
-              ></textarea>
-              <div class="flex items-center justify-between text-xs text-gray-500">
-                <span id="mensagemEscopo" class="italic"></span>
-                <button
-                  type="submit"
-                  class="btn btn-primary text-sm px-4 py-2"
-                >Enviar mensagem</button>
-              </div>
-            </form>
-            <div>
-              <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Últimas mensagens</h3>
-              <div id="listaMensagens" class="mt-3 space-y-3"></div>
-              <p id="mensagensVazio" class="text-sm text-gray-500 hidden">
-                Nenhuma mensagem registrada até o momento.
-              </p>
-            </div>
-          </section>
-
-          <section class="card p-5 space-y-5">
-            <div class="flex items-center justify-between flex-wrap gap-2">
-              <h2 class="text-xl font-semibold flex items-center gap-2">
-                <span class="text-amber-500"><i class="fa-solid fa-triangle-exclamation"></i></span>
-                Problemas por setor
-              </h2>
-              <span id="problemaStatus" class="text-sm text-gray-500"></span>
-            </div>
-            <form id="formProblema" class="grid grid-cols-1 gap-4 md:grid-cols-2">
-              <div class="space-y-2">
-                <label for="problemaTitulo" class="text-sm font-medium text-gray-700">Descrição do problema</label>
-                <textarea
-                  id="problemaTitulo"
-                  class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
-                  rows="3"
-                  placeholder="Ex: Falta de matéria-prima no setor de corte"
-                  required
-                ></textarea>
-              </div>
-              <div class="space-y-2">
-                <label for="problemaSolucao" class="text-sm font-medium text-gray-700">Solução (opcional)</label>
-                <textarea
-                  id="problemaSolucao"
-                  class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
-                  rows="3"
-                  placeholder="Ex: Solicitar reposição urgente ao fornecedor"
-                ></textarea>
-              </div>
-              <div class="space-y-2">
-                <label for="problemaSetor" class="text-sm font-medium text-gray-700">Setor</label>
-                <input
-                  id="problemaSetor"
-                  type="text"
-                  class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
-                  placeholder="Ex: Corte"
-                  required
-                />
-              </div>
-              <div class="space-y-2">
-                <label for="problemaResponsavel" class="text-sm font-medium text-gray-700">Responsável</label>
-                <input
-                  id="problemaResponsavel"
-                  type="text"
-                  class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
-                  placeholder="Quem está acompanhando a resolução?"
-                  required
-                />
-              </div>
-              <div class="space-y-2">
-                <label for="problemaData" class="text-sm font-medium text-gray-700">Data do registro</label>
-                <input
-                  id="problemaData"
-                  type="date"
-                  class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-amber-500"
-                  required
-                />
-              </div>
-              <div class="flex items-end">
-                <button type="submit" class="btn btn-primary text-sm px-4 py-2 w-full md:w-auto">Registrar problema</button>
-              </div>
-            </form>
-            <div>
-              <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Histórico de problemas</h3>
-              <div id="listaProblemas" class="mt-3 space-y-3"></div>
-              <p id="problemasVazio" class="text-sm text-gray-500 hidden">
-                Nenhum problema registrado.
-              </p>
-            </div>
-          </section>
-
-          <section class="card p-5 space-y-5">
-            <div class="flex items-center justify-between flex-wrap gap-2">
-              <h2 class="text-xl font-semibold flex items-center gap-2">
-                <span class="text-indigo-500"><i class="fa-solid fa-calendar-days"></i></span>
-                Calendário de reuniões
-              </h2>
-              <span id="reunioesStatus" class="text-sm text-gray-500"></span>
-            </div>
+      <main class="main-content p-4 space-y-6">
+        <header
+          class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between"
+        >
+          <div>
+            <h1 class="text-2xl font-bold">Painel de Atualizações Gerais</h1>
             <p class="text-sm text-gray-600">
-              Clique em uma data para agendar uma reunião e selecionar os participantes conectados.
+              Centralize comunicados rápidos, reporte problemas dos setores e
+              mantenha a equipe alinhada com as peças em linha.
             </p>
-            <div class="grid gap-4 lg:grid-cols-3">
-              <div class="lg:col-span-2 space-y-4">
-                <div>
-                  <h3
-                    id="calendarioReunioesAtualTitulo"
-                    class="text-xs font-semibold uppercase tracking-wide text-gray-500"
-                  ></h3>
-                  <div
-                    id="calendarioReunioesAtual"
-                    class="mt-3 rounded-lg border border-gray-200 bg-white p-3 shadow-sm"
-                  ></div>
-                </div>
-              </div>
-              <div class="space-y-4">
-                <div>
-                  <h3
-                    id="calendarioReunioesAnteriorTitulo"
-                    class="text-xs font-semibold uppercase tracking-wide text-gray-500"
-                  ></h3>
-                  <div
-                    id="calendarioReunioesAnterior"
-                    class="mt-2 rounded-lg border border-gray-200 bg-white p-2 shadow-sm"
-                  ></div>
-                </div>
-                <div>
-                  <h3
-                    id="calendarioReunioesProximoTitulo"
-                    class="text-xs font-semibold uppercase tracking-wide text-gray-500"
-                  ></h3>
-                  <div
-                    id="calendarioReunioesProximo"
-                    class="mt-2 rounded-lg border border-gray-200 bg-white p-2 shadow-sm"
-                  ></div>
-                </div>
-              </div>
-            </div>
-            <div>
-              <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">
-                Próximas reuniões
-              </h3>
-              <div id="listaReunioes" class="mt-3 space-y-3"></div>
-              <p id="reunioesVazio" class="text-sm text-gray-500 hidden">
-                Nenhuma reunião agendada até o momento.
-              </p>
-            </div>
-          </section>
+          </div>
+          <div id="painelStatus" class="text-sm text-gray-500"></div>
+        </header>
 
-          <section class="card p-5 space-y-5">
-            <div class="flex items-center justify-between flex-wrap gap-2">
-              <h2 class="text-xl font-semibold flex items-center gap-2">
-                <span class="text-emerald-500"><i class="fa-solid fa-cubes"></i></span>
-                Peças em linha
-              </h2>
-              <span id="produtoStatus" class="text-sm text-gray-500"></span>
-            </div>
-            <p id="produtosAviso" class="text-sm text-gray-500 hidden">
-              Apenas gestores ou responsáveis financeiros podem cadastrar novos produtos.
-            </p>
-            <form id="formProduto" class="grid grid-cols-1 gap-4 md:grid-cols-3 hidden">
-              <div class="md:col-span-1 space-y-2">
-                <label for="produtoNome" class="text-sm font-medium text-gray-700">Produto / Peça</label>
-                <input
-                  id="produtoNome"
-                  type="text"
-                  class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-                  placeholder="Ex: Kit móvel 4 portas"
-                  required
-                />
-              </div>
-              <div class="md:col-span-2 space-y-2">
-                <label for="produtoObs" class="text-sm font-medium text-gray-700">Observações (opcional)</label>
-                <textarea
-                  id="produtoObs"
-                  class="w-full border rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-                  rows="2"
-                  placeholder="Detalhes sobre estoque, priorização ou datas"
-                ></textarea>
-              </div>
-              <div class="md:col-span-3 flex justify-end">
-                <button type="submit" class="btn btn-primary text-sm px-4 py-2">Adicionar produto</button>
-              </div>
-            </form>
-            <div>
-              <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Produtos cadastrados</h3>
-              <div id="listaProdutos" class="mt-3 space-y-3"></div>
-              <p id="produtosVazio" class="text-sm text-gray-500 hidden">
-                Nenhum produto em linha cadastrado até o momento.
-              </p>
-            </div>
-          </section>
-        </div>
-
-        <aside class="lg:col-span-1 space-y-6">
-          <section class="card p-5 space-y-4" aria-labelledby="destinatariosTitulo">
-            <div class="flex items-center justify-between gap-2 flex-wrap">
-              <h2 id="destinatariosTitulo" class="text-lg font-semibold flex items-center gap-2">
-                <span class="text-blue-600"><i class="fa-solid fa-user-group"></i></span>
-                Destinatários conectados
-              </h2>
+        <section
+          class="rounded-3xl border border-gray-200 bg-white/80 p-4 shadow-sm backdrop-blur sm:p-6"
+        >
+          <div
+            class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"
+          >
+            <nav
+              class="flex flex-wrap gap-2"
+              aria-label="Seções do painel"
+              role="tablist"
+            >
               <button
-                id="limparParticipantesBtn"
+                id="tab-btn-mensagens"
                 type="button"
-                class="text-xs font-medium text-blue-600 hover:text-blue-700 focus:outline-none"
+                class="tab-button rounded-xl border border-transparent bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-600 shadow-sm transition hover:border-blue-200 hover:bg-blue-100"
+                data-tab-target="mensagens"
+                aria-controls="tab-mensagens"
+                aria-selected="true"
+                role="tab"
+              >
+                Mensagens
+              </button>
+              <button
+                id="tab-btn-mural"
+                type="button"
+                class="tab-button rounded-xl border border-transparent bg-white px-4 py-2 text-sm font-semibold text-gray-500 shadow-sm transition hover:border-purple-200 hover:bg-purple-50"
+                data-tab-target="mural"
+                aria-controls="tab-mural"
+                aria-selected="false"
+                role="tab"
+              >
+                Mural
+              </button>
+              <button
+                id="tab-btn-problemas"
+                type="button"
+                class="tab-button rounded-xl border border-transparent bg-white px-4 py-2 text-sm font-semibold text-gray-500 shadow-sm transition hover:border-amber-200 hover:bg-amber-50"
+                data-tab-target="problemas"
+                aria-controls="tab-problemas"
+                aria-selected="false"
+                role="tab"
+              >
+                Problemas
+              </button>
+              <button
+                id="tab-btn-planejamento"
+                type="button"
+                class="tab-button rounded-xl border border-transparent bg-white px-4 py-2 text-sm font-semibold text-gray-500 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50"
+                data-tab-target="planejamento"
+                aria-controls="tab-planejamento"
+                aria-selected="false"
+                role="tab"
+              >
+                Planejamento
+              </button>
+            </nav>
+            <p class="text-sm text-gray-500">
+              Escolha uma das seções para visualizar ou atualizar as informações
+              da equipe.
+            </p>
+          </div>
+
+          <div class="mt-6 space-y-10">
+            <div
+              id="tab-mensagens"
+              class="space-y-6"
+              data-tab-panel="mensagens"
+              role="tabpanel"
+              aria-labelledby="tab-btn-mensagens"
+            >
+              <section
+                class="rounded-2xl border border-blue-100 bg-gradient-to-r from-blue-50 via-white to-blue-50 p-5 shadow-sm sm:p-6"
+              >
+                <div
+                  class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between"
+                >
+                  <div class="space-y-1">
+                    <h2 class="text-xl font-semibold text-gray-800">
+                      Compartilhe com a sua equipe
+                    </h2>
+                    <p class="text-sm text-gray-500">
+                      Centralize comunicados importantes e acompanhe o histórico
+                      em tempo real.
+                    </p>
+                  </div>
+                  <span
+                    id="mensagemStatus"
+                    class="text-sm text-gray-500"
+                  ></span>
+                </div>
+                <form id="formMensagem" class="mt-4 space-y-4">
+                  <div class="space-y-2">
+                    <label
+                      class="block text-sm font-medium text-gray-700"
+                      for="mensagemTexto"
+                    >
+                      Escreva a mensagem que deseja compartilhar
+                    </label>
+                    <textarea
+                      id="mensagemTexto"
+                      class="w-full rounded-2xl border border-blue-100 bg-white/90 p-3 text-sm text-gray-700 shadow-inner focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                      rows="4"
+                      placeholder="Ex: Ajustes de preços aplicados a partir de amanhã."
+                      required
+                    ></textarea>
+                  </div>
+                  <div
+                    class="flex flex-col gap-3 text-xs text-gray-500 md:flex-row md:items-start md:justify-between"
+                  >
+                    <div class="space-y-1">
+                      <p id="mensagemEscopo" class="italic"></p>
+                      <p
+                        id="participantesResumo"
+                        class="text-[13px] font-medium text-gray-600"
+                      ></p>
+                    </div>
+                    <button
+                      type="submit"
+                      class="btn btn-primary w-full rounded-xl px-4 py-2 text-sm md:w-auto"
+                    >
+                      Selecionar destinatários e enviar
+                    </button>
+                  </div>
+                </form>
+              </section>
+
+              <section
+                class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm sm:p-6"
+              >
+                <div
+                  class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <h3
+                    class="flex items-center gap-2 text-lg font-semibold text-gray-800"
+                  >
+                    <span class="text-blue-600"
+                      ><i class="fa-solid fa-message"></i
+                    ></span>
+                    Painel de mensagens
+                  </h3>
+                  <p class="text-xs text-gray-500">
+                    Acompanhe tudo o que foi compartilhado recentemente.
+                  </p>
+                </div>
+                <div id="listaMensagens" class="mt-4 space-y-3"></div>
+                <p id="mensagensVazio" class="text-sm text-gray-500 hidden">
+                  Nenhuma mensagem registrada até o momento.
+                </p>
+              </section>
+            </div>
+
+            <div
+              id="tab-mural"
+              class="hidden space-y-6"
+              data-tab-panel="mural"
+              role="tabpanel"
+              aria-labelledby="tab-btn-mural"
+            >
+              <section
+                class="rounded-3xl bg-gradient-to-r from-blue-600 via-indigo-500 to-purple-500 p-6 text-white shadow-lg"
+              >
+                <div
+                  class="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between"
+                >
+                  <div class="space-y-2">
+                    <p class="text-xs uppercase tracking-[0.3em] text-white/70">
+                      Mural de informações
+                    </p>
+                    <h2 class="text-2xl font-semibold">
+                      Visão geral da equipe
+                    </h2>
+                    <p class="text-sm text-white/80">
+                      Últimas novidades, agenda e prioridades reunidas em um só
+                      lugar.
+                    </p>
+                  </div>
+                  <div class="grid w-full gap-4 sm:max-w-md sm:grid-cols-2">
+                    <div class="rounded-2xl bg-white/10 p-4 shadow-inner">
+                      <p class="text-xs uppercase tracking-wide text-white/70">
+                        Destinatários conectados
+                      </p>
+                      <p
+                        id="muralResumoDestinatarios"
+                        class="mt-2 text-2xl font-semibold"
+                      >
+                        —
+                      </p>
+                    </div>
+                    <div class="rounded-2xl bg-white/10 p-4 shadow-inner">
+                      <p class="text-xs uppercase tracking-wide text-white/70">
+                        Próxima reunião
+                      </p>
+                      <p
+                        id="muralResumoProximaReuniao"
+                        class="mt-2 text-sm font-medium text-white/90"
+                      >
+                        Nenhuma reunião futura agendada.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div class="mt-6 rounded-2xl bg-white/10 p-4 shadow-inner">
+                  <p class="text-xs uppercase tracking-[0.3em] text-white/60">
+                    Última atualização
+                  </p>
+                  <p
+                    id="muralMensagemDestaqueTexto"
+                    class="mt-2 text-lg font-semibold text-white"
+                  >
+                    Compartilhe uma atualização para iniciar o dia.
+                  </p>
+                  <p
+                    id="muralMensagemDestaqueAutor"
+                    class="mt-1 text-sm text-white/80"
+                  ></p>
+                </div>
+              </section>
+
+              <div class="grid gap-6 lg:grid-cols-2 xl:grid-cols-4">
+                <section
+                  class="rounded-2xl border border-blue-100 bg-white p-5 shadow-sm"
+                >
+                  <div class="flex items-center justify-between">
+                    <h3
+                      class="flex items-center gap-2 text-sm font-semibold text-blue-700"
+                    >
+                      <i class="fa-solid fa-messages"></i>
+                      Atualizações recentes
+                    </h3>
+                  </div>
+                  <div id="muralMensagensLista" class="mt-4 space-y-3"></div>
+                  <p id="muralMensagensVazio" class="text-sm text-gray-500">
+                    Nenhuma mensagem recente disponível.
+                  </p>
+                </section>
+
+                <section
+                  class="rounded-2xl border border-amber-100 bg-white p-5 shadow-sm"
+                >
+                  <div class="flex items-center justify-between">
+                    <h3
+                      class="flex items-center gap-2 text-sm font-semibold text-amber-600"
+                    >
+                      <i class="fa-solid fa-triangle-exclamation"></i>
+                      Alertas em destaque
+                    </h3>
+                  </div>
+                  <div id="muralProblemasLista" class="mt-4 space-y-3"></div>
+                  <p id="muralProblemasVazio" class="text-sm text-gray-500">
+                    Nenhum problema registrado recentemente.
+                  </p>
+                </section>
+
+                <section
+                  class="rounded-2xl border border-indigo-100 bg-white p-5 shadow-sm"
+                >
+                  <div class="flex items-center justify-between">
+                    <h3
+                      class="flex items-center gap-2 text-sm font-semibold text-indigo-600"
+                    >
+                      <i class="fa-solid fa-calendar-days"></i>
+                      Agenda em foco
+                    </h3>
+                  </div>
+                  <div id="muralReunioesLista" class="mt-4 space-y-3"></div>
+                  <p id="muralReunioesVazio" class="text-sm text-gray-500">
+                    Nenhuma reunião agendada para os próximos dias.
+                  </p>
+                </section>
+
+                <section
+                  class="rounded-2xl border border-emerald-100 bg-white p-5 shadow-sm"
+                >
+                  <div class="flex items-center justify-between">
+                    <h3
+                      class="flex items-center gap-2 text-sm font-semibold text-emerald-600"
+                    >
+                      <i class="fa-solid fa-cubes"></i>
+                      Peças em linha
+                    </h3>
+                  </div>
+                  <div id="muralProdutosLista" class="mt-4 space-y-3"></div>
+                  <p id="muralProdutosVazio" class="text-sm text-gray-500">
+                    Nenhum produto em linha cadastrado.
+                  </p>
+                </section>
+              </div>
+            </div>
+
+            <div
+              id="tab-problemas"
+              class="hidden space-y-6"
+              data-tab-panel="problemas"
+              role="tabpanel"
+              aria-labelledby="tab-btn-problemas"
+            >
+              <section
+                class="rounded-2xl border border-amber-100 bg-white p-5 shadow-sm sm:p-6"
+              >
+                <div
+                  class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between"
+                >
+                  <div class="space-y-1">
+                    <h2
+                      class="flex items-center gap-2 text-xl font-semibold text-gray-800"
+                    >
+                      <span class="text-amber-500"
+                        ><i class="fa-solid fa-triangle-exclamation"></i
+                      ></span>
+                      Registrar problema por setor
+                    </h2>
+                    <p class="text-sm text-gray-500">
+                      Documente ocorrências, responsáveis e soluções propostas.
+                    </p>
+                  </div>
+                  <span
+                    id="problemaStatus"
+                    class="text-sm text-gray-500"
+                  ></span>
+                </div>
+                <form
+                  id="formProblema"
+                  class="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2"
+                >
+                  <div class="space-y-2">
+                    <label
+                      for="problemaTitulo"
+                      class="text-sm font-medium text-gray-700"
+                      >Descrição do problema</label
+                    >
+                    <textarea
+                      id="problemaTitulo"
+                      class="w-full rounded-2xl border border-amber-200 bg-amber-50/40 p-3 text-sm text-gray-700 shadow-inner focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-200"
+                      rows="3"
+                      placeholder="Ex: Falta de matéria-prima no setor de corte"
+                      required
+                    ></textarea>
+                  </div>
+                  <div class="space-y-2">
+                    <label
+                      for="problemaSolucao"
+                      class="text-sm font-medium text-gray-700"
+                      >Solução (opcional)</label
+                    >
+                    <textarea
+                      id="problemaSolucao"
+                      class="w-full rounded-2xl border border-amber-200 bg-white p-3 text-sm text-gray-700 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-200"
+                      rows="3"
+                      placeholder="Ex: Solicitar reposição urgente ao fornecedor"
+                    ></textarea>
+                  </div>
+                  <div class="space-y-2">
+                    <label
+                      for="problemaSetor"
+                      class="text-sm font-medium text-gray-700"
+                      >Setor</label
+                    >
+                    <input
+                      id="problemaSetor"
+                      type="text"
+                      class="w-full rounded-2xl border border-amber-200 bg-white p-3 text-sm text-gray-700 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-200"
+                      placeholder="Ex: Corte"
+                      required
+                    />
+                  </div>
+                  <div class="space-y-2">
+                    <label
+                      for="problemaResponsavel"
+                      class="text-sm font-medium text-gray-700"
+                      >Responsável</label
+                    >
+                    <input
+                      id="problemaResponsavel"
+                      type="text"
+                      class="w-full rounded-2xl border border-amber-200 bg-white p-3 text-sm text-gray-700 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-200"
+                      placeholder="Quem está acompanhando a resolução?"
+                      required
+                    />
+                  </div>
+                  <div class="space-y-2">
+                    <label
+                      for="problemaData"
+                      class="text-sm font-medium text-gray-700"
+                      >Data do registro</label
+                    >
+                    <input
+                      id="problemaData"
+                      type="date"
+                      class="w-full rounded-2xl border border-amber-200 bg-white p-3 text-sm text-gray-700 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-200"
+                      required
+                    />
+                  </div>
+                  <div class="flex items-end">
+                    <button
+                      type="submit"
+                      class="btn btn-primary w-full rounded-xl px-4 py-2 text-sm lg:w-auto"
+                    >
+                      Registrar problema
+                    </button>
+                  </div>
+                </form>
+              </section>
+
+              <section
+                class="rounded-2xl border border-amber-100 bg-amber-50/40 p-5 shadow-inner sm:p-6"
+              >
+                <div class="flex items-center justify-between">
+                  <h3
+                    class="text-sm font-semibold uppercase tracking-wide text-amber-700"
+                  >
+                    Histórico de problemas
+                  </h3>
+                  <p class="text-xs text-amber-700/80">
+                    Acompanhe os registros mais recentes e suas soluções.
+                  </p>
+                </div>
+                <div id="listaProblemas" class="mt-4 space-y-3"></div>
+                <p id="problemasVazio" class="text-sm text-amber-700 hidden">
+                  Nenhum problema registrado.
+                </p>
+              </section>
+            </div>
+
+            <div
+              id="tab-planejamento"
+              class="hidden space-y-6"
+              data-tab-panel="planejamento"
+              role="tabpanel"
+              aria-labelledby="tab-btn-planejamento"
+            >
+              <section
+                class="rounded-2xl border border-indigo-100 bg-white p-5 shadow-sm sm:p-6"
+              >
+                <div
+                  class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between"
+                >
+                  <div class="space-y-1">
+                    <h2
+                      class="flex items-center gap-2 text-xl font-semibold text-gray-800"
+                    >
+                      <span class="text-indigo-500"
+                        ><i class="fa-solid fa-calendar-days"></i
+                      ></span>
+                      Calendário de reuniões
+                    </h2>
+                    <p class="text-sm text-gray-500">
+                      Clique em uma data para agendar e escolher os
+                      participantes.
+                    </p>
+                  </div>
+                  <span
+                    id="reunioesStatus"
+                    class="text-sm text-gray-500"
+                  ></span>
+                </div>
+                <div class="mt-4 grid gap-4 lg:grid-cols-3">
+                  <div class="lg:col-span-2 space-y-4">
+                    <div>
+                      <h3
+                        id="calendarioReunioesAtualTitulo"
+                        class="text-xs font-semibold uppercase tracking-wide text-gray-500"
+                      ></h3>
+                      <div
+                        id="calendarioReunioesAtual"
+                        class="mt-3 rounded-2xl border border-gray-200 bg-white p-3 shadow-inner"
+                      ></div>
+                    </div>
+                  </div>
+                  <div class="space-y-4">
+                    <div>
+                      <h3
+                        id="calendarioReunioesAnteriorTitulo"
+                        class="text-xs font-semibold uppercase tracking-wide text-gray-500"
+                      ></h3>
+                      <div
+                        id="calendarioReunioesAnterior"
+                        class="mt-2 rounded-2xl border border-gray-200 bg-white p-2 shadow-inner"
+                      ></div>
+                    </div>
+                    <div>
+                      <h3
+                        id="calendarioReunioesProximoTitulo"
+                        class="text-xs font-semibold uppercase tracking-wide text-gray-500"
+                      ></h3>
+                      <div
+                        id="calendarioReunioesProximo"
+                        class="mt-2 rounded-2xl border border-gray-200 bg-white p-2 shadow-inner"
+                      ></div>
+                    </div>
+                  </div>
+                </div>
+                <div class="mt-6">
+                  <h3
+                    class="text-sm font-semibold uppercase tracking-wide text-indigo-600"
+                  >
+                    Próximas reuniões
+                  </h3>
+                  <div id="listaReunioes" class="mt-3 space-y-3"></div>
+                  <p id="reunioesVazio" class="text-sm text-gray-500 hidden">
+                    Nenhuma reunião agendada até o momento.
+                  </p>
+                </div>
+              </section>
+
+              <section
+                class="rounded-2xl border border-emerald-100 bg-white p-5 shadow-sm sm:p-6"
+              >
+                <div
+                  class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between"
+                >
+                  <div class="space-y-1">
+                    <h2
+                      class="flex items-center gap-2 text-xl font-semibold text-gray-800"
+                    >
+                      <span class="text-emerald-500"
+                        ><i class="fa-solid fa-cubes"></i
+                      ></span>
+                      Peças em linha
+                    </h2>
+                    <p class="text-sm text-gray-500">
+                      Registre itens prioritários e compartilhe observações com
+                      a equipe.
+                    </p>
+                  </div>
+                  <span id="produtoStatus" class="text-sm text-gray-500"></span>
+                </div>
+                <p
+                  id="produtosAviso"
+                  class="mt-2 text-sm text-emerald-700 hidden"
+                >
+                  Apenas gestores ou responsáveis financeiros podem cadastrar
+                  novos produtos.
+                </p>
+                <form
+                  id="formProduto"
+                  class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-3 hidden"
+                >
+                  <div class="space-y-2">
+                    <label
+                      for="produtoNome"
+                      class="text-sm font-medium text-gray-700"
+                      >Produto / Peça</label
+                    >
+                    <input
+                      id="produtoNome"
+                      type="text"
+                      class="w-full rounded-2xl border border-emerald-200 bg-white p-3 text-sm text-gray-700 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                      placeholder="Ex: Kit móvel 4 portas"
+                      required
+                    />
+                  </div>
+                  <div class="md:col-span-2 space-y-2">
+                    <label
+                      for="produtoObs"
+                      class="text-sm font-medium text-gray-700"
+                      >Observações (opcional)</label
+                    >
+                    <textarea
+                      id="produtoObs"
+                      class="w-full rounded-2xl border border-emerald-200 bg-white p-3 text-sm text-gray-700 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                      rows="2"
+                      placeholder="Detalhes sobre estoque, priorização ou datas"
+                    ></textarea>
+                  </div>
+                  <div class="md:col-span-3 flex justify-end">
+                    <button
+                      type="submit"
+                      class="btn btn-primary rounded-xl px-4 py-2 text-sm"
+                    >
+                      Adicionar produto
+                    </button>
+                  </div>
+                </form>
+                <div class="mt-4">
+                  <h3
+                    class="text-sm font-semibold uppercase tracking-wide text-emerald-600"
+                  >
+                    Produtos cadastrados
+                  </h3>
+                  <div id="listaProdutos" class="mt-3 space-y-3"></div>
+                  <p id="produtosVazio" class="text-sm text-gray-500 hidden">
+                    Nenhum produto em linha cadastrado até o momento.
+                  </p>
+                </div>
+              </section>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <script>
+        window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';
+        window.CUSTOM_NAVBAR_PATH = '/partials/navbar.html';
+      </script>
+      <script src="shared.js"></script>
+      <script type="module" src="firebase-config.js"></script>
+      <script type="module" src="painel-atualizacoes-gerais.js"></script>
+    </div>
+
+    <div
+      id="modalDestinatariosMensagem"
+      class="fixed inset-0 z-50 hidden items-center justify-center bg-black bg-opacity-40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-hidden="true"
+      aria-labelledby="modalDestinatariosTitulo"
+    >
+      <div class="w-full max-w-2xl rounded-2xl bg-white shadow-2xl">
+        <div class="flex items-center justify-between border-b px-6 py-4">
+          <div>
+            <h3
+              id="modalDestinatariosTitulo"
+              class="text-lg font-semibold text-gray-800"
+            >
+              Selecionar destinatários
+            </h3>
+            <p id="modalDestinatariosDescricao" class="text-sm text-gray-500">
+              Escolha para quais e-mails a mensagem será enviada.
+            </p>
+          </div>
+          <button
+            type="button"
+            id="modalDestinatariosFechar"
+            class="text-gray-400 transition hover:text-gray-600"
+            aria-label="Fechar"
+          >
+            <i class="fa-solid fa-xmark text-xl"></i>
+          </button>
+        </div>
+        <form id="formDestinatariosMensagem" class="space-y-5 px-6 py-5">
+          <div
+            class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <p class="text-sm text-gray-600">
+              Pré-visualização:&nbsp;
+              <span
+                id="modalDestinatariosMensagemResumo"
+                class="font-medium text-gray-800"
+              ></span>
+            </p>
+            <div class="flex flex-wrap gap-2">
+              <button
+                type="button"
+                id="destinatariosSelecionarTodos"
+                class="rounded-lg border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-600 transition hover:border-blue-300 hover:bg-blue-100"
+              >
+                Enviar para todos
+              </button>
+              <button
+                type="button"
+                id="destinatariosLimparSelecao"
+                class="rounded-lg border border-gray-200 bg-white px-3 py-1 text-xs font-semibold text-gray-600 transition hover:bg-gray-100"
               >
                 Limpar seleção
               </button>
             </div>
-            <p class="text-xs text-gray-500 leading-relaxed">
-              Selecione quem deve receber as próximas atualizações. Deixe todos desmarcados para alcançar toda a equipe conectada.
-            </p>
-            <div id="participantesResumo" class="text-xs font-medium text-gray-600"></div>
-            <div id="participantesLista" class="space-y-2 max-h-80 overflow-y-auto pr-1"></div>
-            <p id="participantesVazio" class="text-xs text-gray-500 hidden">
-              Nenhum participante conectado foi encontrado.
-            </p>
-          </section>
-        </aside>
-      </div>
-    </main>
-
-    <script>
-      window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';
-      window.CUSTOM_NAVBAR_PATH = '/partials/navbar.html';
-    </script>
-    <script src="shared.js"></script>
-    <script type="module" src="firebase-config.js"></script>
-    <script type="module" src="painel-atualizacoes-gerais.js"></script>
-  </div>
-
-  <div
-    id="modalReuniao"
-    class="fixed inset-0 z-50 hidden items-center justify-center bg-black bg-opacity-40 p-4"
-    role="dialog"
-    aria-modal="true"
-    aria-labelledby="modalReuniaoTitulo"
-  >
-    <div class="w-full max-w-xl rounded-lg bg-white shadow-lg">
-      <div class="flex items-center justify-between border-b px-5 py-3">
-        <div>
-          <h3 id="modalReuniaoTitulo" class="text-lg font-semibold text-gray-800">
-            Agendar reunião
-          </h3>
-          <p id="modalReuniaoData" class="text-sm text-gray-500"></p>
-        </div>
-        <button
-          type="button"
-          id="modalReuniaoFechar"
-          class="text-gray-400 transition hover:text-gray-600"
-          aria-label="Fechar"
-        >
-          <i class="fa-solid fa-xmark text-xl"></i>
-        </button>
-      </div>
-      <form id="formReuniao" class="space-y-4 px-5 py-4">
-        <div class="grid gap-4 md:grid-cols-2">
-          <div class="space-y-2">
-            <label for="reuniaoHorario" class="text-sm font-medium text-gray-700">
-              Horário da reunião
-            </label>
-            <input
-              id="reuniaoHorario"
-              type="time"
-              class="w-full rounded-lg border border-gray-300 p-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-              required
-            />
           </div>
-          <div class="space-y-2">
-            <label for="reuniaoDescricao" class="text-sm font-medium text-gray-700">
-              Assunto (opcional)
-            </label>
-            <input
-              id="reuniaoDescricao"
-              type="text"
-              class="w-full rounded-lg border border-gray-300 p-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-              placeholder="Ex: alinhamento semanal"
-            />
-          </div>
-        </div>
-        <div class="space-y-2">
-          <p class="text-sm font-medium text-gray-700">Participantes conectados</p>
           <div
-            id="reuniaoParticipantesLista"
-            class="max-h-56 space-y-2 overflow-y-auto rounded-lg border border-gray-200 bg-gray-50 p-3"
+            id="destinatariosMensagemLista"
+            class="max-h-80 space-y-2 overflow-y-auto rounded-2xl border border-gray-200 bg-gray-50 p-3"
           ></div>
-          <p id="reuniaoParticipantesVazio" class="text-xs text-gray-500 hidden">
-            Nenhum participante disponível para seleção.
+          <p
+            id="destinatariosMensagemVazio"
+            class="text-sm text-gray-500 hidden"
+          >
+            Nenhum e-mail relacionado foi encontrado.
           </p>
-        </div>
-        <p id="reuniaoModalStatus" class="text-sm text-red-600"></p>
-        <div class="flex justify-end gap-2 pt-2">
+          <p id="destinatariosMensagemStatus" class="text-sm text-gray-500"></p>
+          <div class="flex justify-end gap-2">
+            <button
+              type="button"
+              id="modalDestinatariosCancelar"
+              class="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              id="modalDestinatariosConfirmar"
+              class="btn btn-primary px-4 py-2 text-sm"
+            >
+              Confirmar envio
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <div
+      id="modalReuniao"
+      class="fixed inset-0 z-50 hidden items-center justify-center bg-black bg-opacity-40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modalReuniaoTitulo"
+    >
+      <div class="w-full max-w-xl rounded-lg bg-white shadow-lg">
+        <div class="flex items-center justify-between border-b px-5 py-3">
+          <div>
+            <h3
+              id="modalReuniaoTitulo"
+              class="text-lg font-semibold text-gray-800"
+            >
+              Agendar reunião
+            </h3>
+            <p id="modalReuniaoData" class="text-sm text-gray-500"></p>
+          </div>
           <button
             type="button"
-            id="reuniaoCancelar"
-            class="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100"
+            id="modalReuniaoFechar"
+            class="text-gray-400 transition hover:text-gray-600"
+            aria-label="Fechar"
           >
-            Cancelar
-          </button>
-          <button
-            type="submit"
-            id="reuniaoSalvar"
-            class="btn btn-primary px-4 py-2 text-sm"
-          >
-            Agendar reunião
+            <i class="fa-solid fa-xmark text-xl"></i>
           </button>
         </div>
-      </form>
+        <form id="formReuniao" class="space-y-4 px-5 py-4">
+          <div class="grid gap-4 md:grid-cols-2">
+            <div class="space-y-2">
+              <label
+                for="reuniaoHorario"
+                class="text-sm font-medium text-gray-700"
+              >
+                Horário da reunião
+              </label>
+              <input
+                id="reuniaoHorario"
+                type="time"
+                class="w-full rounded-lg border border-gray-300 p-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                required
+              />
+            </div>
+            <div class="space-y-2">
+              <label
+                for="reuniaoDescricao"
+                class="text-sm font-medium text-gray-700"
+              >
+                Assunto (opcional)
+              </label>
+              <input
+                id="reuniaoDescricao"
+                type="text"
+                class="w-full rounded-lg border border-gray-300 p-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                placeholder="Ex: alinhamento semanal"
+              />
+            </div>
+          </div>
+          <div class="space-y-2">
+            <p class="text-sm font-medium text-gray-700">
+              Participantes conectados
+            </p>
+            <div
+              id="reuniaoParticipantesLista"
+              class="max-h-56 space-y-2 overflow-y-auto rounded-lg border border-gray-200 bg-gray-50 p-3"
+            ></div>
+            <p
+              id="reuniaoParticipantesVazio"
+              class="text-xs text-gray-500 hidden"
+            >
+              Nenhum participante disponível para seleção.
+            </p>
+          </div>
+          <p id="reuniaoModalStatus" class="text-sm text-red-600"></p>
+          <div class="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              id="reuniaoCancelar"
+              class="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              id="reuniaoSalvar"
+              class="btn btn-primary px-4 py-2 text-sm"
+            >
+              Agendar reunião
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
-  </div>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
## Resumo
- Divide o painel de atualizações gerais em abas dedicadas para mensagens, mural informativo, problemas e planejamento, entregando um layout mais moderno.
- Adiciona um modal de seleção de destinatários para o envio de mensagens, permitindo escolher entre todos os contatos ou um subconjunto específico.
- Atualiza a lógica do painel para alimentar o novo mural de informações, controlar as abas e intermediar o fluxo de envio das mensagens pelo modal.

## Testes
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c9f38f5980832ab81e88088be5015f