### PR TITLE
Add modal progress feedback to faturamento mass import

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -1920,15 +1920,83 @@ await db
             progressText.textContent = '0%';
           }
 
+          const modalElements = {
+            container: document.getElementById('faturamentoMassaModal'),
+            progressBar: document.getElementById('faturamentoMassaModalProgressBar'),
+            progressText: document.getElementById('faturamentoMassaModalProgressText'),
+            instruction: document.getElementById('faturamentoMassaModalMessage'),
+            status: document.getElementById('faturamentoMassaModalStatus'),
+            close: document.getElementById('faturamentoMassaClose')
+          };
+
+          const hideMassaModal = () => {
+            if (modalElements.container) {
+              modalElements.container.style.display = 'none';
+              modalElements.container.classList.add('hidden');
+            }
+          };
+
+          const applyProgress = (pct) => {
+            const safePct = Number.isFinite(pct) ? Math.min(Math.max(pct, 0), 100) : 0;
+            if (progressBar) progressBar.style.width = safePct + '%';
+            if (progressText) progressText.textContent = safePct + '%';
+            if (modalElements.progressBar) modalElements.progressBar.style.width = safePct + '%';
+            if (modalElements.progressText) modalElements.progressText.textContent = safePct + '%';
+          };
+
+          const prepareMassaModal = () => {
+            if (modalElements.container) {
+              modalElements.container.style.display = 'block';
+              modalElements.container.classList.remove('hidden');
+            }
+            if (modalElements.instruction) {
+              modalElements.instruction.textContent = 'Não feche esta janela até finalizar.';
+              modalElements.instruction.classList.remove('text-green-600', 'text-red-600', 'font-semibold');
+              modalElements.instruction.classList.add('text-gray-600');
+            }
+            if (modalElements.status) {
+              modalElements.status.textContent = '';
+              modalElements.status.classList.add('hidden');
+              modalElements.status.classList.remove('bg-green-100', 'text-green-700', 'bg-red-100', 'text-red-700');
+            }
+            if (modalElements.close) {
+              modalElements.close.classList.add('hidden');
+              modalElements.close.disabled = true;
+              modalElements.close.setAttribute('aria-disabled', 'true');
+              modalElements.close.onclick = hideMassaModal;
+            }
+            applyProgress(0);
+          };
+
+          const finalizeMassaModal = (success, message) => {
+            if (modalElements.instruction) {
+              modalElements.instruction.classList.remove('text-gray-600', 'text-green-600', 'text-red-600', 'font-semibold');
+              modalElements.instruction.classList.add(success ? 'text-green-600' : 'text-red-600', 'font-semibold');
+              modalElements.instruction.textContent = success
+                ? 'Processamento finalizado. Você já pode fechar esta janela.'
+                : 'Não foi possível concluir o processamento.';
+            }
+            if (modalElements.status) {
+              modalElements.status.classList.remove('hidden', 'bg-green-100', 'text-green-700', 'bg-red-100', 'text-red-700');
+              modalElements.status.classList.add(success ? 'bg-green-100' : 'bg-red-100', success ? 'text-green-700' : 'text-red-700');
+              modalElements.status.textContent = message;
+            }
+            if (modalElements.close) {
+              modalElements.close.classList.remove('hidden');
+              modalElements.close.disabled = false;
+              modalElements.close.removeAttribute('aria-disabled');
+              modalElements.close.focus();
+            }
+          };
+
+          prepareMassaModal();
+
           const totalRows = rows.length;
           let processedRows = 0;
           const updateProgress = async () => {
-            if (progressBar && progressText) {
-              const pct = Math.round((processedRows / totalRows) * 100);
-              progressBar.style.width = pct + '%';
-              progressText.textContent = pct + '%';
-              if (processedRows % 50 === 0) await new Promise(r => setTimeout(r, 0));
-            }
+            const pct = Math.round((processedRows / totalRows) * 100);
+            applyProgress(pct);
+            if (processedRows % 50 === 0) await new Promise(r => setTimeout(r, 0));
           };
 
           const grupos = {};
@@ -2033,6 +2101,7 @@ await db
 
           if (!Object.keys(grupos).length) {
             mostrarErro('Nenhum registro com data de pagamento foi encontrado.');
+            finalizeMassaModal(false, 'Nenhum registro com data de pagamento foi encontrado na planilha.');
             return;
           }
 
@@ -2355,11 +2424,6 @@ await db
             await notificarResponsavelFinanceiro(dataReferencia, loja, grupo.bruto, liquido, grupo.qtdVendas);
           }
 
-          if (progressBar && progressText) {
-            progressBar.style.width = '100%';
-            progressText.textContent = '100%';
-          }
-
           const sucesso = resultados.filter(r => r.status === 'ok');
           const ignorados = resultados.filter(r => r.status === 'ignorado');
 
@@ -2386,8 +2450,20 @@ await db
           }
 
           document.getElementById('resultadoFaturamento').innerHTML = html || '<div class="alert alert-info"><i class="fas fa-info-circle"></i> Nenhum faturamento foi processado.</div>';
+          applyProgress(100);
+          let mensagemFinal = '';
+          if (sucesso.length) {
+            mensagemFinal = `Foram processados ${sucesso.length} dia(s) com sucesso.`;
+          } else {
+            mensagemFinal = 'Processamento concluído, mas nenhum faturamento novo foi registrado.';
+          }
+          if (ignorados.length || rowsSemData.length) {
+            mensagemFinal += ' Verifique os avisos exibidos abaixo para mais detalhes.';
+          }
+          finalizeMassaModal(true, mensagemFinal.trim());
           input.value = '';
         } catch (err) {
+          finalizeMassaModal(false, 'Erro ao importar: ' + err.message);
           mostrarErro('Erro ao importar: ' + err.message);
           console.error(err);
         }

--- a/sobras-tabs/faturamento.html
+++ b/sobras-tabs/faturamento.html
@@ -78,3 +78,24 @@ exporte <strong>um único dia</strong> por vez. Ao importar o arquivo,
     </div>
   </div>
 </div>
+
+<div id="faturamentoMassaModal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="faturamentoMassaModalTitulo">
+  <div class="modal-content">
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <h3 id="faturamentoMassaModalTitulo" class="text-lg font-semibold text-gray-800">Processando faturamento em massa</h3>
+        <p id="faturamentoMassaModalMessage" class="mt-2 text-sm text-gray-600">Não feche esta janela até finalizar.</p>
+      </div>
+      <button id="faturamentoMassaClose" type="button" class="btn-close hidden" aria-label="Fechar">
+        &times;
+      </button>
+    </div>
+    <div class="mt-6 space-y-4">
+      <div class="progress">
+        <div id="faturamentoMassaModalProgressBar" class="progress-bar"></div>
+      </div>
+      <span id="faturamentoMassaModalProgressText" class="block text-sm text-gray-600 text-center">0%</span>
+      <div id="faturamentoMassaModalStatus" class="hidden rounded-lg px-4 py-3 text-sm font-medium"></div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add a dedicated modal overlay with progress bar and status messaging for processamento em massa de faturamento
- update the faturamento mass-import workflow to drive the modal, sync progress, and show success or error guidance at completion

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68d12d588a34832a9a2e1576970d917e