### PR TITLE
Add linked main SKU support

### DIFF
--- a/sku-associado.html
+++ b/sku-associado.html
@@ -1,56 +1,98 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="pt-BR">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>SKU Associado</title>
-  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/styles.css?v=20240826">
-</head>
-<body class="bg-gray-100 text-gray-800">
-  <div class="app-container">
-  <div id="sidebar-container"></div>
-  <div id="navbar-container"></div>
-  <main class="main-content p-4 space-y-4">
-    <div class="card">
-      <div class="card-header"><h2 class="text-xl font-bold">Cadastrar SKU Associado</h2></div>
-      <div class="card-body space-y-4">
-        <div class="grid gap-4 md:grid-cols-2">
-          <div>
-            <label for="skuPrincipal" class="block text-sm font-medium mb-1">SKU Principal</label>
-            <input id="skuPrincipal" class="w-full p-2 border rounded" placeholder="SKU principal" />
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SKU Associado</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="css/styles.css?v=20240826" />
+  </head>
+  <body class="bg-gray-100 text-gray-800">
+    <div class="app-container">
+      <div id="sidebar-container"></div>
+      <div id="navbar-container"></div>
+      <main class="main-content p-4 space-y-4">
+        <div class="card">
+          <div class="card-header">
+            <h2 class="text-xl font-bold">Cadastrar SKU Associado</h2>
           </div>
-          <div>
-            <label for="skuAssociados" class="block text-sm font-medium mb-1">SKUs Associados</label>
-            <input id="skuAssociados" class="w-full p-2 border rounded" placeholder="Separados por vírgula" />
+          <div class="card-body space-y-4">
+            <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              <div>
+                <label for="skuPrincipal" class="block text-sm font-medium mb-1"
+                  >SKU Principal</label
+                >
+                <input
+                  id="skuPrincipal"
+                  class="w-full p-2 border rounded"
+                  placeholder="SKU principal"
+                />
+              </div>
+              <div>
+                <label
+                  for="skusPrincipaisLinkados"
+                  class="block text-sm font-medium mb-1"
+                  >SKUs Principais Linkados</label
+                >
+                <input
+                  id="skusPrincipaisLinkados"
+                  class="w-full p-2 border rounded"
+                  placeholder="Separados por vírgula"
+                />
+              </div>
+              <div>
+                <label
+                  for="skuAssociados"
+                  class="block text-sm font-medium mb-1"
+                  >SKUs Associados</label
+                >
+                <input
+                  id="skuAssociados"
+                  class="w-full p-2 border rounded"
+                  placeholder="Separados por vírgula"
+                />
+              </div>
+            </div>
+            <button id="salvarSku" class="btn-primary">Salvar</button>
           </div>
         </div>
-        <button id="salvarSku" class="btn-primary">Salvar</button>
-      </div>
-    </div>
 
-    <div class="card">
-      <div class="card-header"><h3 class="text-lg font-bold">SKUs Cadastrados</h3></div>
-      <div class="card-body overflow-x-auto">
-        <table class="min-w-full text-sm" id="skuTable">
-          <thead>
-            <tr class="text-left">
-              <th class="px-2 py-1">SKU Principal</th>
-              <th class="px-2 py-1">Associados</th>
-              <th class="px-2 py-1">Ações</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
-      </div>
+        <div class="card">
+          <div class="card-header">
+            <h3 class="text-lg font-bold">SKUs Cadastrados</h3>
+          </div>
+          <div class="card-body overflow-x-auto">
+            <table class="min-w-full text-sm" id="skuTable">
+              <thead>
+                <tr class="text-left">
+                  <th class="px-2 py-1">SKU Principal</th>
+                  <th class="px-2 py-1">Principais Linkados</th>
+                  <th class="px-2 py-1">Associados</th>
+                  <th class="px-2 py-1">Ações</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </main>
+      <script type="module" src="firebase-config.js"></script>
+      <script type="module" src="sku-associado.js"></script>
+      <script>
+        window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';
+      </script>
+      <script src="shared.js"></script>
     </div>
-  </main>
-  <script type="module" src="firebase-config.js"></script>
-  <script type="module" src="sku-associado.js"></script>
-  <script>window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';</script>
-  <script src="shared.js"></script>
-  </div>
-</body>
+  </body>
 </html>

--- a/sku-associado.js
+++ b/sku-associado.js
@@ -22,7 +22,7 @@ const auth = getAuth(app);
 
 let editId = null;
 
-function parseAssociados(value) {
+function parseLista(value) {
   return value
     .split(',')
     .map((s) => s.trim())
@@ -38,6 +38,7 @@ async function carregarSkus() {
     const tr = document.createElement('tr');
     tr.innerHTML = `
       <td class="px-2 py-1">${data.skuPrincipal || docSnap.id}</td>
+      <td class="px-2 py-1">${(data.principaisLinkados || []).join(', ')}</td>
       <td class="px-2 py-1">${(data.associados || []).join(', ')}</td>
       <td class="px-2 py-1 space-x-2">
         <button class="text-blue-600" data-edit="${docSnap.id}">Editar</button>
@@ -51,12 +52,16 @@ async function carregarSkus() {
 async function salvarSku() {
   const principalEl = document.getElementById('skuPrincipal');
   const associadosEl = document.getElementById('skuAssociados');
+  const principaisLinkadosEl = document.getElementById(
+    'skusPrincipaisLinkados',
+  );
   const skuPrincipal = principalEl.value.trim();
   if (!skuPrincipal) {
     alert('Informe o SKU principal');
     return;
   }
-  const associados = parseAssociados(associadosEl.value);
+  const associados = parseLista(associadosEl.value);
+  const principaisLinkados = parseLista(principaisLinkadosEl.value);
   const id = editId && editId !== skuPrincipal ? editId : skuPrincipal;
   if (editId && editId !== skuPrincipal) {
     await deleteDoc(doc(db, 'skuAssociado', editId));
@@ -64,9 +69,11 @@ async function salvarSku() {
   await setDoc(doc(db, 'skuAssociado', skuPrincipal), {
     skuPrincipal,
     associados,
+    principaisLinkados,
   });
   principalEl.value = '';
   associadosEl.value = '';
+  principaisLinkadosEl.value = '';
   editId = null;
   await carregarSkus();
 }
@@ -76,6 +83,9 @@ function preencherFormulario(id, data) {
   document.getElementById('skuAssociados').value = (data.associados || []).join(
     ', ',
   );
+  document.getElementById('skusPrincipaisLinkados').value = (
+    data.principaisLinkados || []
+  ).join(', ');
   editId = id;
 }
 


### PR DESCRIPTION
## Summary
- add a field to register linked main SKUs when creating associations
- store and render linked main SKU data alongside associated SKUs
- ensure edit flows populate the new linked main SKU input

## Testing
- npx prettier --write sku-associado.html sku-associado.js

------
https://chatgpt.com/codex/tasks/task_e_68daafef6c80832a836cdd5e92ff1af4