### PR TITLE
Adicionar aba Produtos em linha com controle de acesso

### DIFF
--- a/painel-atualizacoes-gerais.html
+++ b/painel-atualizacoes-gerais.html
@@ -92,6 +92,17 @@
               >
                 Planejamento
               </button>
+              <button
+                id="tab-btn-produtos-linha"
+                type="button"
+                class="tab-button rounded-xl border border-transparent bg-white px-4 py-2 text-sm font-semibold text-gray-500 shadow-sm transition hover:border-emerald-200 hover:bg-emerald-50"
+                data-tab-target="produtos-linha"
+                aria-controls="tab-produtos-linha"
+                aria-selected="false"
+                role="tab"
+              >
+                Produtos em linha
+              </button>
             </nav>
             <p class="text-sm text-gray-500">
               Escolha uma das seções para visualizar ou atualizar as informações
@@ -621,6 +632,128 @@
                     Nenhum produto em linha cadastrado até o momento.
                   </p>
                 </div>
+              </section>
+            </div>
+
+            <div
+              id="tab-produtos-linha"
+              class="hidden space-y-6"
+              data-tab-panel="produtos-linha"
+              role="tabpanel"
+              aria-labelledby="tab-btn-produtos-linha"
+            >
+              <section
+                class="rounded-2xl border border-emerald-100 bg-white p-5 shadow-sm sm:p-6"
+              >
+                <div
+                  class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between"
+                >
+                  <div class="space-y-1">
+                    <h2
+                      class="flex items-center gap-2 text-xl font-semibold text-gray-800"
+                    >
+                      <span class="text-emerald-500"
+                        ><i class="fa-solid fa-clipboard-list"></i
+                      ></span>
+                      Produtos em linha importados
+                    </h2>
+                    <p class="text-sm text-gray-500">
+                      Visualize os itens enviados via aba Produtos e Preços e
+                      acompanhe as últimas atualizações compartilhadas pelo
+                      responsável financeiro.
+                    </p>
+                  </div>
+                  <span
+                    id="produtosLinhaStatus"
+                    class="text-sm text-gray-500"
+                  ></span>
+                </div>
+                <p
+                  id="produtosLinhaMeta"
+                  class="mt-3 text-xs text-gray-500"
+                ></p>
+                <div
+                  id="produtosLinhaTabelaContainer"
+                  class="mt-4 overflow-x-auto rounded-2xl border border-emerald-100 bg-white"
+                >
+                  <table class="min-w-full divide-y divide-gray-200">
+                    <thead id="produtosLinhaTabelaCabecalho"></thead>
+                    <tbody
+                      id="produtosLinhaTabelaCorpo"
+                      class="divide-y divide-gray-100"
+                    ></tbody>
+                  </table>
+                </div>
+                <p
+                  id="produtosLinhaAcessoNegado"
+                  class="mt-4 hidden rounded-xl border border-red-100 bg-red-50 p-3 text-sm text-red-600"
+                >
+                  O responsável financeiro ainda não liberou o acesso a essa
+                  lista para o seu usuário.
+                </p>
+                <p
+                  id="produtosLinhaSemInformacao"
+                  class="mt-4 hidden rounded-xl border border-amber-100 bg-amber-50 p-3 text-sm text-amber-700"
+                >
+                  Nenhuma informação foi compartilhada para este usuário.
+                </p>
+                <p
+                  id="produtosLinhaVazio"
+                  class="mt-4 hidden text-sm text-gray-500"
+                >
+                  Nenhum produto importado foi encontrado para exibir.
+                </p>
+              </section>
+
+              <section
+                id="produtosLinhaConfigSecao"
+                class="hidden rounded-2xl border border-blue-100 bg-blue-50/40 p-5 shadow-inner sm:p-6"
+              >
+                <div
+                  class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"
+                >
+                  <div class="space-y-1">
+                    <h3 class="text-lg font-semibold text-gray-800">
+                      Controle de acesso à lista
+                    </h3>
+                    <p class="text-sm text-gray-600">
+                      Escolha quem poderá visualizar a lista de produtos em
+                      linha e quais colunas ficarão disponíveis para cada
+                      usuário.
+                    </p>
+                  </div>
+                  <span
+                    id="produtosLinhaConfigStatus"
+                    class="text-sm text-gray-500"
+                  ></span>
+                </div>
+                <form id="formProdutosLinhaConfig" class="mt-4 space-y-5">
+                  <div
+                    id="produtosLinhaUsuariosLista"
+                    class="space-y-3"
+                  ></div>
+                  <p
+                    id="produtosLinhaConfigVazio"
+                    class="text-sm text-gray-500 hidden"
+                  >
+                    Nenhum usuário relacionado foi encontrado.
+                  </p>
+                  <div class="flex flex-col gap-3 text-xs text-gray-500">
+                    <p>
+                      Colunas disponíveis: SKU, Produto, Preço, Prazo e Última
+                      atualização. As alterações são aplicadas imediatamente
+                      após salvar.
+                    </p>
+                  </div>
+                  <div class="flex justify-end">
+                    <button
+                      type="submit"
+                      class="btn btn-primary rounded-xl px-4 py-2 text-sm"
+                    >
+                      Salvar configurações
+                    </button>
+                  </div>
+                </form>
               </section>
             </div>
           </div>

