### PR TITLE
Ajusta margens no PDF de fechamento de saques

### DIFF
--- a/saques.js
+++ b/saques.js
@@ -609,7 +609,7 @@ async function imprimirFechamento() {
     head: [['Data', 'Loja', 'Saque']],
     body: saquesBody,
     foot: saquesFoot,
-    margin: { left: margin, right: margin },
+    margin: { top: 32, left: margin, right: margin },
     styles: {
       font: 'Roboto',
       fontSize: 12,
@@ -665,7 +665,7 @@ async function imprimirFechamento() {
     head: [['Data', '%', 'Valor', 'Status']],
     body: comissoesBody,
     foot: comissoesFoot,
-    margin: { left: margin, right: margin },
+    margin: { top: 32, left: margin, right: margin },
     styles: {
       font: 'Roboto',
       fontSize: 12,


### PR DESCRIPTION
## Summary
- ajusta a margem superior das tabelas do relatório de fechamento de saques para evitar a sobreposição do cabeçalho ao gerar páginas adicionais

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da89c3ee78832aa85202eaa84ed332