### PR TITLE
Ajusta layout dos cards da aba expedição

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -147,7 +147,7 @@
 /* Card estilo ticket usado na aba Expedição */
 .ticket-card {
   position: relative;
-  align-self: flex-start;
+  align-self: stretch;
 }
 
 .ticket-card::before,
@@ -181,6 +181,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  height: 100%;
   transition:
     transform 0.2s ease,
     box-shadow 0.2s ease;
@@ -244,21 +245,29 @@
 }
 
 #labelsList.grid {
-  align-items: flex-start;
-  align-items: start;
-  justify-items: center;
+  align-items: stretch;
+  justify-items: stretch;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 #labelsList.grid .expedicao-pdf-card {
   width: 100%;
-  max-width: 320px;
-  align-self: flex-start;
-  align-self: start;
+  max-width: 100%;
+  align-self: stretch;
 }
 
 #labelsList.grid .ticket-card {
-  align-self: flex-start;
-  align-self: start;
+  align-self: stretch;
+}
+
+.expedicao-owner-row {
+  flex-wrap: wrap;
+  align-items: stretch;
+}
+
+.expedicao-owner-row .expedicao-card {
+  flex: 1 1 240px;
+  max-width: 320px;
 }
 
 .expedicao-pdf-header {

--- a/expedicao.html
+++ b/expedicao.html
@@ -889,7 +889,7 @@
           title.className = 'font-semibold text-gray-700';
           title.textContent = owner;
           const row = document.createElement('div');
-          row.className = 'flex flex-row flex-nowrap gap-4 overflow-x-auto';
+          row.className = 'expedicao-owner-row flex flex-row gap-4';
           grouped[owner].forEach(r => {
             row.appendChild(createPdfCard(r.doc, r.ownerName));
           });


### PR DESCRIPTION
## Summary
- ajusta os estilos dos cards da aba de expedição para que preencham toda a altura da célula e adotem um grid responsivo
- cria regras específicas para o agrupamento por responsável evitando estouro horizontal quando muitas etiquetas são exibidas
- atualiza a montagem da lista para usar a nova classe utilitária de linhas de responsáveis

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9fd066634832ab980d6604ecc8ea7