### PR TITLE
Registrar quantidade de etiquetas processadas

### DIFF
--- a/etiquetas-shopee.html
+++ b/etiquetas-shopee.html
@@ -638,6 +638,11 @@
         const contadorFinalMeta = Number.isFinite(meta.contadorFinal)
           ? Math.floor(meta.contadorFinal)
           : null;
+        const quantidadeMeta = Number.isFinite(meta.quantidade)
+          ? Number(meta.quantidade)
+          : Number.isFinite(meta.totalPaginas)
+            ? Number(meta.totalPaginas)
+            : null;
         const lojaMeta = typeof meta.loja === 'string' ? meta.loja.trim() : '';
         const dataCurtaMeta = typeof meta.dataProcessamento === 'string' ? meta.dataProcessamento.trim() : '';
         const docPayload = {
@@ -659,6 +664,9 @@
         }
         if (Number.isFinite(meta.totalPaginasOrigem)) {
           docPayload.totalPaginasOrigem = Number(meta.totalPaginasOrigem);
+        }
+        if (quantidadeMeta !== null) {
+          docPayload.quantidade = quantidadeMeta;
         }
         if (contadorInicialMeta !== null) {
           docPayload.contadorInicial = contadorInicialMeta;
@@ -690,6 +698,9 @@
         }
         if (Number.isFinite(meta.totalPaginasOrigem)) {
           resumo.totalPaginasOrigem = Number(meta.totalPaginasOrigem);
+        }
+        if (quantidadeMeta !== null) {
+          resumo.quantidade = quantidadeMeta;
         }
         if (contadorInicialMeta !== null) {
           resumo.contadorInicial = contadorInicialMeta;

--- a/expedicao.html
+++ b/expedicao.html
@@ -1299,6 +1299,7 @@
       const createdDateStr = createdDate
         ? createdDate.toLocaleString('pt-BR')
         : 'Data desconhecida';
+      const quantidadeEtiquetas = getResumoQuantidade(data);
       const div = document.createElement('div');
       div.className = `pdf-card expedicao-card expedicao-pdf-card ticket-card${attention ? ' expedicao-card--attention' : ''}`;
       div.innerHTML = `
@@ -1329,7 +1330,7 @@
         </div>
         <div class="expedicao-pdf-body">
           <p class="expedicao-pdf-name" title="${name}">${name}</p>
-          <p class="expedicao-pdf-quantity">Quantidade: ${data.quantidade || 0} etiquetas</p>
+          <p class="expedicao-pdf-quantity">Quantidade: ${quantidadeEtiquetas} etiquetas</p>
         </div>`;
       div.dataset.ownerUid = data.ownerUid || '';
       div.dataset.ownerEmail = data.ownerEmail || '';


### PR DESCRIPTION
## Summary
- registrar a quantidade de etiquetas gerada no envio do PDF da aba Shopee
- aproveitar o valor salvo para exibir o total correto em cada card de etiqueta na tela de expedição

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d41a4a0490832a93ce7a3075e6108e