### PR TITLE
Ajusta exportação em PDF de produtos vendidos

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -4129,18 +4129,18 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
           );
           return `
             <tr class="pdf-row">
-              <td style="padding:8px;border:1px solid #ddd;">
+              <td class="col-sku">
                 <strong>${escapeHtml(item.sku)}</strong>
-                <div style="margin-top:4px;font-size:11px;color:#555;">
+                <div style="margin-top:2px;font-size:10px;color:#555;">
                   Grupo: ${associados || '-'}
                 </div>
               </td>
-              <td style="padding:8px;border:1px solid #ddd;">${vendidos || '-'}</td>
-              <td style="padding:8px;border:1px solid #ddd;text-align:right;">${item.total.toLocaleString(
+              <td class="col-detalhes">${vendidos || '-'}</td>
+              <td class="col-quantidade">${item.total.toLocaleString(
                 'pt-BR',
               )}</td>
-              <td style="padding:8px;border:1px solid #ddd;text-align:right;">${valorLiquido}</td>
-              <td style="padding:8px;border:1px solid #ddd;">${usuarios || '-'}</td>
+              <td class="col-valor">${valorLiquido}</td>
+              <td class="col-usuarios">${usuarios || '-'}</td>
             </tr>`;
         })
         .join('');
@@ -4150,33 +4150,48 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
       wrapper.innerHTML = `
         <div style="font-family: 'Inter', Arial, sans-serif;">
           <h2 style="margin-bottom:8px;">Produtos Vendidos</h2>
-          <p style="margin-top:0;margin-bottom:16px;font-size:12px;color:#555;">
+          <p style="margin-top:0;margin-bottom:16px;font-size:11px;color:#555;">
             Relatório gerado em ${dataGeracao}
           </p>
           <style>
             .pdf-table {
               width: 100%;
               border-collapse: collapse;
-              font-size: 12px;
+              font-size: 11px;
+              table-layout: fixed;
             }
             .pdf-table th,
             .pdf-table td {
               page-break-inside: avoid;
               break-inside: avoid;
+              padding: 6px;
+              border: 1px solid #ddd;
+              vertical-align: top;
+              word-wrap: break-word;
+              word-break: break-word;
             }
-            .pdf-row {
-              page-break-inside: avoid;
-              break-inside: avoid;
+            .pdf-table thead th {
+              background: #f3f4f6;
+              color: #1f2937;
             }
+            .pdf-table tbody td strong {
+              display: block;
+              margin-bottom: 4px;
+            }
+            .pdf-table .col-sku { width: 18%; }
+            .pdf-table .col-detalhes { width: 28%; }
+            .pdf-table .col-quantidade { width: 14%; text-align: right; }
+            .pdf-table .col-valor { width: 16%; text-align: right; }
+            .pdf-table .col-usuarios { width: 24%; }
           </style>
-          <table class="pdf-table" style="width:100%;border-collapse:collapse;font-size:12px;">
+          <table class="pdf-table">
             <thead>
               <tr class="pdf-row">
-                <th style="padding:8px;border:1px solid #ddd;background:#f3f4f6;text-align:left;">SKU Principal</th>
-                <th style="padding:8px;border:1px solid #ddd;background:#f3f4f6;text-align:left;">Detalhe dos SKUs Vendidos</th>
-                <th style="padding:8px;border:1px solid #ddd;background:#f3f4f6;text-align:right;">Quantidade Vendida</th>
-                <th style="padding:8px;border:1px solid #ddd;background:#f3f4f6;text-align:right;">Valor Líquido</th>
-                <th style="padding:8px;border:1px solid #ddd;background:#f3f4f6;text-align:left;">Usuários Responsáveis</th>
+                <th class="col-sku" style="text-align:left;">SKU Principal</th>
+                <th class="col-detalhes" style="text-align:left;">Detalhe dos SKUs Vendidos</th>
+                <th class="col-quantidade">Quantidade Vendida</th>
+                <th class="col-valor">Valor Líquido</th>
+                <th class="col-usuarios" style="text-align:left;">Usuários Responsáveis</th>
               </tr>
             </thead>
             <tbody>${linhas}</tbody>
@@ -4190,7 +4205,7 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
           .slice(0, 10)}.pdf`,
         image: { type: 'jpeg', quality: 0.98 },
         html2canvas: { scale: 2 },
-        jsPDF: { unit: 'cm', format: 'a4', orientation: 'landscape' },
+        jsPDF: { unit: 'cm', format: 'a4', orientation: 'portrait' },
         pagebreak: { mode: ['avoid-all', 'css', 'legacy'] },
       };
 


### PR DESCRIPTION
## Summary
- ajusta a tabela gerada para o PDF de produtos vendidos com estilos voltados para retrato
- define larguras fixas por coluna e alinhamentos para evitar quebra desordenada
- altera a orientação do jsPDF para retrato, conforme solicitado

## Testing
- no automated tests run

------
https://chatgpt.com/codex/tasks/task_e_68da965b6d20832ab6a5c844c0418dac