--- a/painel-atualizacoes-gerais.js
+++ b/painel-atualizacoes-gerais.js
@@ -8,6 +8,7 @@ import {
   collectionGroup,
   doc,
   addDoc,
+  setDoc,
   deleteDoc,
   getDoc,
   getDocs,
@@ -118,6 +119,39 @@ const muralReunioesListaEl = document.getElementById('muralReunioesLista');
 const muralReunioesVazioEl = document.getElementById('muralReunioesVazio');
 const muralProdutosListaEl = document.getElementById('muralProdutosLista');
 const muralProdutosVazioEl = document.getElementById('muralProdutosVazio');
+const produtosLinhaStatusEl = document.getElementById('produtosLinhaStatus');
+const produtosLinhaTabelaCabecalhoEl = document.getElementById(
+  'produtosLinhaTabelaCabecalho',
+);
+const produtosLinhaTabelaCorpoEl = document.getElementById(
+  'produtosLinhaTabelaCorpo',
+);
+const produtosLinhaTabelaContainerEl = document.getElementById(
+  'produtosLinhaTabelaContainer',
+);
+const produtosLinhaMetaEl = document.getElementById('produtosLinhaMeta');
+const produtosLinhaVazioEl = document.getElementById('produtosLinhaVazio');
+const produtosLinhaAcessoNegadoEl = document.getElementById(
+  'produtosLinhaAcessoNegado',
+);
+const produtosLinhaSemInformacaoEl = document.getElementById(
+  'produtosLinhaSemInformacao',
+);
+const produtosLinhaConfigSecaoEl = document.getElementById(
+  'produtosLinhaConfigSecao',
+);
+const produtosLinhaUsuariosListaEl = document.getElementById(
+  'produtosLinhaUsuariosLista',
+);
+const produtosLinhaConfigVazioEl = document.getElementById(
+  'produtosLinhaConfigVazio',
+);
+const produtosLinhaConfigStatusEl = document.getElementById(
+  'produtosLinhaConfigStatus',
+);
+const produtosLinhaConfigFormEl = document.getElementById(
+  'formProdutosLinhaConfig',
+);
 const modalDestinatariosEl = document.getElementById(
   'modalDestinatariosMensagem',
 );
@@ -158,6 +192,20 @@ let mensagensUnsub = null;
 let problemasUnsub = null;
 let produtosUnsub = null;
 let nomeResponsavel = '';
+let isGestorAtual = false;
+let isResponsavelFinanceiroAtual = false;
+let produtosLinhaPodeGerir = false;
+let usuariosFinanceirosLista = [];
+let produtosLinhaResponsavelUid = null;
+let produtosLinhaImportacoesUnsub = null;
+let produtosLinhaItensUnsub = null;
+let produtosLinhaConfigUnsub = null;
+let produtosLinhaConfigUidAtual = null;
+let produtosLinhaImportacaoMeta = null;
+let produtosLinhaItens = [];
+let produtosLinhaUsuariosMap = new Map();
+let produtosLinhaConfigDados = null;
+let produtosLinhaPronto = false;
 let participantesDetalhes = [];
 let participantesPorUid = new Map();
 let participantesSelecionados = new Set();
@@ -289,6 +337,18 @@ function formatShortDate(date) {
     day: '2-digit',
     month: 'short',
     year: 'numeric',
+  });
+}
+
+function formatCurrency(value) {
+  if (value === null || value === undefined || value === '') return '';
+  const numero = Number(value);
+  if (!Number.isFinite(numero)) return '';
+  return numero.toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
   });
 }
 
@@ -2219,6 +2279,1076 @@ function carregarReunioes() {
   );
 }
 
