### PR TITLE
Adicionar atalho de pedidos reais ao menu financeiro

### DIFF
--- a/login.js
+++ b/login.js
@@ -500,6 +500,7 @@ function applyPerfilRestrictions(perfil) {
       'menu-painel-atualizacoes-mentorados',
       'menu-saques',
       'menu-produtos-precos',
+      'menu-pedidos-reais',
       'menu-acompanhamento-gestor',
       'menu-mentoria',
       'menu-perfil-mentorado',

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -211,6 +211,30 @@
     </li>
     <li>
       <a
+        href="/expedicao-pedidosreais.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-pedidos-reais"
+        data-perfil="gestor,responsavel financeiro"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M2.25 3h1.386a1.125 1.125 0 0 1 1.088.836l.383 1.53M7.5 16.5a1.5 1.5 0 1 0 3 0m-3 0a1.5 1.5 0 1 0 3 0m-3 0h3m3-3h2.386a1.125 1.125 0 0 0 1.088-.836l1.5-6a1.125 1.125 0 0 0-1.088-1.414H5.107m0 0L4.107 4.5m1 2.25h13.5"
+          />
+        </svg>
+        <span class="link-text">Pedidos Reais</span>
+      </a>
+    </li>
+    <li>
+      <a
         href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamentoGestor"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-acompanhamento-gestor"

--- a/shared.js
+++ b/shared.js
@@ -633,6 +633,7 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-comunicacao',
     'menu-saques',
     'menu-produtos-precos',
+    'menu-pedidos-reais',
     'menu-acompanhamento-gestor',
     'menu-mentoria',
     'menu-perfil-mentorado',
@@ -697,6 +698,7 @@ document.addEventListener('sidebarLoaded', async () => {
     const financeiro = getLi('menu-financeiro');
     const saques = getLi('menu-saques');
     const produtosPrecos = getLi('menu-produtos-precos');
+    const pedidosReais = getLi('menu-pedidos-reais');
     const gestao = getLi('menu-gestao');
     const acompGestor = getLi('menu-acompanhamento-gestor');
     const mentoria = getLi('menu-mentoria');
@@ -743,6 +745,7 @@ document.addEventListener('sidebarLoaded', async () => {
     const financeiroGroup = createGroup(financeiro, 'menuFinanceiro', [
       saques,
       produtosPrecos,
+      pedidosReais,
     ]);
     const gestaoGroup = createGroup(gestao, 'menuGestao', [
       acompGestor,


### PR DESCRIPTION
## Summary
- adicionar item "Pedidos Reais" ao grupo financeiro da barra lateral para gestores e responsáveis financeiros
- ajustar a composição dinâmica do menu para incluir o novo atalho junto com Saques e Produtos/Preços
- garantir que o controle de permissões permita que perfis de gestão vejam o novo item

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1475b6f88832a9c3b7941e5ca862c