### PR TITLE
Refinar layout da aba de etiquetas Shopee

### DIFF
--- a/etiquetas-shopee.html
+++ b/etiquetas-shopee.html
@@ -16,165 +16,253 @@
   <script src="https://unpkg.com/pdf-lib@1.17.1/dist/pdf-lib.min.js"></script>
   <style>
     .shopee-labels {
-      --labels-bg: #0f172a;
-      --labels-card: #111827;
-      --labels-muted: #94a3b8;
-      --labels-pad: 16px;
-      --labels-radius: 18px;
-      background: var(--labels-bg);
-      color: #e5e7eb;
-      border-radius: 24px;
-      border: 1px solid #1f2937;
-      box-shadow: 0 25px 40px rgba(15, 23, 42, 0.35);
+      position: relative;
+      background: linear-gradient(180deg, #1e3a8a 0%, #2563eb 45%, #0ea5e9 100%);
+      border-radius: 32px;
+      padding: 40px 32px 44px;
+      color: #fff;
+      box-shadow: 0 35px 65px rgba(37, 99, 235, 0.35);
       overflow: hidden;
     }
-    .shopee-labels .labels-header {
-      padding: 28px 24px 12px;
+    .shopee-labels::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.25), transparent 60%),
+                  radial-gradient(circle at bottom left, rgba(59, 130, 246, 0.4), transparent 65%);
+      pointer-events: none;
+    }
+    .shopee-labels > * {
+      position: relative;
+      z-index: 1;
+    }
+    .labels-banner {
       text-align: center;
+      font-size: clamp(26px, 3.4vw, 40px);
+      font-weight: 800;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      margin-bottom: 28px;
+      text-shadow: 0 12px 25px rgba(15, 23, 42, 0.35);
     }
-    .shopee-labels .labels-title {
-      margin: 0 0 6px;
-      font-size: clamp(22px, 2.6vw, 30px);
-      font-weight: 700;
-      letter-spacing: -0.01em;
-    }
-    .shopee-labels .labels-sub {
-      margin: 0;
-      color: var(--labels-muted);
-      font-size: 0.95rem;
-      line-height: 1.4;
-    }
-    .shopee-labels .labels-wrap {
-      display: grid;
-      gap: 18px;
-      padding: 0 24px 28px;
-    }
-    .shopee-labels .labels-card {
-      background: var(--labels-card);
-      border: 1px solid #1f2937;
-      border-radius: var(--labels-radius);
-      padding: var(--labels-pad);
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
-    }
-    .shopee-labels .labels-row {
+    .labels-body {
       display: flex;
-      flex-wrap: wrap;
+      flex-direction: column;
+      gap: 26px;
+    }
+    .labels-drop {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
       gap: 12px;
-      align-items: center;
-    }
-    .shopee-labels .labels-upload {
-      display: inline-flex;
-      gap: 10px;
-      align-items: center;
-      padding: 10px 14px;
-      border-radius: 12px;
-      background: #1f2937;
-      border: 1px dashed #374151;
+      padding: 38px 24px;
+      border-radius: 26px;
+      border: 3px dashed rgba(37, 99, 235, 0.45);
+      background: rgba(255, 255, 255, 0.96);
+      color: #1e3a8a;
+      font-weight: 600;
+      font-size: 1rem;
+      text-align: center;
       cursor: pointer;
-      transition: border-color 0.2s ease, transform 0.2s ease;
+      transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+      box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.08);
     }
