### PR TITLE
Adjust pickup label info box position

### DIFF
--- a/etiquetas-shopee.html
+++ b/etiquetas-shopee.html
@@ -1344,7 +1344,7 @@
           const PANX = 0.50;
           const PANY = 0.39;
           const GAP = 0;
-          const INFO_BOX_SHIFT = 4 * CM;
+          const INFO_BOX_SHIFT = 5 * CM;
 
           async function drawEmbeddedFillWidth(dstPage, srcPage, cropBox, x, y, w, h) {
             const embedded = cropBox


### PR DESCRIPTION
## Summary
- increase the vertical offset used for the pickup label info box so the label number and store name render lower on the page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6960ddfc0832aa62155c3fb7e09f9