### PR TITLE
Restringe aba Produtos Vendidos a perfis de gestão

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -99,7 +99,11 @@
       </div>
 
       <!-- Aba de Produtos Vendidos (Gestores/Responsáveis Financeiros) -->
-      <div id="produtosVendidos" class="tab-content">
+      <div
+        id="produtosVendidos"
+        class="tab-content"
+        data-perfil="gestor,responsavel,gestor financeiro,responsavel financeiro"
+      >
 
       </div>
 
@@ -539,20 +543,70 @@ function escapeHtml(value) {
     // FUNÇÕES DE NAVEGAÇÃO E INTERFACE
     // =============================================
     
-    window.trocarAba = function trocarAba(id) {
-        // Remove a classe 'active' de todas as abas
-        document.querySelectorAll('.tab-content').forEach(aba => aba.classList.remove('active'));
+    function podeAcessarProdutosVendidos() {
+      const perfilRaw = (window.userPerfil || usuarioLogado.perfil || '')
+        .toString()
+        .toLowerCase();
+      const perfilNormalizado = perfilRaw
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .trim();
+      const perfisPermitidos = new Set([
+        'gestor',
+        'responsavel',
+        'gestor financeiro',
+        'responsavel financeiro',
+        'adm',
+        'admin',
+        'administrador',
+      ]);
+      return (
+        perfisPermitidos.has(perfilNormalizado) ||
+        window.isFinanceiroResponsavel === true
+      );
+    }
 
-        // Ativa a aba correspondente, se existir
-        const abaSelecionada = document.getElementById(id);
-        if (abaSelecionada) {
-          abaSelecionada.classList.add('active');
+    function verificarPermissaoAba(id) {
+      if (id !== 'produtosVendidos') {
+        return true;
+      }
+      const autorizado = podeAcessarProdutosVendidos();
+      if (!autorizado) {
+        if (window.Swal) {
+          Swal.fire(
+            'Acesso restrito',
+            'Esta aba está disponível apenas para gestores ou responsáveis financeiros.',
+            'warning',
+          );
         } else {
-          console.warn(`❌ Aba com ID '${id}' não encontrada.`);
-          return;
+          alert(
+            'A aba Produtos Vendidos está disponível apenas para gestores ou responsáveis financeiros.',
+          );
         }
+      }
+      return autorizado;
+    }
 
-        // Atualiza gráficos, se necessário
+    window.trocarAba = function trocarAba(id) {
+      if (!verificarPermissaoAba(id)) {
+        return;
+      }
+
+      // Remove a classe 'active' de todas as abas
+      document
+        .querySelectorAll('.tab-content')
+        .forEach((aba) => aba.classList.remove('active'));
+
+      // Ativa a aba correspondente, se existir
+      const abaSelecionada = document.getElementById(id);
+      if (abaSelecionada) {
+        abaSelecionada.classList.add('active');
+      } else {
+        console.warn(`❌ Aba com ID '${id}' não encontrada.`);
+        return;
+      }
+
+      // Atualiza gráficos, se necessário
       if (id === 'graficos') {
         setTimeout(atualizarGraficos, 100);
       }
@@ -560,7 +614,7 @@ function escapeHtml(value) {
         if (!produtosVendidosCarregado) carregarProdutosVendidos();
         else renderProdutosVendidos();
       }
-        };
+    };
 
 
     // =============================================

--- a/login.js
+++ b/login.js
@@ -506,6 +506,7 @@ function applyPerfilRestrictions(perfil) {
       'menu-perfil-mentorado',
       'menu-equipes',
       'menu-produtos',
+      'menu-produtos-vendidos',
       'menu-sku-associado',
       'menu-desempenho',
     ],

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -358,6 +358,30 @@
     </li>
     <li>
       <a
+        href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=produtosVendidos"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-produtos-vendidos"
+        data-perfil="gestor,responsavel,gestor financeiro,responsavel financeiro"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M21 7.5 12 2.25 3 7.5v9l9 5.25 9-5.25v-9Zm-9 3L3 7.5m9 3 9-3m-9 3V21"
+          />
+        </svg>
+        <span class="link-text">Produtos Vendidos</span>
+      </a>
+    </li>
+    <li>
+      <a
         href="/sku-associado.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-sku-associado"
@@ -478,13 +502,6 @@
             href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=controleVendas"
             class="sidebar-link block py-2 px-4 transition-colors"
             >Acompanhamento Vendas</a
-          >
-        </li>
-        <li>
-          <a
-            href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=produtosVendidos"
-            class="sidebar-link block py-2 px-4 transition-colors"
-            >Produtos Vendidos</a
           >
         </li>
         <li>

--- a/shared.js
+++ b/shared.js
@@ -639,6 +639,7 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-perfil-mentorado',
     'menu-equipes',
     'menu-produtos',
+    'menu-produtos-vendidos',
     'menu-sku-associado',
     'menu-desempenho',
   ];
@@ -704,6 +705,7 @@ document.addEventListener('sidebarLoaded', async () => {
     const mentoria = getLi('menu-mentoria');
     const perfilMentorado = getLi('menu-perfil-mentorado');
     const produtos = getLi('menu-produtos');
+    const produtosVendidos = getLi('menu-produtos-vendidos');
     const skuAssociado = getLi('menu-sku-associado');
     const comunicacao = getLi('menu-comunicacao');
     const equipes = getLi('menu-equipes');
@@ -752,6 +754,7 @@ document.addEventListener('sidebarLoaded', async () => {
       mentoria,
       perfilMentorado,
       produtos,
+      produtosVendidos,
       skuAssociado,
     ]);
     const comunicacaoGroup = createGroup(comunicacao, 'menuComunicacao', [


### PR DESCRIPTION
## Resumo
- move o atalho de Produtos Vendidos para o grupo de Gestão na sidebar
- garante que apenas gestores ou responsáveis financeiros visualizem o menu e a aba de Produtos Vendidos
- adiciona validação de permissão ao trocar para a aba de Produtos Vendidos

## Testes
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d190a14dec832ab45629cacdf2f8fd