### PR TITLE
Exibir todos os pedidos reais por padrao

### DIFF
--- a/expedicao-pedidosreais.html
+++ b/expedicao-pedidosreais.html
@@ -292,11 +292,9 @@
         const dataPedido = parseDate(p.data);
 
         if (!anyFilter) {
-          const doisDiasAtras = new Date();
-          doisDiasAtras.setDate(doisDiasAtras.getDate() - 2);
-          const recente = dataPedido && dataPedido >= doisDiasAtras;
-          const aEnviar = (p.status || '').toLowerCase() === 'a enviar';
-          return recente || aEnviar;
+          // Sem filtros ativos exibimos toda a lista ordenada, evitando que pedidos antigos
+          // desapareçam quando não há registros recentes ou "a enviar".
+          return true;
         }
 
         if (dataStart && (!dataPedido || dataPedido < dataStart)) return false;


### PR DESCRIPTION
## Summary
- remove the automatic 2-day filter when no search criteria are selected so every pedido real is listed by default
- document the default behavior change to avoid hiding pedidos antigos when there are no registros recentes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d14a6b355c832a8f881f5002e6f7a2