### PR TITLE
Add role and revenue goal controls to mentor profiles

### DIFF
--- a/perfil-mentorado.html
+++ b/perfil-mentorado.html
@@ -56,6 +56,27 @@
               />
             </div>
             <div class="space-y-1">
+              <label for="novoMentoradoCargo" class="text-sm font-medium text-gray-700">Cargo</label>
+              <input
+                id="novoMentoradoCargo"
+                name="novoCargo"
+                type="text"
+                class="form-control"
+                placeholder="Ex: Sócio, Gestor, Analista"
+              />
+            </div>
+            <div class="space-y-1">
+              <label for="novoMentoradoMeta" class="text-sm font-medium text-gray-700">Meta de faturamento líquido</label>
+              <input
+                id="novoMentoradoMeta"
+                name="novoMeta"
+                type="text"
+                inputmode="decimal"
+                class="form-control"
+                placeholder="Ex: 15000 ou 15.000,00"
+              />
+            </div>
+            <div class="space-y-1">
               <label for="novoMentoradoDataInicio" class="text-sm font-medium text-gray-700">Data de início</label>
               <input
                 id="novoMentoradoDataInicio"


### PR DESCRIPTION
## Summary
- add cargo and meta de faturamento fields to mentor creation and persistence flows
- redesign mentor profile cards to show a compact summary with view more and edit controls
- provide helpers for normalizing metas and formatting currency values in the mentor profile UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9f7301998832a81ef38a7eb889971