### PR TITLE
Add PDF export for selected withdrawals

### DIFF
--- a/saques.html
+++ b/saques.html
@@ -114,7 +114,10 @@
             <option value="0.04">4%</option>
             <option value="0.05">5%</option>
           </select>
-          <button onclick="marcarComoPagoSelecionados()" class="h-10 px-4 rounded-xl bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700">Marcar como Pago</button>
+          <div class="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+            <button onclick="marcarComoPagoSelecionados()" class="h-10 px-4 rounded-xl bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700">Marcar como Pago</button>
+            <button onclick="exportarSelecionadosPDF()" class="h-10 px-4 rounded-xl border border-indigo-600 text-indigo-600 text-sm font-medium hover:bg-indigo-50">Exportar PDF</button>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add an action button to export selected withdrawals as PDF using the existing generator

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da85987474832a94a8c31183e8935d