### PR TITLE
Add support for linking primary SKUs

### DIFF
--- a/sku-associado.html
+++ b/sku-associado.html
@@ -1,56 +1,102 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="pt-BR">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>SKU Associado</title>
-  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/styles.css?v=20240826">
-</head>
-<body class="bg-gray-100 text-gray-800">
-  <div class="app-container">
-  <div id="sidebar-container"></div>
-  <div id="navbar-container"></div>
-  <main class="main-content p-4 space-y-4">
-    <div class="card">
-      <div class="card-header"><h2 class="text-xl font-bold">Cadastrar SKU Associado</h2></div>
-      <div class="card-body space-y-4">
-        <div class="grid gap-4 md:grid-cols-2">
-          <div>
-            <label for="skuPrincipal" class="block text-sm font-medium mb-1">SKU Principal</label>
-            <input id="skuPrincipal" class="w-full p-2 border rounded" placeholder="SKU principal" />
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SKU Associado</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="css/styles.css?v=20240826" />
+  </head>
+  <body class="bg-gray-100 text-gray-800">
+    <div class="app-container">
+      <div id="sidebar-container"></div>
+      <div id="navbar-container"></div>
+      <main class="main-content p-4 space-y-4">
+        <div class="card">
+          <div class="card-header">
+            <h2 class="text-xl font-bold">Cadastrar SKU Associado</h2>
           </div>
-          <div>
-            <label for="skuAssociados" class="block text-sm font-medium mb-1">SKUs Associados</label>
-            <input id="skuAssociados" class="w-full p-2 border rounded" placeholder="Separados por vírgula" />
+          <div class="card-body space-y-4">
+            <div class="grid gap-4 md:grid-cols-2">
+              <div>
+                <label for="skuPrincipal" class="block text-sm font-medium mb-1"
+                  >SKU Principal</label
+                >
+                <input
+                  id="skuPrincipal"
+                  class="w-full p-2 border rounded"
+                  placeholder="SKU principal"
+                />
+              </div>
+              <div>
+                <label
+                  for="skuAssociados"
+                  class="block text-sm font-medium mb-1"
+                  >SKUs Associados</label
+                >
+                <input
+                  id="skuAssociados"
+                  class="w-full p-2 border rounded"
+                  placeholder="Separados por vírgula"
+                />
+              </div>
+              <div class="md:col-span-2">
+                <label
+                  for="skusPrincipaisVinculados"
+                  class="block text-sm font-medium mb-1"
+                  >SKUs Principais Vinculados</label
+                >
+                <select
+                  id="skusPrincipaisVinculados"
+                  class="w-full p-2 border rounded h-32"
+                  multiple
+                ></select>
+                <p class="text-xs text-gray-500 mt-1">
+                  Selecione outros SKUs principais que representam a mesma peça
+                  em diferentes variações.
+                </p>
+              </div>
+            </div>
+            <button id="salvarSku" class="btn-primary">Salvar</button>
           </div>
         </div>
-        <button id="salvarSku" class="btn-primary">Salvar</button>
-      </div>
-    </div>
 
-    <div class="card">
-      <div class="card-header"><h3 class="text-lg font-bold">SKUs Cadastrados</h3></div>
-      <div class="card-body overflow-x-auto">
-        <table class="min-w-full text-sm" id="skuTable">
-          <thead>
-            <tr class="text-left">
-              <th class="px-2 py-1">SKU Principal</th>
-              <th class="px-2 py-1">Associados</th>
-              <th class="px-2 py-1">Ações</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
-      </div>
+        <div class="card">
+          <div class="card-header">
+            <h3 class="text-lg font-bold">SKUs Cadastrados</h3>
+          </div>
+          <div class="card-body overflow-x-auto">
+            <table class="min-w-full text-sm" id="skuTable">
+              <thead>
+                <tr class="text-left">
+                  <th class="px-2 py-1">SKU Principal</th>
+                  <th class="px-2 py-1">Associados</th>
+                  <th class="px-2 py-1">Principais Vinculados</th>
+                  <th class="px-2 py-1">Ações</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </main>
+      <script type="module" src="firebase-config.js"></script>
+      <script type="module" src="sku-associado.js"></script>
+      <script>
+        window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';
+      </script>
+      <script src="shared.js"></script>
     </div>
-  </main>
-  <script type="module" src="firebase-config.js"></script>
-  <script type="module" src="sku-associado.js"></script>
-  <script>window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';</script>
-  <script src="shared.js"></script>
-  </div>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- add a multi-select input to link additional primary SKUs when registering associations
- cache Firestore records to refresh the table and populate linked principal options consistently

## Testing
- npx prettier --write sku-associado.html sku-associado.js

------
https://chatgpt.com/codex/tasks/task_e_68daafef6c80832a836cdd5e92ff1af4