### PR TITLE
Adicionar aba de acompanhamento de problemas para gestores

### DIFF
--- a/acompanhamento-problemas.html
+++ b/acompanhamento-problemas.html
@@ -1,0 +1,347 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Acompanhamento de Problemas</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="css/styles.css?v=20240826" />
+  </head>
+  <body class="bg-gray-100 text-gray-800">
+    <div class="app-container">
+      <div id="sidebar-container"></div>
+      <div id="navbar-container"></div>
+
+      <main class="main-content p-4 space-y-6">
+        <header class="space-y-2">
+          <h1 class="text-2xl font-bold flex items-center gap-2">
+            <span>🛟</span>
+            Acompanhamento de Problemas
+          </h1>
+          <p class="text-sm text-gray-600" id="infoUsuarios">
+            Carregando informações dos usuários vinculados...
+          </p>
+        </header>
+
+        <section class="card">
+          <div
+            class="card-body grid gap-4 md:grid-cols-2 lg:grid-cols-4 items-end"
+          >
+            <div class="space-y-2">
+              <label
+                for="filtroUsuario"
+                class="block text-sm font-medium text-gray-700"
+                >Selecionar usuário</label
+              >
+              <select id="filtroUsuario" class="form-control">
+                <option value="">Todos os usuários conectados</option>
+              </select>
+            </div>
+            <div class="space-y-2 lg:col-span-2">
+              <label class="block text-sm font-medium text-gray-700"
+                >Resumo</label
+              >
+              <p class="text-sm text-gray-500" id="resumoUsuarios">
+                Aguarde enquanto buscamos os dados registrados na aba de
+                Problemas.
+              </p>
+            </div>
+            <div class="lg:justify-self-end">
+              <span
+                id="globalStatus"
+                class="text-xs text-gray-500 px-3 py-1 rounded-full bg-gray-100"
+                >Sincronizando dados...</span
+              >
+            </div>
+          </div>
+        </section>
+
+        <nav class="border-b border-gray-200 flex flex-wrap gap-2 text-sm">
+          <button
+            class="tab-btn pb-2 -mb-px border-b-2 border-indigo-600 text-indigo-600 font-medium"
+            data-tab="tab-pecas"
+          >
+            Peças faltantes
+          </button>
+          <button
+            class="tab-btn pb-2 -mb-px border-b-2 border-transparent text-gray-500 hover:text-gray-700"
+            data-tab="tab-reembolsos"
+          >
+            Reembolsos
+          </button>
+        </nav>
+
+        <section id="tab-pecas" class="tab-panel space-y-6">
+          <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+            <div
+              class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
+            >
+              <p class="text-xs uppercase text-gray-500">Total de registros</p>
+              <p class="text-2xl font-semibold" id="pecasResumoTotal">0</p>
+            </div>
+            <div
+              class="bg-white border border-amber-200 rounded-lg p-4 shadow-sm"
+            >
+              <p class="text-xs uppercase text-amber-600">Não feito</p>
+              <p
+                class="text-2xl font-semibold text-amber-600"
+                id="pecasResumoNaoFeito"
+              >
+                0
+              </p>
+            </div>
+            <div
+              class="bg-white border border-blue-200 rounded-lg p-4 shadow-sm"
+            >
+              <p class="text-xs uppercase text-blue-600">Em andamento</p>
+              <p
+                class="text-2xl font-semibold text-blue-600"
+                id="pecasResumoEmAndamento"
+              >
+                0
+              </p>
+            </div>
+            <div
+              class="bg-white border border-emerald-200 rounded-lg p-4 shadow-sm"
+            >
+              <p class="text-xs uppercase text-emerald-600">Resolvidos</p>
+              <p
+                class="text-2xl font-semibold text-emerald-600"
+                id="pecasResumoResolvido"
+              >
+                0
+              </p>
+            </div>
+            <div
+              class="bg-white border border-indigo-200 rounded-lg p-4 shadow-sm"
+            >
+              <p class="text-xs uppercase text-indigo-600">Valor gasto</p>
+              <p
+                class="text-2xl font-semibold text-indigo-600"
+                id="pecasResumoValor"
+              >
+                R$ 0,00
+              </p>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card-body grid gap-4 md:grid-cols-5">
+              <div class="space-y-2">
+                <label
+                  for="pecasInicio"
+                  class="text-sm font-medium text-gray-700"
+                  >Início</label
+                >
+                <input type="date" id="pecasInicio" class="form-control" />
+              </div>
+              <div class="space-y-2">
+                <label for="pecasFim" class="text-sm font-medium text-gray-700"
+                  >Fim</label
+                >
+                <input type="date" id="pecasFim" class="form-control" />
+              </div>
+              <div class="space-y-2">
+                <label
+                  for="pecasStatus"
+                  class="text-sm font-medium text-gray-700"
+                  >Status</label
+                >
+                <select id="pecasStatus" class="form-control">
+                  <option value="">Todos</option>
+                  <option value="NÃO FEITO">Não feito</option>
+                  <option value="EM ANDAMENTO">Em andamento</option>
+                  <option value="RESOLVIDO">Resolvido</option>
+                </select>
+              </div>
+              <div class="space-y-2 md:col-span-2">
+                <label
+                  for="pecasBusca"
+                  class="text-sm font-medium text-gray-700"
+                  >Busca</label
+                >
+                <input
+                  type="text"
+                  id="pecasBusca"
+                  class="form-control"
+                  placeholder="Número, peça, loja ou responsável"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div class="card">
+            <div
+              class="card-header flex flex-wrap items-center justify-between gap-2 border-b border-gray-100 px-6 py-4"
+            >
+              <h2 class="text-lg font-semibold">Peças faltantes registradas</h2>
+              <span id="pecasStatusMsg" class="text-sm text-gray-500"></span>
+            </div>
+            <div class="card-body p-0">
+              <div class="overflow-x-auto">
+                <table class="min-w-full text-sm">
+                  <thead class="bg-gray-50 text-left text-xs font-semibold">
+                    <tr>
+                      <th class="px-4 py-3">Data</th>
+                      <th class="px-4 py-3">Responsável</th>
+                      <th class="px-4 py-3">Cliente</th>
+                      <th class="px-4 py-3">Número</th>
+                      <th class="px-4 py-3">Loja</th>
+                      <th class="px-4 py-3">Peça</th>
+                      <th class="px-4 py-3">Status</th>
+                      <th class="px-4 py-3 text-right">Valor gasto</th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    id="pecasTableBody"
+                    class="divide-y divide-gray-100"
+                  ></tbody>
+                </table>
+              </div>
+              <p
+                id="pecasEmpty"
+                class="text-sm text-gray-500 text-center py-6 hidden"
+              >
+                Nenhum registro encontrado com os filtros selecionados.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section id="tab-reembolsos" class="tab-panel space-y-6 hidden">
+          <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <div
+              class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
+            >
+              <p class="text-xs uppercase text-gray-500">Total de reembolsos</p>
+              <p class="text-2xl font-semibold" id="reembolsosResumoTotal">0</p>
+            </div>
+            <div
+              class="bg-white border border-indigo-200 rounded-lg p-4 shadow-sm"
+            >
+              <p class="text-xs uppercase text-indigo-600">Valor total</p>
+              <p
+                class="text-2xl font-semibold text-indigo-600"
+                id="reembolsosResumoValor"
+              >
+                R$ 0,00
+              </p>
+            </div>
+            <div
+              class="bg-white border border-emerald-200 rounded-lg p-4 shadow-sm"
+            >
+              <p class="text-xs uppercase text-emerald-600">Ticket médio</p>
+              <p
+                class="text-2xl font-semibold text-emerald-600"
+                id="reembolsosResumoMedio"
+              >
+                R$ 0,00
+              </p>
+            </div>
+            <div
+              class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm"
+            >
+              <p class="text-xs uppercase text-gray-500">Último registro</p>
+              <p class="text-2xl font-semibold" id="reembolsosResumoRecente">
+                -
+              </p>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card-body grid gap-4 md:grid-cols-4">
+              <div class="space-y-2">
+                <label
+                  for="reembolsosInicio"
+                  class="text-sm font-medium text-gray-700"
+                  >Início</label
+                >
+                <input type="date" id="reembolsosInicio" class="form-control" />
+              </div>
+              <div class="space-y-2">
+                <label
+                  for="reembolsosFim"
+                  class="text-sm font-medium text-gray-700"
+                  >Fim</label
+                >
+                <input type="date" id="reembolsosFim" class="form-control" />
+              </div>
+              <div class="space-y-2 md:col-span-2">
+                <label
+                  for="reembolsosBusca"
+                  class="text-sm font-medium text-gray-700"
+                  >Busca</label
+                >
+                <input
+                  type="text"
+                  id="reembolsosBusca"
+                  class="form-control"
+                  placeholder="Número, loja ou descrição do problema"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div class="card">
+            <div
+              class="card-header flex flex-wrap items-center justify-between gap-2 border-b border-gray-100 px-6 py-4"
+            >
+              <h2 class="text-lg font-semibold">Reembolsos registrados</h2>
+              <span
+                id="reembolsosStatusMsg"
+                class="text-sm text-gray-500"
+              ></span>
+            </div>
+            <div class="card-body p-0">
+              <div class="overflow-x-auto">
+                <table class="min-w-full text-sm">
+                  <thead class="bg-gray-50 text-left text-xs font-semibold">
+                    <tr>
+                      <th class="px-4 py-3">Data</th>
+                      <th class="px-4 py-3">Responsável</th>
+                      <th class="px-4 py-3">Número</th>
+                      <th class="px-4 py-3">Apelido</th>
+                      <th class="px-4 py-3">NF</th>
+                      <th class="px-4 py-3">Loja</th>
+                      <th class="px-4 py-3">Problema</th>
+                      <th class="px-4 py-3 text-right">Valor</th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    id="reembolsosTableBody"
+                    class="divide-y divide-gray-100"
+                  ></tbody>
+                </table>
+              </div>
+              <p
+                id="reembolsosEmpty"
+                class="text-sm text-gray-500 text-center py-6 hidden"
+              >
+                Nenhum reembolso encontrado com os filtros selecionados.
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+
+    <script type="module" src="firebase-config.js"></script>
+    <script type="module" src="acompanhamento-problemas.js"></script>
+    <script>
+      window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';
+      window.CUSTOM_NAVBAR_PATH = '/partials/navbar.html';
+    </script>
+    <script src="shared.js"></script>
+  </body>
+</html>

