### PR TITLE
Add compact rasterized option for etiquetas

### DIFF
--- a/etiquetas-shopee.html
+++ b/etiquetas-shopee.html
@@ -13,6 +13,12 @@
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-storage-compat.js"></script>
   <script src="expedicao-notifier.js"></script>
+  <!-- PDF.js (para rasterizar recortes em JPEG quando necessário) -->
+  <script src="https://unpkg.com/pdfjs-dist@4.6.82/build/pdf.min.js"></script>
+  <script>
+    pdfjsLib.GlobalWorkerOptions.workerSrc =
+      "https://unpkg.com/pdfjs-dist@4.6.82/build/pdf.worker.min.js";
+  </script>
   <script src="https://unpkg.com/pdf-lib@1.17.1/dist/pdf-lib.min.js"></script>
   <style>
     .shopee-labels {
@@ -197,6 +203,34 @@
                     <span>Processar</span>
                   </button>
                   <label class="labels-chk">
+                    <input id="compact" type="checkbox" checked />
+                    <span class="labels-mono">Modo compacto (rasterizar checklist)</span>
+                  </label>
+                  <label class="labels-chk" style="gap:6px">
+                    <span class="labels-mono">DPI:</span>
+                    <input
+                      id="dpi"
+                      type="number"
+                      value="144"
+                      min="72"
+                      max="300"
+                      step="12"
+                      style="width:80px;background:#0b1220;border:1px solid #1f2937;color:#e5e7eb;border-radius:8px;padding:4px"
+                    />
+                  </label>
+                  <label class="labels-chk" style="gap:6px">
+                    <span class="labels-mono">Qualidade:</span>
+                    <input
+                      id="jpgq"
+                      type="number"
+                      value="0.65"
+                      min="0.3"
+                      max="0.95"
+                      step="0.05"
+                      style="width:80px;background:#0b1220;border:1px solid #1f2937;color:#e5e7eb;border-radius:8px;padding:4px"
+                    />
+                  </label>
+                  <label class="labels-chk">
                     <input id="debug" type="checkbox" />
                     <span class="labels-mono">Gerar PDF DEBUG</span>
                   </label>
@@ -253,6 +287,9 @@
     const fileInput = document.getElementById('file');
     const processBtn = document.getElementById('go');
     const debugCheckbox = document.getElementById('debug');
+    const compactCheckbox = document.getElementById('compact');
+    const dpiInput = document.getElementById('dpi');
+    const jpgQualityInput = document.getElementById('jpgq');
     const statusEl = document.getElementById('status');
     const logEl = document.getElementById('log');
     const outEl = document.getElementById('out');
@@ -497,12 +534,87 @@
         const CM_TO_PT = 28.3464566929;
         const cm = (v) => v * CM_TO_PT;
 
+        // Rasteriza uma região (em pontos) de uma página em JPEG (Uint8Array)
+        async function rasterizeRegionToJpeg(srcBytes, pageIndex, regionPt, dpi = 144, quality = 0.65) {
+          const scale = dpi / 72;
+          const loadingTask = pdfjsLib.getDocument({ data: srcBytes });
+          const pdf = await loadingTask.promise;
+
+          try {
+            const page = await pdf.getPage(pageIndex + 1);
+            const viewport = page.getViewport({ scale });
+            const pt2px = scale;
+
+            const x = regionPt.left * pt2px;
+            const yTop = viewport.height - regionPt.top * pt2px;
+            const w = (regionPt.right - regionPt.left) * pt2px;
+            const h = (regionPt.top - regionPt.bottom) * pt2px;
+
+            const canvas = document.createElement('canvas');
+            canvas.width = Math.ceil(viewport.width);
+            canvas.height = Math.ceil(viewport.height);
+            const ctx = canvas.getContext('2d', { willReadFrequently: true });
+            await page.render({ canvasContext: ctx, viewport }).promise;
+
+            const srcW = Math.max(1, Math.floor(w));
+            const srcH = Math.max(1, Math.floor(h));
+            const crop = document.createElement('canvas');
+            crop.width = srcW;
+            crop.height = srcH;
+            const cctx = crop.getContext('2d');
+            cctx.drawImage(
+              canvas,
+              Math.floor(x),
+              Math.floor(yTop),
+              srcW,
+              srcH,
+              0,
+              0,
+              crop.width,
+              crop.height,
+            );
+
+            const dataUrl = crop.toDataURL('image/jpeg', quality);
+            const bin = atob(dataUrl.split(',')[1]);
+            const bytes = new Uint8Array(bin.length);
+            for (let j = 0; j < bin.length; j++) bytes[j] = bin.charCodeAt(j);
+            if (typeof page.cleanup === 'function') {
+              await page.cleanup();
+            }
+            return bytes;
+          } finally {
+            if (typeof pdf.cleanup === 'function') {
+              try {
+                await pdf.cleanup();
+              } catch (cleanupError) {
+                console.warn('Falha ao liberar PDF rasterizado:', cleanupError);
+              }
+            }
+            if (typeof loadingTask.destroy === 'function') {
+              try {
+                await loadingTask.destroy();
+              } catch (destroyError) {
+                console.warn('Falha ao destruir worker do PDF.js:', destroyError);
+              }
+            }
+          }
+        }
+
         const CM_TOP = 15;
         const CM_DISCARD = 2.3;
         const CM_TAKE = 1.7;
         const COL_WIDTHS = [2.0, 1.9, 1.9, 1.9, 1.9];
         const PICK = [3, 5];
         const zoomFactor = 2.6;
+        const useCompact = Boolean(compactCheckbox?.checked);
+        const dpiValueRaw = parseInt(dpiInput?.value ?? '144', 10);
+        const dpiValue = Number.isFinite(dpiValueRaw)
+          ? Math.min(300, Math.max(72, dpiValueRaw))
+          : 144;
+        const jpgQualityRaw = parseFloat(jpgQualityInput?.value ?? '0.65');
+        const jpgQuality = Number.isFinite(jpgQualityRaw)
+          ? Math.min(0.95, Math.max(0.3, jpgQualityRaw))
+          : 0.65;
 
         let totalOutPages = 0;
 
@@ -563,11 +675,21 @@
 
             const [embTop] = await outDoc.embedPages([page], [topRegion]);
 
+            const compact = useCompact;
+            const dpi = dpiValue;
+            const jpgq = jpgQuality;
+
             const chosen = [];
             for (const k of PICK) {
               const box = colBoxes[k - 1];
-              const [emb] = await outDoc.embedPages([page], [box]);
-              chosen.push({ emb, box });
+              if (compact) {
+                const jpegBytes = await rasterizeRegionToJpeg(srcBytes, i, box, dpi, jpgq);
+                const embImg = await outDoc.embedJpg(jpegBytes);
+                chosen.push({ type: 'img', img: embImg, box });
+              } else {
+                const [emb] = await outDoc.embedPages([page], [box]);
+                chosen.push({ type: 'page', emb, box });
+              }
             }
 
             const bottomTrimCm = -0.4;
@@ -585,17 +707,27 @@
 
             const pairW = chosen.reduce((s, { box }) => s + box.width, 0);
             const pairWZoom = pairW * zoomFactor;
-            const cx = (outW - pairWZoom) / 1.5;
+            const cx = (outW - pairWZoom) / 2;
 
             let dx = 0;
-            for (const { emb, box } of chosen) {
-              const w = box.width;
-              outPage.drawPage(emb, {
-                x: cx + dx * zoomFactor,
-                y: 0,
-                width: w * zoomFactor,
-                height: takeH * zoomFactor,
-              });
+            for (const it of chosen) {
+              const w = it.box.width;
+              const h = takeH;
+              if (it.type === 'img') {
+                outPage.drawImage(it.img, {
+                  x: cx + dx * zoomFactor,
+                  y: 0,
+                  width: w * zoomFactor,
+                  height: h * zoomFactor,
+                });
+              } else {
+                outPage.drawPage(it.emb, {
+                  x: cx + dx * zoomFactor,
+                  y: 0,
+                  width: w * zoomFactor,
+                  height: h * zoomFactor,
+                });
+              }
               dx += w;
             }
 
@@ -625,7 +757,7 @@
         }
 
         setStatus('Salvando PDF…');
-        const outBytes = await outDoc.save();
+        const outBytes = await outDoc.save({ useObjectStreams: true });
         const outBlob = new Blob([outBytes], { type: 'application/pdf' });
         const baseName = file.name.replace(/\.pdf$/i, '') || 'etiquetas';
         const finalFileName = `${baseName}-cols3-5-zoom.pdf`;


### PR DESCRIPTION
## Summary
- add PDF.js support and helper utilities to rasterize checklist slices when compact mode is enabled
- expose compact mode, DPI and JPEG quality controls in the Shopee labels UI and center rasterized columns
- save generated PDFs with object stream compression to reduce file size

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2e4154f58832aaefeaf9a5eab465b