### PR TITLE
Add slider controls to expedition cards

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -259,6 +259,67 @@
   align-self: start;
 }
 
+.expedicao-slider {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+}
+
+.expedicao-slider-track {
+  flex: 1 1 auto;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 1rem;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-behavior: smooth;
+  padding: 0.5rem 0;
+}
+
+.expedicao-slider-track::-webkit-scrollbar {
+  display: none;
+}
+
+.expedicao-slider-track {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.expedicao-slider-track .expedicao-card {
+  flex: 0 0 auto;
+}
+
+.expedicao-slider-btn {
+  flex-shrink: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(79, 70, 229, 0.2);
+  background: var(--white);
+  color: #4f46e5;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 10px 20px rgba(79, 70, 229, 0.15);
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    background 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.expedicao-slider-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: rgba(79, 70, 229, 0.08);
+}
+
+.expedicao-slider-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+  box-shadow: none;
+}
+
 .expedicao-pdf-header {
   display: flex;
   justify-content: space-between;

--- a/expedicao.html
+++ b/expedicao.html
@@ -173,6 +173,7 @@
     let attentionOnly = false;
     const equipeUsuarios = new Map();
     let checklistRows = [];
+    const sliderResizeHandlers = [];
 
     function getResumoTimeWindow() {
       const now = new Date();
@@ -820,6 +821,8 @@
     async function carregarEtiquetas() {
       const list = document.getElementById('labelsList');
       list.innerHTML = '';
+      sliderResizeHandlers.forEach(handler => window.removeEventListener('resize', handler));
+      sliderResizeHandlers.length = 0;
       const filter = currentFilter;
       const snap = await db
         .collection('pdfDocs')
@@ -888,14 +891,69 @@
           const title = document.createElement('h2');
           title.className = 'font-semibold text-gray-700';
           title.textContent = owner;
-          const row = document.createElement('div');
-          row.className = 'flex flex-row flex-nowrap gap-4 overflow-x-auto';
+          const slider = document.createElement('div');
+          slider.className = 'expedicao-slider';
+
+          const prevBtn = document.createElement('button');
+          prevBtn.type = 'button';
+          prevBtn.className = 'expedicao-slider-btn';
+          prevBtn.innerHTML = '<i class="fas fa-chevron-left"></i>';
+          prevBtn.setAttribute('aria-label', 'Ver etiquetas anteriores');
+          prevBtn.style.display = 'none';
+
+          const track = document.createElement('div');
+          track.className = 'expedicao-slider-track';
+
           grouped[owner].forEach(r => {
-            row.appendChild(createPdfCard(r.doc, r.ownerName));
+            track.appendChild(createPdfCard(r.doc, r.ownerName));
           });
+
+          const nextBtn = document.createElement('button');
+          nextBtn.type = 'button';
+          nextBtn.className = 'expedicao-slider-btn';
+          nextBtn.innerHTML = '<i class="fas fa-chevron-right"></i>';
+          nextBtn.setAttribute('aria-label', 'Ver próximas etiquetas');
+          nextBtn.style.display = 'none';
+
+          slider.appendChild(prevBtn);
+          slider.appendChild(track);
+          slider.appendChild(nextBtn);
           wrapper.appendChild(title);
-          wrapper.appendChild(row);
+          wrapper.appendChild(slider);
           list.appendChild(wrapper);
+
+          const updateButtons = () => {
+            const maxScroll = track.scrollWidth - track.clientWidth;
+            const hasOverflow = maxScroll > 4;
+            prevBtn.style.display = hasOverflow ? 'inline-flex' : 'none';
+            nextBtn.style.display = hasOverflow ? 'inline-flex' : 'none';
+            if (!hasOverflow) return;
+            prevBtn.disabled = track.scrollLeft <= 0;
+            nextBtn.disabled = track.scrollLeft >= maxScroll - 1;
+          };
+
+          const getScrollAmount = () => {
+            const card = track.querySelector('.expedicao-card');
+            if (!card) return track.clientWidth;
+            const style = window.getComputedStyle(track);
+            const gap = parseFloat(style.columnGap || style.gap || '0');
+            return card.getBoundingClientRect().width + gap;
+          };
+
+          const scrollByAmount = direction => {
+            const amount = getScrollAmount();
+            track.scrollBy({ left: direction * amount, behavior: 'smooth' });
+          };
+
+          prevBtn.addEventListener('click', () => scrollByAmount(-1));
+          nextBtn.addEventListener('click', () => scrollByAmount(1));
+          track.addEventListener('scroll', () => window.requestAnimationFrame(updateButtons));
+
+          const resizeHandler = () => updateButtons();
+          sliderResizeHandlers.push(resizeHandler);
+          window.addEventListener('resize', resizeHandler);
+
+          window.requestAnimationFrame(updateButtons);
         });
       } else {
         list.className = viewMode === 'cards'


### PR DESCRIPTION
## Summary
- add horizontal slider controls for grouped expedition cards so the list stays within the page margins
- reset resize listeners when rebuilding the expedition list to avoid duplicate handlers
- style the slider track and arrow buttons to keep cards aligned and accessible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9f5dd455c832aa5d4a1390e11127e