### PR TITLE
Ensure Mercado Livre sales tab stores real order summaries

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -1852,6 +1852,34 @@ document.getElementById("dadosSobrasIA").value = sobras.map(s => {
               ? { inicio: resumoPorDia[0].data, fim: resumoPorDia[resumoPorDia.length - 1].data }
               : { inicio: dataReferencia, fim: dataReferencia };
 
+          const resumoPedidos = {
+            data: dataReferencia,
+            loja,
+            plataforma: 'Mercado Livre',
+            atualizadoEm:
+              typeof firebase !== 'undefined' && firebase.firestore?.FieldValue?.serverTimestamp
+                ? firebase.firestore.FieldValue.serverTimestamp()
+                : new Date().toISOString(),
+            totalLinhas: totalRows,
+            totalPedidosAtivos: qtdVendas,
+            valorBruto: bruto,
+            valorLiquido: liquidoTotal,
+            taxas
+          };
+          await pedidosRef.doc(dataReferencia).set({ ...resumoPedidos, uid: usuarioLogado.uid }, { merge: true });
+          if (baseResp && respEmail) {
+            await baseResp
+              .collection('pedidosreais')
+              .doc(dataReferencia)
+              .set({ ...resumoPedidos, uid: usuarioLogado.uid }, { merge: true });
+          }
+          if (baseExp && gestorEmail) {
+            await baseExp
+              .collection('pedidosreais')
+              .doc(dataReferencia)
+              .set({ ...resumoPedidos, uid: usuarioLogado.uid }, { merge: true });
+          }
+
           const refSku = db
             .collection('uid')
             .doc(usuarioLogado.uid)


### PR DESCRIPTION
## Summary
- create or update a resumo document in `pedidosreais` when importing Mercado Livre sales
- sync the resumo metadata for linked responsible and gestor users to mirror the main account

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d155723ee0832ab02c7f283cecde91