### PR TITLE
Destacar cartões de etiquetas impressas com fundo verde

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -614,13 +614,43 @@
   border-color: rgba(234, 179, 8, 0.4);
 }
 
-.expedicao-pdf-card--printed {
-  background: #dcfce7;
-  border-color: rgba(34, 197, 94, 0.45);
+.expedicao-pdf-card--printed,
+.expedicao-pdf-card--done {
+  background: #16a34a;
+  border-color: #15803d;
+  color: var(--white);
 }
 
-.expedicao-pdf-card--done {
-  background: var(--white);
+.expedicao-pdf-card--printed .expedicao-pdf-header,
+.expedicao-pdf-card--done .expedicao-pdf-header,
+.expedicao-pdf-card--printed .expedicao-pdf-name,
+.expedicao-pdf-card--done .expedicao-pdf-name {
+  color: var(--white);
+}
+
+.expedicao-pdf-card--printed .expedicao-pdf-date,
+.expedicao-pdf-card--done .expedicao-pdf-date,
+.expedicao-pdf-card--printed .expedicao-pdf-quantity,
+.expedicao-pdf-card--done .expedicao-pdf-quantity {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.expedicao-pdf-card--printed .expedicao-pdf-icon,
+.expedicao-pdf-card--done .expedicao-pdf-icon {
+  background: rgba(255, 255, 255, 0.2);
+  color: var(--white);
+}
+
+.expedicao-pdf-card--printed .expedicao-card-btn,
+.expedicao-pdf-card--done .expedicao-card-btn {
+  border-color: rgba(255, 255, 255, 0.65);
+  color: var(--white);
+}
+
+.expedicao-pdf-card--printed .expedicao-card-btn:hover,
+.expedicao-pdf-card--done .expedicao-card-btn:hover {
+  background: rgba(255, 255, 255, 0.18);
+  color: var(--white);
 }
 
 @media (min-width: 768px) {

--- a/expedicao.html
+++ b/expedicao.html
@@ -174,6 +174,19 @@
     const equipeUsuarios = new Map();
     let checklistRows = [];
 
+    const CARD_STATUS_CLASS_MAP = {
+      nao_impresso: 'expedicao-pdf-card--pending',
+      impresso: 'expedicao-pdf-card--printed',
+      concluido: 'expedicao-pdf-card--done'
+    };
+    const CARD_STATUS_CLASSES = Object.values(CARD_STATUS_CLASS_MAP);
+
+    function applyPdfCardStatus(card, status) {
+      if (!card) return;
+      card.classList.remove(...CARD_STATUS_CLASSES);
+      card.classList.add(CARD_STATUS_CLASS_MAP[status] || CARD_STATUS_CLASS_MAP.nao_impresso);
+    }
+
     function getResumoTimeWindow() {
       const now = new Date();
       const end = new Date(now);
@@ -1458,8 +1471,7 @@
       }
       await db.collection('pdfDocs').doc(id).update({ status: checked ? 'impresso' : 'nao_impresso' });
       if (card) {
-        card.classList.remove('expedicao-pdf-card--pending', 'expedicao-pdf-card--printed', 'expedicao-pdf-card--done');
-        card.classList.add(checked ? 'expedicao-pdf-card--printed' : 'expedicao-pdf-card--pending');
+        applyPdfCardStatus(card, checked ? 'impresso' : 'nao_impresso');
         card.dataset.status = checked ? 'impresso' : 'nao_impresso';
       }
       showToast('Status atualizado');
@@ -1525,7 +1537,10 @@
       }
 
       showToast('Status atualizado');
-      if (card) card.dataset.status = newStatus;
+      if (card) {
+        applyPdfCardStatus(card, newStatus);
+        card.dataset.status = newStatus;
+      }
       if (newStatus === 'impresso' && previousStatus !== 'impresso') {
         await notifyEtiquetaStatusChange({ id, newStatus: 'impresso', card });
       }
@@ -1546,10 +1561,13 @@
         badge.textContent = statusInfo[newStatus].text;
         badge.className = `status-badge text-xs text-white px-2 py-0.5 rounded-full ${statusInfo[newStatus].color}`;
       }
+      if (card) {
+        applyPdfCardStatus(card, newStatus);
+        card.dataset.status = newStatus;
+      }
       if (newStatus === 'concluido' && currentFilter === 'all') {
         card.remove();
       }
-      if (card) card.dataset.status = newStatus;
       showToast('Status atualizado');
       if (['impresso', 'concluido'].includes(newStatus) && previousStatus !== newStatus) {
         await notifyEtiquetaStatusChange({ id, newStatus, card });


### PR DESCRIPTION
## Summary
- pinta os cartões de etiquetas com status impresso ou concluído com fundo verde e ajustes de contraste
- centraliza a atualização das classes visuais ao mudar o status das etiquetas

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc0c754338832ab6d9288f7bce7f55