### PR TITLE
Ajusta totais de principais vinculados na aba de produtos vendidos

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -4140,7 +4140,10 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
         }
 
         produtosVendidosResumo = Array.from(agregados.values()).map((item) => {
-          const vendidosPorSku = Array.from(item.vendidosPorSku.entries()).sort(
+          const vendidosPorSkuEntries = Array.from(
+            item.vendidosPorSku.entries(),
+          );
+          const vendidosPorSku = vendidosPorSkuEntries.sort(
             (a, b) => a[0].localeCompare(b[0], 'pt-BR'),
           );
           const grupoCompleto = Array.from(item.grupoOficial.values()).sort((
@@ -4161,7 +4164,24 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
           const principaisVinculadosDetalhes = principaisVinculados.map(
             (sku) => ({
               sku,
-              quantidade: mapaQuantidadesPrincipais.get(sku) || 0,
+              quantidade: (() => {
+                const grupoPrincipalVinculado = grupoPorPrincipal.get(sku);
+                if (grupoPrincipalVinculado && grupoPrincipalVinculado.size) {
+                  const grupoNormalizado = new Set(
+                    Array.from(grupoPrincipalVinculado.values()).map(
+                      (skuGrupo) => normalizarSku(skuGrupo),
+                    ),
+                  );
+                  let acumulado = 0;
+                  vendidosPorSkuEntries.forEach(([skuVenda, quantidade]) => {
+                    if (grupoNormalizado.has(normalizarSku(skuVenda))) {
+                      acumulado += quantidade;
+                    }
+                  });
+                  if (acumulado) return acumulado;
+                }
+                return mapaQuantidadesPrincipais.get(sku) || 0;
+              })(),
             }),
           );
           const todosSkus = Array.from(


### PR DESCRIPTION
## Summary
- soma as quantidades dos principais vinculados considerando todos os SKUs associados
- mantém um fallback para o total previamente acumulado quando o grupo não está disponível

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daca0372cc832a8f4e272c356c74ea