### PR TITLE
Filtra histórico de faturamento por mês vigente

### DIFF
--- a/atualizacoes.js
+++ b/atualizacoes.js
@@ -226,11 +226,11 @@ async function carregarHistoricoFaturamento() {
     card.classList.add('hidden');
     return;
   }
-  card.classList.remove('hidden');
   const mesAtual = new Date().toISOString().slice(0, 7);
   const ano = new Date().getFullYear();
   const mesNum = new Date().getMonth() + 1;
   const totalDiasMes = new Date(ano, mesNum, 0).getDate();
+  let possuiHistorico = false;
   for (const u of usuariosResponsaveis) {
     let metaMensal = 0;
     try {
@@ -254,8 +254,13 @@ async function carregarHistoricoFaturamento() {
     );
     const dias = fatSnap.docs
       .map((d) => d.id)
+      .filter((id) => id.startsWith(mesAtual))
       .sort()
       .slice(-1);
+
+    if (!dias.length) {
+      continue;
+    }
 
     const col = document.createElement('div');
     col.className = 'faturamento-col';
@@ -290,6 +295,13 @@ async function carregarHistoricoFaturamento() {
     }
 
     container.appendChild(col);
+    possuiHistorico = true;
+  }
+
+  if (possuiHistorico) {
+    card.classList.remove('hidden');
+  } else {
+    card.classList.add('hidden');
   }
 }
 


### PR DESCRIPTION
## Summary
- considera apenas registros de faturamento do mês atual ao montar o histórico
- oculta o card de faturamento quando o usuário não possui lançamentos no mês vigente

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9f853618c832a8a3cd87dfca6c8ea