-    .shopee-labels .labels-upload:hover {
-      border-color: #60a5fa;
-      transform: translateY(-1px);
+    .labels-drop:hover {
+      border-color: #38bdf8;
+      transform: translateY(-2px);
+      box-shadow: 0 24px 48px rgba(14, 165, 233, 0.35);
+    }
+    .labels-drop-icon {
+      font-size: 2.75rem;
+      color: #2563eb;
+    }
+    .labels-drop-note {
+      font-size: 0.85rem;
+      color: #2563eb;
+      font-weight: 600;
     }
     .shopee-labels input[type="file"] {
       display: none;
     }
-    .shopee-labels .labels-action {
-      all: unset;
-      display: inline-flex;
-      gap: 10px;
+    .labels-actions {
+      display: flex;
+      flex-direction: column;
       align-items: center;
-      background: linear-gradient(135deg, #06b6d4, #22d3ee);
-      color: #001018;
-      font-weight: 700;
-      padding: 12px 18px;
-      border-radius: 12px;
+      gap: 14px;
+    }
+    .labels-start {
+      border: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      padding: 0 56px;
+      height: 60px;
+      border-radius: 9999px;
+      font-size: 1.25rem;
+      font-weight: 800;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      background: linear-gradient(135deg, #34d399 0%, #22d3ee 100%);
+      color: #0f172a;
       cursor: pointer;
-      transition: transform 0.15s ease, box-shadow 0.15s ease;
+      box-shadow: 0 28px 45px rgba(16, 185, 129, 0.35);
+      transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
     }
-    .shopee-labels .labels-action:disabled {
+    .labels-start:disabled {
+      opacity: 0.55;
       cursor: not-allowed;
-      opacity: 0.6;
-      transform: none !important;
-      box-shadow: none !important;
+      box-shadow: none;
+      transform: none;
+      filter: grayscale(10%);
     }
-    .shopee-labels .labels-action:not(:disabled):hover {
-      transform: translateY(-1px);
-      box-shadow: 0 8px 18px rgba(14, 165, 233, 0.25);
+    .labels-start:not(:disabled):hover {
+      transform: translateY(-2px);
+      box-shadow: 0 32px 54px rgba(13, 148, 136, 0.4);
     }
-    .shopee-labels .labels-action:not(:disabled):active {
+    .labels-start:not(:disabled):active {
       transform: translateY(1px);
     }
-    .shopee-labels .labels-field {
+    .labels-status {
+      font-size: 0.85rem;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: rgba(226, 232, 240, 0.85);
+      min-height: 1.6rem;
+    }
+    .labels-options {
+      display: flex;
+      justify-content: center;
+      align-items: flex-end;
+      gap: 18px;
+      flex-wrap: wrap;
+    }
+    .labels-field {
       display: flex;
       flex-direction: column;
       gap: 6px;
+      min-width: 220px;
     }
-    .shopee-labels .labels-field-label {
-      font-size: 0.7rem;
+    .labels-field label {
+      font-size: 0.75rem;
       letter-spacing: 0.08em;
-      color: var(--labels-muted);
       text-transform: uppercase;
+      color: rgba(226, 232, 240, 0.9);
     }
-    .shopee-labels .labels-input {
-      background: #0b162b;
-      border: 1px solid #1f2937;
-      border-radius: 12px;
-      color: #e2e8f0;
-      padding: 10px 14px;
+    .labels-input {
+      background: rgba(255, 255, 255, 0.98);
+      border: none;
+      border-radius: 16px;
+      padding: 12px 16px;
+      color: #0f172a;
       font-size: 0.95rem;
-      width: 220px;
-      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.12);
+      transition: box-shadow 0.2s ease, transform 0.2s ease;
     }
-    .shopee-labels .labels-input::placeholder {
-      color: var(--labels-muted);
-    }
-    .shopee-labels .labels-input:focus {
+    .labels-input:focus {
       outline: none;
-      border-color: #60a5fa;
-      box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.25);
+      box-shadow: 0 0 0 3px rgba(125, 211, 252, 0.65);
+      transform: translateY(-1px);
     }
-    .shopee-labels .labels-mono {
-      font-family: ui-monospace, Menlo, Consolas, monospace;
-      font-size: 12.5px;
-      color: #cbd5e1;
-    }
-    .shopee-labels .labels-hint {
-      color: var(--labels-muted);
-      font-size: 13px;
-      line-height: 1.4;
-    }
-    .shopee-labels .labels-ok {
-      color: #22c55e;
-      font-weight: 700;
-    }
-    .shopee-labels .labels-link {
-      color: #67e8f9;
-      text-decoration: underline;
+    .labels-checkbox {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 12px 16px;
+      border-radius: 16px;
+      background: rgba(15, 23, 42, 0.25);
+      border: 1px solid rgba(255, 255, 255, 0.18);
       font-weight: 600;
+      color: rgba(226, 232, 240, 0.92);
     }
-    .shopee-labels .labels-grid {
+    .labels-checkbox input {
+      width: 18px;
+      height: 18px;
+      accent-color: #22d3ee;
+    }
+    .labels-checkbox span {
+      font-family: 'JetBrains Mono', 'Fira Code', monospace;
+      font-size: 0.8rem;
+      letter-spacing: 0.04em;
+    }
+    .labels-hint {
+      font-size: 0.9rem;
+      line-height: 1.5;
+      color: rgba(226, 232, 240, 0.88);
+    }
+    .labels-hint-center {
+      text-align: center;
+    }
+    .labels-sections {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 20px;
+    }
+    .labels-card {
+      background: rgba(15, 23, 42, 0.28);
+      border-radius: 24px;
+      padding: 24px;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+      display: flex;
+      flex-direction: column;
       gap: 16px;
     }
-    .shopee-labels .labels-chk {
-      display: inline-flex;
-      gap: 8px;
-      align-items: center;
-      padding: 6px 10px;
-      border: 1px solid #374151;
-      border-radius: 10px;
-      background: #1f2937;
+    .labels-card-title {
+      font-size: 1.15rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
     }
-    .shopee-labels .labels-log {
+    .labels-card-content {
+      font-size: 0.95rem;
+      color: rgba(226, 232, 240, 0.95);
+      min-height: 40px;
+    }
+    .labels-log {
       background: rgba(15, 23, 42, 0.55);
-      border-radius: 12px;
-      padding: 12px;
-      border: 1px solid rgba(148, 163, 184, 0.12);
+      border-radius: 18px;
+      padding: 16px;
+      border: 1px solid rgba(148, 163, 184, 0.18);
       max-height: 240px;
       overflow-y: auto;
+    }
+    .labels-log pre {
+      margin: 0;
+      color: #e2e8f0;
+      font-family: 'JetBrains Mono', 'Fira Code', monospace;
+      font-size: 0.85rem;
+      white-space: pre-wrap;
+    }
+    .labels-emails {
+      background: rgba(15, 23, 42, 0.2);
+      border-radius: 24px;
+      padding: 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    }
+    .labels-emails label {
+      font-size: 0.8rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      font-weight: 700;
+      color: rgba(226, 232, 240, 0.85);
+    }
+    .labels-emails input {
+      background: rgba(255, 255, 255, 0.98);
+      border: none;
+      border-radius: 16px;
+      padding: 12px 16px;
+      color: #0f172a;
+      font-size: 0.95rem;
+      box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.12);
+      transition: box-shadow 0.2s ease, transform 0.2s ease;
+    }
+    .labels-emails input:focus {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(125, 211, 252, 0.65);
+      transform: translateY(-1px);
     }
     .progress-bar-bg {
       background: linear-gradient(90deg, #cfd9df 0%, #e2ebf0 100%);
@@ -211,18 +299,35 @@
     }
     #timerText {
       font-size: 0.875rem;
-      color: #374151;
+      color: #1f2937;
       font-weight: 500;
     }
     #status {
-      min-height: 2rem;
+      min-height: 1.6rem;
     }
     @media (max-width: 768px) {
-      .shopee-labels .labels-header {
-        padding: 24px 16px 12px;
+      .shopee-labels {
+        padding: 32px 24px 36px;
       }
-      .shopee-labels .labels-wrap {
-        padding: 0 16px 24px;
+      .labels-drop {
+        padding: 30px 18px;
+      }
+      .labels-start {
+        width: 100%;
+      }
+      .labels-options {
+        justify-content: stretch;
+      }
+    }
+    @media (max-width: 480px) {
+      .labels-start {
+        font-size: 1.1rem;
+        padding: 0 32px;
+        height: 54px;
+      }
+      .labels-checkbox {
+        width: 100%;
+        justify-content: center;
       }
     }
   </style>
@@ -233,65 +338,47 @@
     <div id="navbar-container"></div>
     <div class="main-content">
       <div class="px-4 py-6">
-        <div class="max-w-5xl mx-auto space-y-6">
-          <div class="bg-white rounded-2xl shadow border border-gray-200 p-6 space-y-4">
-            <div class="flex items-center gap-3">
-              <div class="h-12 w-12 rounded-xl bg-blue-100 text-blue-600 flex items-center justify-center text-2xl">
-                <i class="fa-solid fa-scissors"></i>
-              </div>
-              <div>
-                <h1 class="text-2xl font-semibold text-gray-900">Etiqueta Shopee - Corte 15/2/2</h1>
-                <p class="text-sm text-gray-500">Processa PDFs A4, recorta etiqueta superior e checklist (colunas 3 e 5) com zoom. Resultado salvo automaticamente no Firebase.</p>
-              </div>
-            </div>
-            <div>
-              <label for="gestoresEmails" class="block text-sm font-medium text-gray-700">E-mails do gestor de expedição</label>
-              <input id="gestoresEmails" type="text" placeholder="Separados por vírgula" class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" />
-              <p class="text-xs text-gray-500 mt-1">Os PDFs serão compartilhados com os e-mails listados. Se houver mais de um, você poderá escolher durante o envio.</p>
-            </div>
-          </div>
-
+        <div class="max-w-4xl mx-auto">
           <div class="shopee-labels">
-            <div class="labels-header">
-              <h2 class="labels-title">✂️ Etiqueta em cima + colunas 3 e 5 do checklist (com zoom)</h2>
-              <p class="labels-sub">A4 ➜ divide no meio (10,5 cm), pega 15 cm do topo (etiqueta), do checklist descarta 2 cm e usa os 2 cm seguintes ➜ divide em 5 colunas (2.2, 1.9, 1.9, 1.9, 1.9 cm), pega colunas 3 e 5 e remonta abaixo com zoom.</p>
-            </div>
-            <div class="labels-wrap">
-              <div class="labels-card">
-                <div class="labels-row">
-                  <label class="labels-upload">
-                    <input id="file" type="file" accept="application/pdf" />
-                    <span>📄 Escolher PDF A4…</span>
-                  </label>
-                  <button id="go" type="button" class="labels-action">
-                    <span>Processar</span>
-                  </button>
-                  <label class="labels-field">
-                    <span class="labels-field-label">Loja</span>
-                    <input id="storeName" type="text" class="labels-input" placeholder="Ex.: Loja Principal" />
-                  </label>
-                  <label class="labels-chk">
-                    <input id="debug" type="checkbox" />
-                    <span class="labels-mono">Gerar PDF DEBUG</span>
-                  </label>
-                  <span id="status" class="labels-mono"></span>
-                </div>
-                <div class="labels-hint" style="margin-top:8px">
-                  Colunas (cm): <b>[2.2, 1.9, 1.9, 1.9, 1.9]</b>. Zoom padrão: <b>120%</b> (ajustável no código: <code>zoomFactor</code>).
-                </div>
+            <div class="labels-banner">Etiquetas Shopee</div>
+            <div class="labels-body">
+              <label class="labels-drop" for="file">
+                <input id="file" type="file" accept="application/pdf" />
+                <span class="labels-drop-icon"><i class="fa-solid fa-cloud-arrow-up"></i></span>
+                <span>Arrastar e soltar ou clicar para fazer upload</span>
+                <span class="labels-drop-note">PDF A4 com checklist Shopee</span>
+              </label>
+              <div class="labels-actions">
+                <button id="go" type="button" class="labels-start">Iniciar</button>
+                <span id="status" class="labels-status"></span>
               </div>
-
-              <div class="labels-grid">
+              <div class="labels-options">
+                <div class="labels-field">
+                  <label for="storeName">Loja</label>
+                  <input id="storeName" type="text" class="labels-input" placeholder="Ex.: Loja Principal" />
+                </div>
+                <label class="labels-checkbox">
+                  <input id="debug" type="checkbox" />
+                  <span>Gerar PDF DEBUG</span>
+                </label>
+              </div>
+              <p class="labels-hint labels-hint-center">Colunas (cm): <strong>[2.2, 1.9, 1.9, 1.9, 1.9]</strong>. Zoom padrão: <strong>120%</strong> (ajustável em <code>zoomFactor</code>).</p>
+              <div class="labels-sections">
                 <div class="labels-card">
-                  <div><strong>Saída</strong></div>
-                  <div id="out" class="labels-hint" style="margin-top:8px">Links para download aparecerão aqui.</div>
+                  <h3 class="labels-card-title">Resultados</h3>
+                  <div id="out" class="labels-card-content">Links para download aparecerão aqui.</div>
                 </div>
                 <div class="labels-card">
-                  <div><strong>Log</strong></div>
+                  <h3 class="labels-card-title">Log</h3>
                   <div class="labels-log">
-                    <pre id="log" class="labels-mono" style="white-space:pre-wrap;margin:0"></pre>
+                    <pre id="log"></pre>
                   </div>
                 </div>
+              </div>
+              <div class="labels-emails">
+                <label for="gestoresEmails">E-mails do gestor de expedição</label>
+                <input id="gestoresEmails" type="text" placeholder="separados por vírgula" />
+                <p class="labels-hint">Os PDFs serão compartilhados com os e-mails listados. Se houver mais de um, você poderá escolher durante o envio.</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- atualiza a interface da aba de etiquetas Shopee com cabeçalho destacado, área de upload por arrastar e soltar e botão iniciar inspirado no layout de referência
- reposiciona campos de loja, opção de debug, resultados, log e e-mails em cards coerentes com o novo visual

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d41909b5a4832a93d08fb45b5a1165