+const PRODUTOS_LINHA_CAMPOS = [
+  'sku',
+  'produto',
+  'preco',
+  'prazo',
+  'ultimaAtualizacao',
+];
+
+const PRODUTOS_LINHA_LABELS = {
+  sku: 'SKU',
+  produto: 'Produto',
+  preco: 'Preço',
+  prazo: 'Prazo',
+  ultimaAtualizacao: 'Última atualização',
+};
+
+const PRODUTOS_LINHA_PRAZO_OPCOES = {
+  sem_prazo: 'Sem prazo',
+  com_prazo: 'Com prazo',
+};
+
+function atualizarProdutosLinhaStatus(message = '', isError = false) {
+  setStatus(produtosLinhaStatusEl, message, isError);
+}
+
+function limparMonitoramentoProdutosLinhaImportacoes() {
+  produtosLinhaImportacoesUnsub?.();
+  produtosLinhaImportacoesUnsub = null;
+}
+
+function limparMonitoramentoProdutosLinhaItens() {
+  produtosLinhaItensUnsub?.();
+  produtosLinhaItensUnsub = null;
+}
+
+function limparMonitoramentoProdutosLinhaConfig() {
+  produtosLinhaConfigUnsub?.();
+  produtosLinhaConfigUnsub = null;
+  produtosLinhaConfigUidAtual = null;
+}
+
+function limparProdutosLinhaDados() {
+  produtosLinhaResponsavelUid = null;
+  produtosLinhaImportacaoMeta = null;
+  produtosLinhaItens = [];
+  produtosLinhaPronto = false;
+  atualizarProdutosLinhaMeta();
+  renderProdutosLinhaTabela();
+}
+
+function normalizarImportacaoMeta(docSnap) {
+  if (!docSnap) return null;
+  const data = docSnap.data() || {};
+  const criadoEm =
+    data.criadoEm?.toDate?.() ||
+    (data.criadoEm instanceof Date ? data.criadoEm : null);
+  const autorUid =
+    data.autorUid || data.responsavelUid || produtosLinhaResponsavelUid || '';
+  return {
+    id: docSnap.id,
+    autorUid,
+    autorNome: data.autorNome || data.responsavelNome || '',
+    dataReferencia: data.dataReferencia || '',
+    arquivoNome: data.arquivoNome || '',
+    criadoEm,
+    totalProdutos: Number(data.totalProdutos) || 0,
+    destinatarios: Array.isArray(data.destinatarios)
+      ? data.destinatarios.filter((uid) => typeof uid === 'string' && uid)
+      : [],
+    visivelParaUid: data.visivelParaUid || '',
+  };
+}
+
+function atualizarProdutosLinhaMeta() {
+  if (!produtosLinhaMetaEl) return;
+  if (!produtosLinhaImportacaoMeta) {
+    produtosLinhaMetaEl.textContent = '';
+    return;
+  }
+  const partes = [];
+  const meta = produtosLinhaImportacaoMeta;
+  if (meta.dataReferencia) {
+    partes.push(`Referência ${meta.dataReferencia}`);
+  }
+  if (meta.criadoEm) {
+    partes.push(`Importado em ${formatDate(meta.criadoEm, true)}`);
+  }
+  if (produtosLinhaItens.length) {
+    const total = produtosLinhaItens.length;
+    partes.push(`${total} produto${total === 1 ? '' : 's'}`);
+  }
+  if (meta.arquivoNome) {
+    partes.push(meta.arquivoNome);
+  }
+  produtosLinhaMetaEl.textContent = partes.join(' • ');
+}
+
+function extrairCamposAtivos(fields) {
+  if (!fields || typeof fields !== 'object') {
+    return [...PRODUTOS_LINHA_CAMPOS];
+  }
+  const ativos = PRODUTOS_LINHA_CAMPOS.filter((campo) => {
+    if (!Object.prototype.hasOwnProperty.call(fields, campo)) {
+      return false;
+    }
+    return Boolean(fields[campo]);
+  });
+  return ativos;
+}
+
+function obterPermissoesProdutosLinha() {
+  const todos = [...PRODUTOS_LINHA_CAMPOS];
+  if (
+    produtosLinhaPodeGerir &&
+    produtosLinhaResponsavelUid === currentUser?.uid
+  ) {
+    return { allowed: true, campos: todos };
+  }
+  const uidAtual = currentUser?.uid;
+  if (!uidAtual) {
+    return { allowed: false, campos: [] };
+  }
+  if (!produtosLinhaConfigDados) {
+    return { allowed: true, campos: todos };
+  }
+  const allowedUsers =
+    produtosLinhaConfigDados.allowedUsers &&
+    typeof produtosLinhaConfigDados.allowedUsers === 'object'
+      ? produtosLinhaConfigDados.allowedUsers
+      : {};
+  if (Object.prototype.hasOwnProperty.call(allowedUsers, uidAtual)) {
+    const entry = allowedUsers[uidAtual] || {};
+    const allowed = entry.allowed !== false;
+    const campos = extrairCamposAtivos(entry.fields);
+    return { allowed, campos };
+  }
+  const camposPadrao = extrairCamposAtivos(
+    produtosLinhaConfigDados.defaultFields,
+  );
+  if (!camposPadrao.length) {
+    return { allowed: true, campos: todos };
+  }
+  return { allowed: true, campos: camposPadrao };
+}
+
+function obterChaveProdutoLinha(item = {}) {
+  if (item.id) return String(item.id);
+  if (item.sku) {
+    return `sku:${String(item.sku).trim().toUpperCase()}`;
+  }
+  if (item.produto) {
+    return `produto:${String(item.produto).trim().toUpperCase()}`;
+  }
+  if (typeof item.ordem === 'number') {
+    return `ordem:${item.ordem}`;
+  }
+  return '';
+}
+
+function obterPrazoStatus(itemId) {
+  if (!itemId) return 'sem_prazo';
+  if (!produtosLinhaConfigDados) return 'sem_prazo';
+  const mapa =
+    produtosLinhaConfigDados.prazoStatus &&
+    typeof produtosLinhaConfigDados.prazoStatus === 'object'
+      ? produtosLinhaConfigDados.prazoStatus
+      : {};
+  const valor = mapa[itemId];
+  if (
+    valor &&
+    Object.prototype.hasOwnProperty.call(PRODUTOS_LINHA_PRAZO_OPCOES, valor)
+  ) {
+    return valor;
+  }
+  return 'sem_prazo';
+}
+
+function renderProdutosLinhaTabela() {
+  if (!produtosLinhaTabelaCabecalhoEl || !produtosLinhaTabelaCorpoEl) {
+    return;
+  }
+
+  const permissoes = obterPermissoesProdutosLinha();
+  const camposAtivos =
+    Array.isArray(permissoes.campos) && permissoes.campos.length
+      ? permissoes.campos
+      : [];
+  const podeExibirTabela = permissoes.allowed && camposAtivos.length > 0;
+
+  if (produtosLinhaTabelaContainerEl) {
+    produtosLinhaTabelaContainerEl.classList.toggle(
+      'hidden',
+      !podeExibirTabela,
+    );
+  }
+
+  if (!permissoes.allowed) {
+    produtosLinhaAcessoNegadoEl?.classList.remove('hidden');
+  } else {
+    produtosLinhaAcessoNegadoEl?.classList.add('hidden');
+  }
+
+  if (permissoes.allowed && !camposAtivos.length) {
+    produtosLinhaSemInformacaoEl?.classList.remove('hidden');
+  } else {
+    produtosLinhaSemInformacaoEl?.classList.add('hidden');
+  }
+
+  if (!podeExibirTabela) {
+    produtosLinhaTabelaCabecalhoEl.innerHTML = '';
+    produtosLinhaTabelaCorpoEl.innerHTML = '';
+    if (permissoes.allowed) {
+      produtosLinhaVazioEl?.classList.add('hidden');
+    }
+    return;
+  }
+
+  const thead = produtosLinhaTabelaCabecalhoEl;
+  thead.innerHTML = '';
+  const headerRow = document.createElement('tr');
+  camposAtivos.forEach((campo) => {
+    const th = document.createElement('th');
+    th.scope = 'col';
+    th.className =
+      'px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500';
+    th.textContent = PRODUTOS_LINHA_LABELS[campo] || campo;
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+
+  const tbody = produtosLinhaTabelaCorpoEl;
+  tbody.innerHTML = '';
+  const itensOrdenados = [...produtosLinhaItens].sort((a, b) => {
+    const nomeA = (a.produto || '').toLowerCase();
+    const nomeB = (b.produto || '').toLowerCase();
+    if (nomeA && nomeB && nomeA !== nomeB) {
+      return nomeA.localeCompare(nomeB, 'pt-BR');
+    }
+    const skuA = (a.sku || '').toLowerCase();
+    const skuB = (b.sku || '').toLowerCase();
+    if (skuA && skuB && skuA !== skuB) {
+      return skuA.localeCompare(skuB, 'pt-BR');
+    }
+    if (typeof a.ordem === 'number' && typeof b.ordem === 'number') {
+      return a.ordem - b.ordem;
+    }
+    return 0;
+  });
+
+  if (!itensOrdenados.length) {
+    if (produtosLinhaPronto) {
+      produtosLinhaVazioEl?.classList.remove('hidden');
+    } else {
+      produtosLinhaVazioEl?.classList.add('hidden');
+    }
+    return;
+  }
+
+  produtosLinhaVazioEl?.classList.add('hidden');
+  const podeEditarPrazo =
+    produtosLinhaPodeGerir && produtosLinhaResponsavelUid === currentUser?.uid;
+  const frag = document.createDocumentFragment();
+  itensOrdenados.forEach((item) => {
+    const tr = document.createElement('tr');
+    tr.className = 'transition hover:bg-emerald-50/60';
+    camposAtivos.forEach((campo) => {
+      const td = document.createElement('td');
+      td.className = 'px-4 py-3 text-sm text-gray-700 align-top';
+      preencherCelulaProdutoLinha(td, item, campo, podeEditarPrazo);
+      tr.appendChild(td);
+    });
+    frag.appendChild(tr);
+  });
+  tbody.appendChild(frag);
+}
+
+function preencherCelulaProdutoLinha(td, item, campo, podeEditarPrazo) {
+  switch (campo) {
+    case 'sku': {
+      const texto = item.sku ? String(item.sku) : '-';
+      td.textContent = texto;
+      if (!item.sku) td.classList.add('text-gray-400');
+      break;
+    }
+    case 'produto': {
+      const texto = item.produto ? String(item.produto) : '-';
+      td.textContent = texto;
+      if (!item.produto) td.classList.add('text-gray-400');
+      break;
+    }
+    case 'preco': {
+      const valor = item.preco ?? item.sobra ?? null;
+      const texto = formatCurrency(valor);
+      td.textContent = texto || '-';
+      if (!texto) td.classList.add('text-gray-400');
+      break;
+    }
+    case 'prazo': {
+      const itemId = obterChaveProdutoLinha(item);
+      const status = obterPrazoStatus(itemId);
+      if (podeEditarPrazo && itemId) {
+        const select = document.createElement('select');
+        select.className =
+          'produtos-linha-prazo-select w-full rounded-lg border border-emerald-200 bg-white px-2 py-1 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-emerald-300';
+        select.dataset.itemId = itemId;
+        Object.entries(PRODUTOS_LINHA_PRAZO_OPCOES).forEach(
+          ([valor, label]) => {
+            const option = document.createElement('option');
+            option.value = valor;
+            option.textContent = label;
+            select.appendChild(option);
+          },
+        );
+        select.value = status;
+        td.appendChild(select);
+      } else {
+        td.textContent =
+          PRODUTOS_LINHA_PRAZO_OPCOES[status] ||
+          PRODUTOS_LINHA_PRAZO_OPCOES.sem_prazo;
+      }
+      break;
+    }
+    case 'ultimaAtualizacao': {
+      const atualizadoEm =
+        item.atualizadoEm instanceof Date ? item.atualizadoEm : null;
+      let texto = atualizadoEm ? formatDate(atualizadoEm, true) : '';
+      if (!texto && item.dataReferencia) {
+        texto = `Referência ${item.dataReferencia}`;
+      }
+      td.textContent = texto || '-';
+      if (!texto) td.classList.add('text-gray-400');
+      break;
+    }
+    default: {
+      const valor = item && campo in item ? item[campo] : '';
+      const texto = valor === null || valor === undefined ? '' : String(valor);
+      td.textContent = texto || '-';
+      if (!texto) td.classList.add('text-gray-400');
+    }
+  }
+}
+
+function renderProdutosLinhaConfig() {
+  if (!produtosLinhaConfigSecaoEl) return;
+  const podeGerenciar =
+    produtosLinhaPodeGerir && produtosLinhaResponsavelUid === currentUser?.uid;
+  if (!podeGerenciar) {
+    produtosLinhaConfigSecaoEl.classList.add('hidden');
+    setStatus(produtosLinhaConfigStatusEl, '');
+    return;
+  }
+
+  produtosLinhaConfigSecaoEl.classList.remove('hidden');
+  if (!produtosLinhaUsuariosListaEl) return;
+
+  const usuarios = Array.from(produtosLinhaUsuariosMap.values()).sort((a, b) =>
+    (a.nome || '').localeCompare(b.nome || '', 'pt-BR'),
+  );
+
+  produtosLinhaUsuariosListaEl.innerHTML = '';
+
+  if (!usuarios.length) {
+    produtosLinhaConfigVazioEl?.classList.remove('hidden');
+    return;
+  }
+
+  produtosLinhaConfigVazioEl?.classList.add('hidden');
+  const allowedUsers =
+    produtosLinhaConfigDados?.allowedUsers &&
+    typeof produtosLinhaConfigDados.allowedUsers === 'object'
+      ? produtosLinhaConfigDados.allowedUsers
+      : {};
+
+  const frag = document.createDocumentFragment();
+  usuarios.forEach((info) => {
+    const entry = allowedUsers[info.uid] || null;
+    frag.appendChild(criarItemConfigUsuario(info, entry));
+  });
+  produtosLinhaUsuariosListaEl.appendChild(frag);
+}
+
+function criarItemConfigUsuario(info = {}, entry = null) {
+  const wrapper = document.createElement('div');
+  wrapper.className =
+    'space-y-3 rounded-2xl border border-white bg-white p-4 shadow-sm';
+  wrapper.dataset.uid = info.uid || '';
+
+  const header = document.createElement('div');
+  header.className =
+    'flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between';
+
+  const label = document.createElement('label');
+  label.className = 'flex items-center gap-3 text-sm font-medium text-gray-800';
+
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.className =
+    'produtos-linha-user-enable h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500';
+  const habilitado = entry ? entry.allowed !== false : true;
+  checkbox.checked = habilitado;
+  label.appendChild(checkbox);
+
+  const nomeEl = document.createElement('span');
+  const nomePadrao = info.nome || info.email || '';
+  nomeEl.textContent =
+    nomePadrao || `Usuário ${String(info.uid || '').slice(0, 6)}`;
+  label.appendChild(nomeEl);
+
+  header.appendChild(label);
+
+  if (info.email) {
+    const emailEl = document.createElement('span');
+    emailEl.className = 'text-xs text-gray-500 break-all';
+    emailEl.textContent = info.email;
+    header.appendChild(emailEl);
+  }
+
+  wrapper.appendChild(header);
+
+  const camposContainer = document.createElement('div');
+  camposContainer.className = 'mt-2 flex flex-wrap gap-3';
+
+  const camposConfig =
+    entry && entry.fields && typeof entry.fields === 'object'
+      ? entry.fields
+      : null;
+
+  PRODUTOS_LINHA_CAMPOS.forEach((campo) => {
+    const option = document.createElement('label');
+    option.className =
+      'flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs font-medium text-gray-600';
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.className =
+      'produtos-linha-user-field h-4 w-4 rounded border-gray-300 text-emerald-600 focus:ring-emerald-500';
+    input.dataset.field = campo;
+    let marcado = true;
+    if (camposConfig && Object.keys(camposConfig).length) {
+      if (Object.prototype.hasOwnProperty.call(camposConfig, campo)) {
+        marcado = Boolean(camposConfig[campo]);
+      }
+    }
+    input.checked = marcado;
+    input.disabled = !habilitado;
+    option.appendChild(input);
+    const span = document.createElement('span');
+    span.textContent = PRODUTOS_LINHA_LABELS[campo] || campo;
+    option.appendChild(span);
+    camposContainer.appendChild(option);
+  });
+
+  wrapper.appendChild(camposContainer);
+
+  checkbox.addEventListener('change', (event) => {
+    atualizarDisponibilidadeCampos(wrapper, event.target.checked);
+  });
+
+  return wrapper;
+}
+
+function atualizarDisponibilidadeCampos(container, habilitado) {
+  if (!container) return;
+  const campos = container.querySelectorAll('.produtos-linha-user-field');
+  campos.forEach((checkbox) => {
+    checkbox.disabled = !habilitado;
+  });
+}
+
+function extrairCamposSelecionados(container) {
+  const campos = {};
+  if (!container) return campos;
+  container.querySelectorAll('.produtos-linha-user-field').forEach((input) => {
+    const campo = input.dataset.field;
+    if (!campo) return;
+    campos[campo] = input.checked;
+  });
+  return campos;
+}
+
+async function salvarConfiguracoesProdutosLinha(event) {
+  event.preventDefault();
+  if (
+    !produtosLinhaPodeGerir ||
+    produtosLinhaResponsavelUid !== currentUser?.uid ||
+    !produtosLinhaUsuariosListaEl
+  ) {
+    return;
+  }
+
+  const botao = produtosLinhaConfigFormEl?.querySelector(
+    'button[type="submit"]',
+  );
+  if (botao) {
+    botao.disabled = true;
+    botao.classList.add('opacity-60', 'cursor-not-allowed');
+  }
+  setStatus(produtosLinhaConfigStatusEl, 'Salvando configurações...');
+
+  try {
+    const containers =
+      produtosLinhaUsuariosListaEl.querySelectorAll('[data-uid]');
+    const allowedUsers = {};
+    containers.forEach((container) => {
+      const uid = container.dataset.uid;
+      if (!uid) return;
+      const habilitado = !!container.querySelector(
+        '.produtos-linha-user-enable',
+      )?.checked;
+      const campos = extrairCamposSelecionados(container);
+      allowedUsers[uid] = { allowed: habilitado, fields: campos };
+    });
+
+    const defaultFields =
+      produtosLinhaConfigDados?.defaultFields &&
+      typeof produtosLinhaConfigDados.defaultFields === 'object'
+        ? produtosLinhaConfigDados.defaultFields
+        : PRODUTOS_LINHA_CAMPOS.reduce((acc, campo) => {
+            acc[campo] = true;
+            return acc;
+          }, {});
+
+    await setDoc(
+      doc(db, 'produtosEmLinhaConfigs', produtosLinhaResponsavelUid),
+      {
+        responsavelUid: produtosLinhaResponsavelUid,
+        responsavelEmail: currentUser?.email || '',
+        responsavelNome: currentUser?.displayName || '',
+        allowedUsers,
+        defaultFields,
+        updatedAt: serverTimestamp(),
+        updatedBy: currentUser?.uid || '',
+      },
+      { merge: true },
+    );
+
+    showTemporaryStatus(
+      produtosLinhaConfigStatusEl,
+      'Configurações atualizadas com sucesso.',
+    );
+  } catch (err) {
+    console.error('Erro ao salvar configurações de produtos em linha:', err);
+    showTemporaryStatus(
+      produtosLinhaConfigStatusEl,
+      'Não foi possível salvar as configurações.',
+      true,
+    );
+  } finally {
+    if (botao) {
+      botao.disabled = false;
+      botao.classList.remove('opacity-60', 'cursor-not-allowed');
+    }
+  }
+}
+
+async function atualizarPrazoProdutoLinha(itemId, valor) {
+  if (
+    !produtosLinhaPodeGerir ||
+    produtosLinhaResponsavelUid !== currentUser?.uid ||
+    !itemId
+  ) {
+    return;
+  }
+
+  const status = Object.prototype.hasOwnProperty.call(
+    PRODUTOS_LINHA_PRAZO_OPCOES,
+    valor,
+  )
+    ? valor
+    : 'sem_prazo';
+
+  try {
+    const docRef = doc(
+      db,
+      'produtosEmLinhaConfigs',
+      produtosLinhaResponsavelUid,
+    );
+    const payload = {
+      responsavelUid: produtosLinhaResponsavelUid,
+      responsavelEmail: currentUser?.email || '',
+      responsavelNome: currentUser?.displayName || '',
+      updatedAt: serverTimestamp(),
+      updatedBy: currentUser?.uid || '',
+    };
+    payload[`prazoStatus.${itemId}`] = status;
+    await setDoc(docRef, payload, { merge: true });
+  } catch (err) {
+    console.error('Erro ao atualizar prazo do produto em linha:', err);
+    showTemporaryStatus(
+      produtosLinhaStatusEl,
+      'Não foi possível atualizar o status de prazo.',
+      true,
+    );
+  }
+}
+
+async function garantirUsuariosProdutosLinha(uids = []) {
+  const validos = Array.from(
+    new Set((uids || []).filter((uid) => typeof uid === 'string' && uid)),
+  );
+  if (!validos.length) return;
+
+  const faltantes = validos.filter((uid) => !produtosLinhaUsuariosMap.has(uid));
+  if (!faltantes.length) return;
+
+  faltantes.forEach((uid) => {
+    produtosLinhaUsuariosMap.set(uid, {
+      uid,
+      nome: `Usuário ${uid.slice(0, 6)}`,
+      email: '',
+    });
+  });
+  renderProdutosLinhaConfig();
+
+  try {
+    const detalhes = await buscarDetalhesUsuariosBasico(faltantes);
+    detalhes.forEach((info) => {
+      produtosLinhaUsuariosMap.set(info.uid, {
+        uid: info.uid,
+        nome: info.nome || info.email || `Usuário ${info.uid.slice(0, 6)}`,
+        email: info.email || '',
+      });
+    });
+    renderProdutosLinhaConfig();
+  } catch (err) {
+    console.error(
+      'Erro ao carregar usuários relacionados aos produtos em linha:',
+      err,
+    );
+  }
+}
+
+async function buscarDetalhesUsuariosBasico(uids = []) {
+  const validos = Array.from(
+    new Set((uids || []).filter((uid) => typeof uid === 'string' && uid)),
+  );
+  if (!validos.length) return [];
+
+  const resultados = new Map();
+
+  const buscar = async (colecao, ids) => {
+    for (let i = 0; i < ids.length; i += 10) {
+      const lote = ids.slice(i, i + 10);
+      if (!lote.length) continue;
+      try {
+        const snap = await getDocs(
+          query(collection(db, colecao), where(documentId(), 'in', lote)),
+        );
+        snap.forEach((docSnap) => {
+          resultados.set(
+            docSnap.id,
+            montarDetalhesParticipante(docSnap.id, docSnap.data() || {}),
+          );
+        });
+      } catch (err) {
+        console.error(`Erro ao buscar usuários (${colecao}):`, err);
+      }
+    }
+  };
+
+  await buscar('usuarios', validos);
+  const faltantes = validos.filter((uid) => !resultados.has(uid));
+  if (faltantes.length) {
+    await buscar('uid', faltantes);
+  }
+
+  return validos.map((uid) => {
+    if (resultados.has(uid)) {
+      const info = resultados.get(uid);
+      return {
+        uid: info.uid,
+        nome: info.nome,
+        email: info.email,
+      };
+    }
+    const detalhes = montarDetalhesParticipante(uid, {});
+    return {
+      uid: detalhes.uid,
+      nome: detalhes.nome,
+      email: detalhes.email,
+    };
+  });
+}
+
+async function inicializarProdutosLinha(usuarios = []) {
+  produtosLinhaUsuariosMap = new Map();
+  usuariosFinanceirosLista = Array.isArray(usuarios) ? usuarios : [];
+  usuariosFinanceirosLista.forEach((info) => {
+    if (!info?.uid) return;
+    const nome = info.nome || info.email || '';
+    produtosLinhaUsuariosMap.set(info.uid, {
+      uid: info.uid,
+      nome: nome || `Usuário ${info.uid.slice(0, 6)}`,
+      email: info.email || '',
+    });
+  });
+
+  if (currentUser?.uid && !produtosLinhaUsuariosMap.has(currentUser.uid)) {
+    produtosLinhaUsuariosMap.set(currentUser.uid, {
+      uid: currentUser.uid,
+      nome: currentUser.displayName || currentUser.email || 'Você',
+      email: currentUser.email || '',
+    });
+  }
+
+  renderProdutosLinhaConfig();
+  produtosLinhaItens = [];
+  produtosLinhaImportacaoMeta = null;
+  produtosLinhaPronto = false;
+  atualizarProdutosLinhaMeta();
+  renderProdutosLinhaTabela();
+
+  if (produtosLinhaPodeGerir) {
+    produtosLinhaResponsavelUid = currentUser?.uid || null;
+    await garantirUsuariosProdutosLinha([produtosLinhaResponsavelUid]);
+    monitorarConfigProdutosLinha(produtosLinhaResponsavelUid);
+    monitorarProdutosLinhaResponsavel();
+  } else {
+    monitorarConfigProdutosLinha(null);
+    monitorarProdutosLinhaUsuario();
+  }
+}
+
+async function monitorarConfigProdutosLinha(responsavelUid) {
+  if (!responsavelUid) {
+    produtosLinhaConfigDados = null;
+    limparMonitoramentoProdutosLinhaConfig();
+    renderProdutosLinhaConfig();
+    renderProdutosLinhaTabela();
+    return;
+  }
+
+  if (
+    produtosLinhaConfigUidAtual === responsavelUid &&
+    produtosLinhaConfigUnsub
+  ) {
+    return;
+  }
+
+  limparMonitoramentoProdutosLinhaConfig();
+  produtosLinhaConfigUidAtual = responsavelUid;
+  const configRef = doc(db, 'produtosEmLinhaConfigs', responsavelUid);
+  produtosLinhaConfigUnsub = onSnapshot(
+    configRef,
+    async (docSnap) => {
+      produtosLinhaConfigDados = docSnap.exists() ? docSnap.data() || {} : null;
+      const chaves =
+        produtosLinhaConfigDados?.allowedUsers &&
+        typeof produtosLinhaConfigDados.allowedUsers === 'object'
+          ? Object.keys(produtosLinhaConfigDados.allowedUsers)
+          : [];
+      await garantirUsuariosProdutosLinha([
+        responsavelUid,
+        ...(produtosLinhaImportacaoMeta?.destinatarios || []),
+        ...chaves,
+      ]);
+      renderProdutosLinhaConfig();
+      renderProdutosLinhaTabela();
+    },
+    (err) => {
+      console.error(
+        'Erro ao monitorar configurações de produtos em linha:',
+        err,
+      );
+      produtosLinhaConfigDados = null;
+      renderProdutosLinhaConfig();
+      renderProdutosLinhaTabela();
+    },
+  );
+}
+
+function monitorarProdutosLinhaResponsavel() {
+  if (!currentUser) return;
+  limparMonitoramentoProdutosLinhaImportacoes();
+  atualizarProdutosLinhaStatus('Carregando produtos importados...');
+  produtosLinhaPronto = false;
+
+  const importacoesRef = query(
+    collection(db, 'produtosPrecos'),
+    where('autorUid', '==', currentUser.uid),
+    orderBy('criadoEm', 'desc'),
+    limit(1),
+  );
+
+  produtosLinhaImportacoesUnsub = onSnapshot(
+    importacoesRef,
+    (snap) => {
+      if (snap.empty) {
+        produtosLinhaPronto = true;
+        produtosLinhaImportacaoMeta = null;
+        produtosLinhaItens = [];
+        atualizarProdutosLinhaStatus(
+          'Nenhuma importação encontrada para exibir.',
+        );
+        atualizarProdutosLinhaMeta();
+        renderProdutosLinhaTabela();
+        limparMonitoramentoProdutosLinhaItens();
+        return;
+      }
+
+      produtosLinhaPronto = true;
+      atualizarProdutosLinhaStatus('', false);
+      const docSnap = snap.docs[0];
+      processarImportacaoProdutosLinha(docSnap);
+    },
+    async (err) => {
+      console.error(
+        'Erro ao monitorar importações do responsável financeiro:',
+        err,
+      );
+      if (err.code === 'failed-precondition') {
+        await carregarImportacaoResponsavelFallback(currentUser.uid);
+      } else {
+        atualizarProdutosLinhaStatus(
+          'Não foi possível carregar as importações de produtos.',
+          true,
+        );
+        limparProdutosLinhaDados();
+      }
+    },
+  );
+}
+
+function monitorarProdutosLinhaUsuario() {
+  if (!currentUser) return;
+  limparMonitoramentoProdutosLinhaImportacoes();
+  atualizarProdutosLinhaStatus('Carregando produtos importados...');
+  produtosLinhaPronto = false;
+
+  const importacoesRef = query(
+    collection(db, 'uid', currentUser.uid, 'produtosPrecos'),
+    orderBy('criadoEm', 'desc'),
+    limit(1),
+  );
+
+  produtosLinhaImportacoesUnsub = onSnapshot(
+    importacoesRef,
+    (snap) => {
+      if (snap.empty) {
+        produtosLinhaPronto = true;
+        produtosLinhaImportacaoMeta = null;
+        produtosLinhaItens = [];
+        atualizarProdutosLinhaStatus(
+          'Nenhum produto importado foi encontrado.',
+        );
+        atualizarProdutosLinhaMeta();
+        renderProdutosLinhaTabela();
+        limparMonitoramentoProdutosLinhaItens();
+        monitorarConfigProdutosLinha(null);
+        return;
+      }
+
+      produtosLinhaPronto = true;
+      atualizarProdutosLinhaStatus('', false);
+      const docSnap = snap.docs[0];
+      const data = docSnap.data() || {};
+      produtosLinhaResponsavelUid =
+        data.autorUid || data.responsavelUid || produtosLinhaResponsavelUid;
+      if (produtosLinhaResponsavelUid) {
+        monitorarConfigProdutosLinha(produtosLinhaResponsavelUid);
+      }
+      const destinatarios = Array.isArray(data.destinatarios)
+        ? data.destinatarios
+        : [];
+      garantirUsuariosProdutosLinha([
+        currentUser.uid,
+        produtosLinhaResponsavelUid,
+        ...destinatarios,
+      ]);
+      processarImportacaoProdutosLinha(docSnap);
+    },
+    async (err) => {
+      console.error('Erro ao monitorar importações do usuário:', err);
+      if (err.code === 'failed-precondition') {
+        await carregarImportacaoUsuarioFallback(currentUser.uid);
+      } else {
+        atualizarProdutosLinhaStatus(
+          'Não foi possível carregar os produtos importados.',
+          true,
+        );
+        limparProdutosLinhaDados();
+        monitorarConfigProdutosLinha(null);
+      }
+    },
+  );
+}
+
+async function carregarImportacaoResponsavelFallback(uid) {
+  if (!uid) return;
+  try {
+    const snap = await getDocs(
+      query(
+        collection(db, 'produtosPrecos'),
+        orderBy('criadoEm', 'desc'),
+        limit(20),
+      ),
+    );
+    const docSnap = snap.docs.find((doc) => {
+      const data = doc.data() || {};
+      return (data.autorUid || data.responsavelUid) === uid;
+    });
+
+    if (!docSnap) {
+      produtosLinhaPronto = true;
+      produtosLinhaImportacaoMeta = null;
+      produtosLinhaItens = [];
+      atualizarProdutosLinhaStatus(
+        'Nenhuma importação encontrada para exibir.',
+      );
+      atualizarProdutosLinhaMeta();
+      renderProdutosLinhaTabela();
+      limparMonitoramentoProdutosLinhaItens();
+      return;
+    }
+
+    produtosLinhaPronto = true;
+    atualizarProdutosLinhaStatus('', false);
+    processarImportacaoProdutosLinha(docSnap);
+  } catch (err) {
+    console.error(
+      'Erro ao carregar importações do responsável (fallback):',
+      err,
+    );
+    atualizarProdutosLinhaStatus(
+      'Não foi possível carregar as importações de produtos.',
+      true,
+    );
+    limparProdutosLinhaDados();
+  }
+}
+
+async function carregarImportacaoUsuarioFallback(uid) {
+  if (!uid) return;
+  try {
+    const snap = await getDocs(
+      query(
+        collection(db, 'uid', uid, 'produtosPrecos'),
+        orderBy('criadoEm', 'desc'),
+        limit(1),
+      ),
+    );
+    if (snap.empty) {
+      produtosLinhaPronto = true;
+      produtosLinhaImportacaoMeta = null;
+      produtosLinhaItens = [];
+      atualizarProdutosLinhaStatus('Nenhum produto importado foi encontrado.');
+      atualizarProdutosLinhaMeta();
+      renderProdutosLinhaTabela();
+      limparMonitoramentoProdutosLinhaItens();
+      monitorarConfigProdutosLinha(null);
+      return;
+    }
+
+    produtosLinhaPronto = true;
+    atualizarProdutosLinhaStatus('', false);
+    const docSnap = snap.docs[0];
+    const data = docSnap.data() || {};
+    produtosLinhaResponsavelUid =
+      data.autorUid || data.responsavelUid || produtosLinhaResponsavelUid;
+    if (produtosLinhaResponsavelUid) {
+      monitorarConfigProdutosLinha(produtosLinhaResponsavelUid);
+    }
+    const destinatarios = Array.isArray(data.destinatarios)
+      ? data.destinatarios
+      : [];
+    garantirUsuariosProdutosLinha([
+      uid,
+      produtosLinhaResponsavelUid,
+      ...destinatarios,
+    ]);
+    processarImportacaoProdutosLinha(docSnap);
+  } catch (err) {
+    console.error('Erro ao carregar importações do usuário (fallback):', err);
+    atualizarProdutosLinhaStatus(
+      'Não foi possível carregar os produtos importados.',
+      true,
+    );
+    limparProdutosLinhaDados();
+    monitorarConfigProdutosLinha(null);
+  }
+}
+
+function processarImportacaoProdutosLinha(docSnap) {
+  if (!docSnap) return;
+  produtosLinhaImportacaoMeta = normalizarImportacaoMeta(docSnap);
+  if (produtosLinhaImportacaoMeta?.autorUid) {
+    produtosLinhaResponsavelUid = produtosLinhaImportacaoMeta.autorUid;
+    monitorarConfigProdutosLinha(produtosLinhaResponsavelUid);
+  }
+
+  const destinatarios = Array.isArray(
+    produtosLinhaImportacaoMeta?.destinatarios,
+  )
+    ? produtosLinhaImportacaoMeta.destinatarios
+    : [];
+
+  garantirUsuariosProdutosLinha([
+    produtosLinhaResponsavelUid,
+    ...(destinatarios || []),
+    produtosLinhaImportacaoMeta?.visivelParaUid,
+  ]);
+
+  atualizarProdutosLinhaMeta();
+  monitorarProdutosLinhaItens(docSnap.ref);
+}
+
+function monitorarProdutosLinhaItens(importacaoRef) {
+  limparMonitoramentoProdutosLinhaItens();
+  if (!importacaoRef) {
+    produtosLinhaItens = [];
+    renderProdutosLinhaTabela();
+    return;
+  }
+
+  const itensRef = query(
+    collection(importacaoRef, 'itens'),
+    orderBy('ordem', 'asc'),
+  );
+
+  produtosLinhaItensUnsub = onSnapshot(
+    itensRef,
+    (snap) => {
+      produtosLinhaItens = snap.docs.map((docSnap) => {
+        const data = docSnap.data() || {};
+        const atualizadoEm =
+          data.atualizadoEm?.toDate?.() ||
+          (data.atualizadoEm instanceof Date ? data.atualizadoEm : null);
+        return {
+          id: docSnap.id,
+          sku: data.sku || '',
+          produto: data.produto || data.nome || '',
+          preco:
+            data.preco ?? data.precoTabela ?? data.sobra ?? data.valor ?? null,
+          sobra: data.sobra ?? null,
+          atualizadoEm,
+          ordem: data.ordem ?? null,
+          dataReferencia:
+            data.dataReferencia ||
+            produtosLinhaImportacaoMeta?.dataReferencia ||
+            '',
+        };
+      });
+
+      if (
+        !produtosLinhaItens.length &&
+        produtosLinhaImportacaoMeta?.totalProdutos
+      ) {
+        atualizarProdutosLinhaStatus(
+          'Aguardando processamento dos itens importados...',
+          false,
+        );
+      } else {
+        atualizarProdutosLinhaStatus('', false);
+      }
+
+      atualizarProdutosLinhaMeta();
+      renderProdutosLinhaTabela();
+    },
+    (err) => {
+      console.error('Erro ao carregar itens importados:', err);
+      produtosLinhaItens = [];
+      atualizarProdutosLinhaStatus(
+        'Não foi possível carregar os itens importados.',
+        true,
+      );
+      atualizarProdutosLinhaMeta();
+      renderProdutosLinhaTabela();
+    },
+  );
+}
+
 function enviarMensagem(event) {
   event.preventDefault();
   if (!currentUser) return;
@@ -2416,6 +3546,15 @@ modalDestinatariosEl?.addEventListener('click', (event) => {
     fecharModalDestinatariosMensagem();
   }
 });
+produtosLinhaConfigFormEl?.addEventListener(
+  'submit',
+  salvarConfiguracoesProdutosLinha,
+);
+produtosLinhaTabelaContainerEl?.addEventListener('change', (event) => {
+  const select = event.target.closest('.produtos-linha-prazo-select');
+  if (!select) return;
+  atualizarPrazoProdutoLinha(select.dataset.itemId, select.value);
+});
 destinatariosSelecionarTodosBtn?.addEventListener(
   'click',
   selecionarTodosDestinatariosModal,
@@ -2471,11 +3610,18 @@ onAuthStateChanged(auth, async (user) => {
     atualizarEscopoMensagem();
     setStatus(painelStatusEl, '');
 
+    let usuariosFinanceiros = [];
     try {
-      const { isGestor, isResponsavelFinanceiro } =
-        await carregarUsuariosFinanceiros(db, user);
-      const podeGerirProdutos = isGestor || isResponsavelFinanceiro;
-      if (podeGerirProdutos) {
+      const {
+        usuarios = [],
+        isGestor,
+        isResponsavelFinanceiro,
+      } = await carregarUsuariosFinanceiros(db, user);
+      usuariosFinanceiros = Array.isArray(usuarios) ? usuarios : [];
+      isGestorAtual = Boolean(isGestor);
+      isResponsavelFinanceiroAtual = Boolean(isResponsavelFinanceiro);
+      produtosLinhaPodeGerir = isGestorAtual || isResponsavelFinanceiroAtual;
+      if (produtosLinhaPodeGerir) {
         formProduto?.classList.remove('hidden');
         produtosAvisoEl?.classList.add('hidden');
       } else {
@@ -2486,8 +3632,13 @@ onAuthStateChanged(auth, async (user) => {
       console.error('Erro ao verificar permissões financeiras:', err);
       formProduto?.classList.add('hidden');
       produtosAvisoEl?.classList.remove('hidden');
+      isGestorAtual = false;
+      isResponsavelFinanceiroAtual = false;
+      produtosLinhaPodeGerir = false;
+      usuariosFinanceiros = [];
     }
 
+    await inicializarProdutosLinha(usuariosFinanceiros);
     carregarMensagens();
     carregarProblemas();
     carregarReunioes();
@@ -2502,6 +3653,10 @@ onAuthStateChanged(auth, async (user) => {
     participantesCompartilhamento = currentUser?.uid ? [currentUser.uid] : [];
     await carregarDetalhesParticipantes(participantesCompartilhamento);
     atualizarEscopoMensagem();
+    produtosLinhaPodeGerir = false;
+    isGestorAtual = false;
+    isResponsavelFinanceiroAtual = false;
+    await inicializarProdutosLinha([]);
     carregarReunioes();
   }
 });


### PR DESCRIPTION
## Resumo
- adiciona a aba Produtos em linha no painel com tabela de SKU, produto, preço, prazo e última atualização
- implementa carregamento em tempo real dos itens importados e configuração de acesso por responsável financeiro
- atualiza a preparação do painel para inicializar a nova aba conforme as permissões do usuário

## Testes
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c9fb230fa0832aa25a02951345f392