### PR TITLE
Add download button to expedition label cards

### DIFF
--- a/expedicao.html
+++ b/expedicao.html
@@ -1311,6 +1311,7 @@
         </div>
         <div class="expedicao-pdf-actions">
           <button class="expedicao-card-btn" onclick="visualizar('${url}')">Abrir</button>
+          <a class="expedicao-card-btn" href="${url}" download="${(name || 'etiqueta.pdf').replace(/[^\w\d\s._-]/g, '_')}">Baixar</a>
           <button class="expedicao-card-btn expedicao-card-btn--danger" onclick="excluirEtiqueta('${doc.id}', this.closest('.pdf-card'))">Excluir</button>
         </div>`;
       div.dataset.ownerUid = data.ownerUid || '';


### PR DESCRIPTION
## Summary
- add a download control to expedition label cards so users can save etiqueta PDFs directly alongside the existing open and delete actions.

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d137c15d28832a8ed7ef240309b8c6