### PR TITLE
Adicionar filtros avançados na aba de problemas

### DIFF
--- a/problemas.html
+++ b/problemas.html
@@ -128,11 +128,7 @@
         </form>
         <div class="card space-y-4 lg:col-span-1 lg:sticky lg:top-4">
           <h2 class="text-lg font-semibold text-slate-700">Filtros</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div class="flex flex-col">
-              <label for="filtroData" class="block text-sm font-medium text-slate-600">Data</label>
-              <input type="date" id="filtroData" class="mt-1 w-full rounded-xl border-slate-300 focus:border-violet-500 focus:ring-violet-500">
-            </div>
+          <div class="space-y-4">
             <div class="flex flex-col">
               <label for="filtroStatus" class="block text-sm font-medium text-slate-600">Status</label>
               <select id="filtroStatus" class="mt-1 w-full rounded-xl border-slate-300 focus:border-violet-500 focus:ring-violet-500">
@@ -142,6 +138,20 @@
                 <option value="RESOLVIDO">Resolvido</option>
               </select>
             </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div class="flex flex-col">
+                <label for="filtroDataInicio" class="block text-sm font-medium text-slate-600">Data inicial</label>
+                <input type="date" id="filtroDataInicio" class="mt-1 w-full rounded-xl border-slate-300 focus:border-violet-500 focus:ring-violet-500">
+              </div>
+              <div class="flex flex-col">
+                <label for="filtroDataFim" class="block text-sm font-medium text-slate-600">Data final</label>
+                <input type="date" id="filtroDataFim" class="mt-1 w-full rounded-xl border-slate-300 focus:border-violet-500 focus:ring-violet-500">
+              </div>
+            </div>
+            <div class="flex flex-col">
+              <label for="searchPecas" class="block text-sm font-medium text-slate-600">Buscar</label>
+              <input type="text" id="searchPecas" placeholder="Buscar por nome ou número do pedido" class="mt-1 w-full rounded-xl border-slate-300 focus:border-violet-500 focus:ring-violet-500">
+            </div>
           </div>
           <div class="flex justify-end">
             <button id="limparFiltros" class="px-4 py-2 rounded-xl border border-slate-300 text-slate-700 w-full sm:w-auto">Limpar</button>
@@ -149,8 +159,7 @@
         </div>
       </div>
       <div class="card overflow-x-auto space-y-4">
-        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-          <input type="text" id="searchPecas" placeholder="Pesquisar..." class="w-full sm:w-64 rounded-xl border-slate-300 focus:border-violet-500 focus:ring-violet-500">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-end gap-2">
           <button id="exportCsv" class="px-4 py-2 rounded-xl border border-slate-300 text-slate-700 w-full sm:w-auto">Exportar CSV</button>
         </div>
         <table class="min-w-full text-sm data-table">

--- a/problemas.js
+++ b/problemas.js
@@ -39,7 +39,10 @@ onAuthStateChanged(auth, (user) => {
     .getElementById('reembolsosForm')
     ?.addEventListener('submit', salvarReembolso);
   document
-    .getElementById('filtroData')
+    .getElementById('filtroDataInicio')
+    ?.addEventListener('change', renderPecas);
+  document
+    .getElementById('filtroDataFim')
     ?.addEventListener('change', renderPecas);
   document
     .getElementById('filtroStatus')
@@ -65,10 +68,12 @@ onAuthStateChanged(auth, (user) => {
   });
   document.getElementById('limparFiltros')?.addEventListener('click', (ev) => {
     ev.preventDefault();
-    const fd = document.getElementById('filtroData');
     const fs = document.getElementById('filtroStatus');
     const search = document.getElementById('searchPecas');
-    if (fd) fd.value = '';
+    const fdInicio = document.getElementById('filtroDataInicio');
+    const fdFim = document.getElementById('filtroDataFim');
+    if (fdInicio) fdInicio.value = '';
+    if (fdFim) fdFim.value = '';
     if (fs) fs.value = '';
     if (search) search.value = '';
     renderPecas();
@@ -121,12 +126,16 @@ function renderPecas() {
   const tbody = document.getElementById('pecasTableBody');
   if (!tbody) return;
   tbody.innerHTML = '';
-  const filtroData = document.getElementById('filtroData')?.value;
+  const filtroDataInicio = document.getElementById('filtroDataInicio')?.value;
+  const filtroDataFim = document.getElementById('filtroDataFim')?.value;
   const filtroStatus = document.getElementById('filtroStatus')?.value;
   const busca =
     document.getElementById('searchPecas')?.value.toLowerCase() || '';
   pecasFiltradas = pecasCache.filter((d) => {
-    const dataOk = filtroData ? d.data === filtroData : true;
+    const data = d.data || '';
+    const dataInicioOk = filtroDataInicio ? data >= filtroDataInicio : true;
+    const dataFimOk = filtroDataFim ? data <= filtroDataFim : true;
+    const dataOk = dataInicioOk && dataFimOk;
     const statusOk = filtroStatus ? d.status === filtroStatus : true;
     const searchOk = busca
       ? Object.values(d).some((v) => String(v).toLowerCase().includes(busca))


### PR DESCRIPTION
## Summary
- reorganize a seção de filtros da aba de Peças Faltantes na página de Problemas com status, período e busca por nome ou número
- ajustar o script de Problemas para considerar o novo intervalo de datas e limpar corretamente os filtros

## Testing
- not run (static front-end change)


------
https://chatgpt.com/codex/tasks/task_e_68dc1a4bf7a0832a8c693191a109ff95