--- a/acompanhamento-problemas.js
+++ b/acompanhamento-problemas.js
@@ -1,0 +1,561 @@
+import {
+  initializeApp,
+  getApps,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import {
+  getFirestore,
+  collection,
+  doc,
+  getDocs,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import {
+  getAuth,
+  onAuthStateChanged,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { firebaseConfig } from './firebase-config.js';
+import { carregarUsuariosFinanceiros } from './responsavel-financeiro.js';
+
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+const db = getFirestore(app);
+const auth = getAuth(app);
+
+const filtroUsuarioEl = document.getElementById('filtroUsuario');
+const infoUsuariosEl = document.getElementById('infoUsuarios');
+const resumoUsuariosEl = document.getElementById('resumoUsuarios');
+const globalStatusEl = document.getElementById('globalStatus');
+
+const pecasStatusMsgEl = document.getElementById('pecasStatusMsg');
+const pecasEmptyEl = document.getElementById('pecasEmpty');
+const pecasTabelaBody = document.getElementById('pecasTableBody');
+
+const reembolsosStatusMsgEl = document.getElementById('reembolsosStatusMsg');
+const reembolsosEmptyEl = document.getElementById('reembolsosEmpty');
+const reembolsosTabelaBody = document.getElementById('reembolsosTableBody');
+
+let usuarios = [];
+let pecasCache = [];
+let reembolsosCache = [];
+let usuarioSelecionado = '';
+let currentUser = null;
+
+initTabs();
+registrarEventos();
+
+onAuthStateChanged(auth, async (user) => {
+  if (!user) {
+    window.location.href = 'index.html?login=1';
+    return;
+  }
+  currentUser = user;
+  atualizarStatusGlobal('Carregando usuários vinculados...', false);
+  try {
+    const resposta = await carregarUsuariosFinanceiros(db, user);
+    usuarios = resposta.usuarios || [];
+  } catch (err) {
+    console.error('Erro ao carregar usuários financeiros:', err);
+    usuarios = [
+      {
+        uid: user.uid,
+        nome: user.displayName || user.email || 'Usuário',
+        email: user.email || '',
+      },
+    ];
+  }
+  preencherSelectUsuarios();
+  atualizarMensagensUsuarios();
+  await carregarDados();
+});
+
+function initTabs() {
+  const tabButtons = Array.from(document.querySelectorAll('.tab-btn'));
+  const tabPanels = Array.from(document.querySelectorAll('.tab-panel'));
+  if (!tabButtons.length) return;
+
+  function setActiveTab(targetId) {
+    tabButtons.forEach((btn) => {
+      const isActive = btn.dataset.tab === targetId;
+      btn.classList.toggle('border-indigo-600', isActive);
+      btn.classList.toggle('text-indigo-600', isActive);
+      btn.classList.toggle('font-medium', isActive);
+      btn.classList.toggle('border-transparent', !isActive);
+      btn.classList.toggle('text-gray-500', !isActive);
+    });
+    tabPanels.forEach((panel) => {
+      panel.classList.toggle('hidden', panel.id !== targetId);
+    });
+  }
+
+  tabButtons.forEach((btn) => {
+    btn.addEventListener('click', () => setActiveTab(btn.dataset.tab));
+  });
+
+  const defaultTab = tabButtons[0]?.dataset.tab || 'tab-pecas';
+  setActiveTab(defaultTab);
+}
+
+function registrarEventos() {
+  filtroUsuarioEl?.addEventListener('change', () => {
+    usuarioSelecionado = filtroUsuarioEl.value;
+    renderPecas();
+    renderReembolsos();
+  });
+
+  document
+    .getElementById('pecasInicio')
+    ?.addEventListener('change', renderPecas);
+  document.getElementById('pecasFim')?.addEventListener('change', renderPecas);
+  document
+    .getElementById('pecasStatus')
+    ?.addEventListener('change', renderPecas);
+  document.getElementById('pecasBusca')?.addEventListener('input', renderPecas);
+
+  document
+    .getElementById('reembolsosInicio')
+    ?.addEventListener('change', renderReembolsos);
+  document
+    .getElementById('reembolsosFim')
+    ?.addEventListener('change', renderReembolsos);
+  document
+    .getElementById('reembolsosBusca')
+    ?.addEventListener('input', renderReembolsos);
+}
+
+async function carregarDados() {
+  atualizarStatusGlobal('Sincronizando dados dos problemas...', false);
+  await Promise.all([carregarPecas(), carregarReembolsos()]);
+  atualizarStatusGlobal(
+    `Atualizado em ${new Date().toLocaleTimeString('pt-BR', {
+      hour: '2-digit',
+      minute: '2-digit',
+    })}`,
+    false,
+  );
+}
+
+async function carregarPecas() {
+  if (!usuarios.length) {
+    pecasCache = [];
+    renderPecas();
+    return;
+  }
+  setStatus(pecasStatusMsgEl, 'Carregando peças faltantes...', false);
+  try {
+    const resultados = (
+      await Promise.all(
+        usuarios.map((usuario) =>
+          carregarColecaoProblemas(usuario, 'pecasfaltando'),
+        ),
+      )
+    ).flat();
+    pecasCache = resultados;
+    setStatus(
+      pecasStatusMsgEl,
+      resultados.length
+        ? `${resultados.length.toLocaleString('pt-BR')} registro(s) carregados.`
+        : 'Nenhum registro encontrado para os usuários selecionados.',
+      false,
+    );
+  } catch (err) {
+    console.error('Erro ao carregar peças faltantes:', err);
+    pecasCache = [];
+    setStatus(
+      pecasStatusMsgEl,
+      'Não foi possível carregar os registros de peças faltantes.',
+      true,
+    );
+  }
+  renderPecas();
+}
+
+async function carregarReembolsos() {
+  if (!usuarios.length) {
+    reembolsosCache = [];
+    renderReembolsos();
+    return;
+  }
+  setStatus(reembolsosStatusMsgEl, 'Carregando reembolsos...', false);
+  try {
+    const resultados = (
+      await Promise.all(
+        usuarios.map((usuario) =>
+          carregarColecaoProblemas(usuario, 'reembolsos'),
+        ),
+      )
+    ).flat();
+    reembolsosCache = resultados;
+    setStatus(
+      reembolsosStatusMsgEl,
+      resultados.length
+        ? `${resultados.length.toLocaleString('pt-BR')} reembolso(s) carregados.`
+        : 'Nenhum reembolso encontrado para os usuários selecionados.',
+      false,
+    );
+  } catch (err) {
+    console.error('Erro ao carregar reembolsos:', err);
+    reembolsosCache = [];
+    setStatus(
+      reembolsosStatusMsgEl,
+      'Não foi possível carregar os registros de reembolso.',
+      true,
+    );
+  }
+  renderReembolsos();
+}
+
+async function carregarColecaoProblemas(usuario, tipo) {
+  if (!usuario?.uid) return [];
+  try {
+    const itensRef = collection(
+      doc(db, 'uid', usuario.uid, 'problemas', tipo),
+      'itens',
+    );
+    const snap = await getDocs(itensRef);
+    return snap.docs.map((docSnap) => ({
+      id: docSnap.id,
+      ...docSnap.data(),
+      usuarioUid: usuario.uid,
+      usuarioNome: usuario.nome || usuario.email || usuario.uid,
+      usuarioEmail: usuario.email || '',
+    }));
+  } catch (err) {
+    console.error(`Erro ao carregar ${tipo} para ${usuario.uid}:`, err);
+    return [];
+  }
+}
+
+function renderPecas() {
+  if (!pecasTabelaBody) return;
+
+  const inicio = document.getElementById('pecasInicio')?.value || '';
+  const fim = document.getElementById('pecasFim')?.value || '';
+  const statusFiltro = (
+    document.getElementById('pecasStatus')?.value || ''
+  ).trim();
+  const busca = (
+    document.getElementById('pecasBusca')?.value || ''
+  ).toLowerCase();
+
+  const filtrados = pecasCache
+    .filter((item) => {
+      if (usuarioSelecionado && item.usuarioUid !== usuarioSelecionado)
+        return false;
+      const data = item.data || '';
+      if (inicio && (!data || data < inicio)) return false;
+      if (fim && (!data || data > fim)) return false;
+      if (statusFiltro) {
+        const statusItem = normalizarStatus(item.status);
+        const statusComparacao = normalizarStatus(statusFiltro);
+        if (statusItem !== statusComparacao) return false;
+      }
+      if (busca) {
+        const campos = [
+          item.nomeCliente,
+          item.apelido,
+          item.numero,
+          item.loja,
+          item.peca,
+          item.usuarioNome,
+          item.usuarioEmail,
+        ];
+        const contemBusca = campos.some((valor) =>
+          String(valor || '')
+            .toLowerCase()
+            .includes(busca),
+        );
+        if (!contemBusca) return false;
+      }
+      return true;
+    })
+    .sort((a, b) => ordenarPorDataNumero(b, a));
+
+  pecasTabelaBody.innerHTML = '';
+  filtrados.forEach((item) => {
+    const tr = document.createElement('tr');
+    tr.className = 'hover:bg-gray-50';
+
+    const status = normalizarStatus(item.status);
+    const statusTexto = formatarStatus(status);
+    const statusClasses = obterClasseStatus(status);
+
+    const clienteHtml = item.nomeCliente
+      ? `<div class="flex flex-col"><span class="font-medium text-gray-700">${escapeHtml(
+          item.nomeCliente,
+        )}</span>${item.apelido ? `<span class="text-xs text-gray-500">${escapeHtml(item.apelido)}</span>` : ''}</div>`
+      : escapeHtml(item.apelido || '-');
+
+    const responsavelEmail = item.usuarioEmail
+      ? `<span class="text-xs text-gray-500">${escapeHtml(item.usuarioEmail)}</span>`
+      : '';
+
+    tr.innerHTML = `
+      <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">${formatarData(
+        item.data,
+      )}</td>
+      <td class="px-4 py-3">
+        <div class="flex flex-col">
+          <span class="font-medium text-gray-700">${escapeHtml(item.usuarioNome)}</span>
+          ${responsavelEmail}
+        </div>
+      </td>
+      <td class="px-4 py-3">${clienteHtml}</td>
+      <td class="px-4 py-3">${escapeHtml(item.numero || '-')}</td>
+      <td class="px-4 py-3">${escapeHtml(item.loja || '-')}</td>
+      <td class="px-4 py-3">${escapeHtml(item.peca || '-')}</td>
+      <td class="px-4 py-3">
+        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${statusClasses}">
+          ${statusTexto}
+        </span>
+      </td>
+      <td class="px-4 py-3 text-right font-medium text-gray-700">${formatarMoeda(
+        Number(item.valorGasto) || 0,
+      )}</td>
+    `;
+
+    pecasTabelaBody.appendChild(tr);
+  });
+
+  pecasEmptyEl?.classList.toggle('hidden', filtrados.length > 0);
+  atualizarResumoPecas(filtrados);
+}
+
+function renderReembolsos() {
+  if (!reembolsosTabelaBody) return;
+
+  const inicio = document.getElementById('reembolsosInicio')?.value || '';
+  const fim = document.getElementById('reembolsosFim')?.value || '';
+  const busca = (
+    document.getElementById('reembolsosBusca')?.value || ''
+  ).toLowerCase();
+
+  const filtrados = reembolsosCache
+    .filter((item) => {
+      if (usuarioSelecionado && item.usuarioUid !== usuarioSelecionado)
+        return false;
+      const data = item.data || '';
+      if (inicio && (!data || data < inicio)) return false;
+      if (fim && (!data || data > fim)) return false;
+      if (busca) {
+        const campos = [
+          item.numero,
+          item.apelido,
+          item.nf,
+          item.loja,
+          item.problema,
+          item.usuarioNome,
+          item.usuarioEmail,
+        ];
+        const contemBusca = campos.some((valor) =>
+          String(valor || '')
+            .toLowerCase()
+            .includes(busca),
+        );
+        if (!contemBusca) return false;
+      }
+      return true;
+    })
+    .sort((a, b) => ordenarPorDataNumero(b, a));
+
+  reembolsosTabelaBody.innerHTML = '';
+  filtrados.forEach((item) => {
+    const tr = document.createElement('tr');
+    tr.className = 'hover:bg-gray-50';
+
+    const responsavelEmail = item.usuarioEmail
+      ? `<span class="text-xs text-gray-500">${escapeHtml(item.usuarioEmail)}</span>`
+      : '';
+
+    tr.innerHTML = `
+      <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">${formatarData(
+        item.data,
+      )}</td>
+      <td class="px-4 py-3">
+        <div class="flex flex-col">
+          <span class="font-medium text-gray-700">${escapeHtml(item.usuarioNome)}</span>
+          ${responsavelEmail}
+        </div>
+      </td>
+      <td class="px-4 py-3">${escapeHtml(item.numero || '-')}</td>
+      <td class="px-4 py-3">${escapeHtml(item.apelido || '-')}</td>
+      <td class="px-4 py-3">${escapeHtml(item.nf || '-')}</td>
+      <td class="px-4 py-3">${escapeHtml(item.loja || '-')}</td>
+      <td class="px-4 py-3">${escapeHtml(item.problema || '-')}</td>
+      <td class="px-4 py-3 text-right font-medium text-gray-700">${formatarMoeda(
+        Number(item.valor) || 0,
+      )}</td>
+    `;
+
+    reembolsosTabelaBody.appendChild(tr);
+  });
+
+  reembolsosEmptyEl?.classList.toggle('hidden', filtrados.length > 0);
+  atualizarResumoReembolsos(filtrados);
+}
+
+function atualizarResumoPecas(lista) {
+  document.getElementById('pecasResumoTotal').textContent =
+    lista.length.toLocaleString('pt-BR');
+
+  const contagem = {
+    naoFeito: 0,
+    emAndamento: 0,
+    resolvido: 0,
+  };
+  let totalValor = 0;
+
+  lista.forEach((item) => {
+    const status = normalizarStatus(item.status);
+    if (status === 'RESOLVIDO') contagem.resolvido += 1;
+    else if (status === 'EM ANDAMENTO') contagem.emAndamento += 1;
+    else contagem.naoFeito += 1;
+    totalValor += Number(item.valorGasto) || 0;
+  });
+
+  document.getElementById('pecasResumoNaoFeito').textContent =
+    contagem.naoFeito.toLocaleString('pt-BR');
+  document.getElementById('pecasResumoEmAndamento').textContent =
+    contagem.emAndamento.toLocaleString('pt-BR');
+  document.getElementById('pecasResumoResolvido').textContent =
+    contagem.resolvido.toLocaleString('pt-BR');
+  document.getElementById('pecasResumoValor').textContent =
+    formatarMoeda(totalValor);
+}
+
+function atualizarResumoReembolsos(lista) {
+  document.getElementById('reembolsosResumoTotal').textContent =
+    lista.length.toLocaleString('pt-BR');
+  const totalValor = lista.reduce(
+    (acc, item) => acc + (Number(item.valor) || 0),
+    0,
+  );
+  document.getElementById('reembolsosResumoValor').textContent =
+    formatarMoeda(totalValor);
+  const ticket = lista.length ? totalValor / lista.length : 0;
+  document.getElementById('reembolsosResumoMedio').textContent =
+    formatarMoeda(ticket);
+  const ultimo = lista.reduce((maior, item) => {
+    if (!item.data) return maior;
+    if (!maior || item.data > maior) return item.data;
+    return maior;
+  }, '');
+  document.getElementById('reembolsosResumoRecente').textContent = ultimo
+    ? formatarData(ultimo)
+    : '-';
+}
+
+function preencherSelectUsuarios() {
+  if (!filtroUsuarioEl) return;
+  filtroUsuarioEl.innerHTML = '';
+  const optionTodos = document.createElement('option');
+  optionTodos.value = '';
+  optionTodos.textContent = 'Todos os usuários conectados';
+  filtroUsuarioEl.appendChild(optionTodos);
+
+  usuarios.forEach((usuario) => {
+    const option = document.createElement('option');
+    option.value = usuario.uid;
+    const nome = usuario.nome || usuario.email || usuario.uid;
+    option.textContent = usuario.email ? `${nome} (${usuario.email})` : nome;
+    filtroUsuarioEl.appendChild(option);
+  });
+
+  filtroUsuarioEl.value = '';
+  usuarioSelecionado = '';
+}
+
+function atualizarMensagensUsuarios() {
+  if (infoUsuariosEl) {
+    if (usuarios.length > 1) {
+      infoUsuariosEl.textContent = `Visualize os problemas cadastrados por ${usuarios.length} usuários vinculados ao seu e-mail de responsável financeiro.`;
+    } else {
+      infoUsuariosEl.textContent =
+        'Visualize os problemas cadastrados na aba Problemas com o seu usuário.';
+    }
+  }
+  if (resumoUsuariosEl) {
+    const extras = usuarios.filter((u) => u.uid !== currentUser?.uid);
+    if (extras.length) {
+      resumoUsuariosEl.textContent = `Consolidando registros do seu usuário e de ${extras.length} mentorado(s)/vendedor(es) conectados.`;
+    } else {
+      resumoUsuariosEl.textContent =
+        'Nenhum outro usuário está vinculado ao seu e-mail de responsável financeiro.';
+    }
+  }
+}
+
+function setStatus(elemento, texto, isError) {
+  if (!elemento) return;
+  elemento.textContent = texto || '';
+  elemento.classList.toggle('text-red-600', Boolean(isError));
+  elemento.classList.toggle('text-gray-500', !isError);
+}
+
+function atualizarStatusGlobal(texto, isError) {
+  if (!globalStatusEl) return;
+  globalStatusEl.textContent = texto || '';
+  globalStatusEl.classList.toggle('text-red-600', Boolean(isError));
+  globalStatusEl.classList.toggle('text-gray-500', !isError);
+}
+
+function normalizarStatus(status) {
+  const valor = (status || '').toString().toUpperCase();
+  if (valor === 'NAO FEITO' || valor === 'NÃO FEITO') return 'NÃO FEITO';
+  if (valor === 'EM ANDAMENTO') return 'EM ANDAMENTO';
+  if (valor === 'RESOLVIDO') return 'RESOLVIDO';
+  return valor || 'NÃO INFORMADO';
+}
+
+function formatarStatus(status) {
+  switch (status) {
+    case 'RESOLVIDO':
+      return 'Resolvido';
+    case 'EM ANDAMENTO':
+      return 'Em andamento';
+    case 'NÃO FEITO':
+    case 'NAO FEITO':
+      return 'Não feito';
+    default:
+      return status && status !== 'NÃO INFORMADO' ? status : 'Não informado';
+  }
+}
+
+function obterClasseStatus(status) {
+  if (status === 'RESOLVIDO')
+    return 'bg-emerald-50 text-emerald-700 border border-emerald-200';
+  if (status === 'EM ANDAMENTO')
+    return 'bg-blue-50 text-blue-700 border border-blue-200';
+  return 'bg-amber-50 text-amber-700 border border-amber-200';
+}
+
+function ordenarPorDataNumero(a, b) {
+  const dataA = a?.data || '';
+  const dataB = b?.data || '';
+  if (dataA && dataB && dataA !== dataB) return dataA.localeCompare(dataB);
+  const numeroA = (a?.numero || '').toString();
+  const numeroB = (b?.numero || '').toString();
+  return numeroA.localeCompare(numeroB);
+}
+
+function formatarData(valor) {
+  if (!valor) return '-';
+  const dataStr = valor.split('T')[0];
+  const [ano, mes, dia] = dataStr.split('-');
+  if (!ano || !mes || !dia) return valor;
+  return `${dia}/${mes}/${ano}`;
+}
+
+function formatarMoeda(valor) {
+  return Number(valor || 0).toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    minimumFractionDigits: 2,
+  });
+}
+
+function escapeHtml(texto) {
+  return String(texto || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/login.js
+++ b/login.js
@@ -502,6 +502,7 @@ function applyPerfilRestrictions(perfil) {
       'menu-produtos-precos',
       'menu-pedidos-reais',
       'menu-acompanhamento-gestor',
+      'menu-acompanhamento-problemas',
       'menu-mentoria',
       'menu-perfil-mentorado',
       'menu-equipes',

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -259,6 +259,35 @@
         <span class="link-text">Mentorados/Vendedores</span>
       </a>
     </li>
+    <li>
+      <a
+        href="/acompanhamento-problemas.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-acompanhamento-problemas"
+        data-perfil="gestor,responsavel financeiro"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M10.343 3.94c.562-1.003 1.752-1.003 2.314 0l7.79 13.88c.562 1-.141 2.25-1.157 2.25H3.71c-1.016 0-1.719-1.25-1.157-2.25l7.79-13.88z"
+          />
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M12 9v4.5m0 3h.008v.008H12V16.5Z"
+          />
+        </svg>
+        <span class="link-text">Acompanhamento Problemas</span>
+      </a>
+    </li>
 
     <li>
       <a

--- a/shared.js
+++ b/shared.js
@@ -635,6 +635,7 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-produtos-precos',
     'menu-pedidos-reais',
     'menu-acompanhamento-gestor',
+    'menu-acompanhamento-problemas',
     'menu-mentoria',
     'menu-perfil-mentorado',
     'menu-equipes',
@@ -702,6 +703,7 @@ document.addEventListener('sidebarLoaded', async () => {
     const pedidosReais = getLi('menu-pedidos-reais');
     const gestao = getLi('menu-gestao');
     const acompGestor = getLi('menu-acompanhamento-gestor');
+    const acompProblemas = getLi('menu-acompanhamento-problemas');
     const mentoria = getLi('menu-mentoria');
     const perfilMentorado = getLi('menu-perfil-mentorado');
     const produtos = getLi('menu-produtos');
@@ -751,6 +753,7 @@ document.addEventListener('sidebarLoaded', async () => {
     ]);
     const gestaoGroup = createGroup(gestao, 'menuGestao', [
       acompGestor,
+      acompProblemas,
       mentoria,
       perfilMentorado,
       produtos,


### PR DESCRIPTION
## Summary
- adicionar a página Acompanhamento de Problemas com indicadores, filtros e duas subpáginas para peças faltantes e reembolsos vinculados ao responsável financeiro
- carregar automaticamente os registros dos usuários associados ao responsável, com consolidação de métricas e tabelas filtráveis
- expor a nova aba no grupo Gestão e ajustar permissões de exibição no menu lateral

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d19715bcc8832aabb11f8afad3fb33