### PR TITLE
Add progress modal for mass faturamento import

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -1914,21 +1914,60 @@ await db
           const progressContainer = document.getElementById('progressContainer');
           const progressBar = document.getElementById('faturamentoProgressBar');
           const progressText = document.getElementById('faturamentoProgressText');
-          if (progressContainer && progressBar && progressText) {
-            progressContainer.classList.remove('hidden');
-            progressBar.style.width = '0%';
-            progressText.textContent = '0%';
-          }
+          const massaModal = document.getElementById('massaFaturamentoModal');
+          const massaStatus = document.getElementById('massaFaturamentoStatus');
+          const massaCloseBtn = document.getElementById('massaModalClose');
+          const massaProgressBar = document.getElementById('massaProgressBar');
+          const massaProgressText = document.getElementById('massaProgressText');
+
+          const atualizarStatusModal = (mensagem, classe) => {
+            if (!massaStatus) return;
+            massaStatus.textContent = mensagem;
+            massaStatus.classList.remove('text-blue-600', 'text-green-600', 'text-red-600');
+            if (classe) massaStatus.classList.add(classe);
+          };
+
+          const progressTargets = [
+            {
+              bar: progressBar,
+              text: progressText,
+              onShow: () => {
+                if (progressContainer) progressContainer.classList.remove('hidden');
+              }
+            },
+            {
+              bar: massaProgressBar,
+              text: massaProgressText,
+              onShow: () => {
+                if (massaModal) massaModal.style.display = 'block';
+                atualizarStatusModal('Processando planilha. Não feche esta janela até finalizar.', 'text-blue-600');
+                if (massaCloseBtn) {
+                  massaCloseBtn.classList.add('hidden');
+                  massaCloseBtn.disabled = false;
+                }
+              }
+            }
+          ];
+
+          progressTargets.forEach(({ bar, text, onShow }) => {
+            if (typeof onShow === 'function') onShow();
+            if (bar) bar.style.width = '0%';
+            if (text) text.textContent = '0%';
+          });
+
+          const setProgress = (pct) => {
+            progressTargets.forEach(({ bar, text }) => {
+              if (bar) bar.style.width = pct + '%';
+              if (text) text.textContent = pct + '%';
+            });
+          };
 
           const totalRows = rows.length;
           let processedRows = 0;
           const updateProgress = async () => {
-            if (progressBar && progressText) {
-              const pct = Math.round((processedRows / totalRows) * 100);
-              progressBar.style.width = pct + '%';
-              progressText.textContent = pct + '%';
-              if (processedRows % 50 === 0) await new Promise(r => setTimeout(r, 0));
-            }
+            const pct = totalRows ? Math.round((processedRows / totalRows) * 100) : 0;
+            setProgress(pct);
+            if (processedRows % 50 === 0) await new Promise(r => setTimeout(r, 0));
           };
 
           const grupos = {};
@@ -2033,6 +2072,8 @@ await db
 
           if (!Object.keys(grupos).length) {
             mostrarErro('Nenhum registro com data de pagamento foi encontrado.');
+            atualizarStatusModal('Nenhum registro com data de pagamento foi encontrado.', 'text-red-600');
+            if (massaCloseBtn) massaCloseBtn.classList.remove('hidden');
             return;
           }
 
@@ -2355,10 +2396,9 @@ await db
             await notificarResponsavelFinanceiro(dataReferencia, loja, grupo.bruto, liquido, grupo.qtdVendas);
           }
 
-          if (progressBar && progressText) {
-            progressBar.style.width = '100%';
-            progressText.textContent = '100%';
-          }
+          setProgress(100);
+          atualizarStatusModal('Processamento concluído com sucesso!', 'text-green-600');
+          if (massaCloseBtn) massaCloseBtn.classList.remove('hidden');
 
           const sucesso = resultados.filter(r => r.status === 'ok');
           const ignorados = resultados.filter(r => r.status === 'ignorado');
@@ -2390,6 +2430,8 @@ await db
         } catch (err) {
           mostrarErro('Erro ao importar: ' + err.message);
           console.error(err);
+          atualizarStatusModal('Ocorreu um erro durante o processamento.', 'text-red-600');
+          if (massaCloseBtn) massaCloseBtn.classList.remove('hidden');
         }
       };
 
@@ -3738,6 +3780,13 @@ function aplicarEstiloCritico() {
     const card = document.getElementById('infoFaturamento');
     if (card) {
       card.classList.toggle('hidden');
+    }
+  };
+
+  window.fecharFaturamentoMassaModal = function() {
+    const modal = document.getElementById('massaFaturamentoModal');
+    if (modal) {
+      modal.style.display = 'none';
     }
   };
 

--- a/sobras-tabs/faturamento.html
+++ b/sobras-tabs/faturamento.html
@@ -17,6 +17,31 @@ exporte <strong>um único dia</strong> por vez. Ao importar o arquivo,
     <img src="../images/faturamento-exportar-pedidos.png" alt="Passos para exportar pedidos na Shopee" class="my-4">
 </div>
 
+<div id="massaFaturamentoModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="massaFaturamentoTitulo">
+  <div class="modal-content max-w-lg text-center">
+    <h3 id="massaFaturamentoTitulo" class="text-xl font-semibold text-gray-800">
+      Processando importação em massa
+    </h3>
+    <p id="massaFaturamentoStatus" class="mt-3 text-sm font-medium text-blue-600">
+      Processando planilha. Não feche esta janela até finalizar.
+    </p>
+    <div class="mt-5">
+      <div class="progress">
+        <div id="massaProgressBar" class="progress-bar"></div>
+      </div>
+      <span id="massaProgressText" class="block text-sm text-gray-600 mt-2">0%</span>
+    </div>
+    <button
+      id="massaModalClose"
+      type="button"
+      class="btn-secondary mt-6 hidden"
+      onclick="fecharFaturamentoMassaModal()"
+    >
+      Fechar
+    </button>
+  </div>
+</div>
+
 <div class="grid gap-6 md:grid-cols-3">
   <div class="md:col-span-2 space-y-6">
       <div class="card">


### PR DESCRIPTION
## Summary
- add a dedicated modal with progress indicator for the faturamento importação em massa workflow
- synchronize progress updates across the sidebar widget and new modal while guiding the user not to close the window
- show a green success message at completion and expose a close button, with error messaging when processing fails

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d133fd9a80832a885882f4654b6ab5