### PR TITLE
Ajusta resumo do acompanhamento mensal

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -5134,6 +5134,8 @@ let uids = [];
             if (anoS !== anoFiltro || mesS !== mesFiltro) continue;
           }
           let dadosSaque = docS.data();
+          let saqueRegistrado = 0;
+          let possuiValorDireto = false;
           if (dadosSaque.encrypted) {
             try {
               const txt = await decryptString(dadosSaque.encrypted, getPassphrase() || `chave-${dadosSaque.uid || usuarioLogado.uid}`);
@@ -5143,11 +5145,18 @@ let uids = [];
               continue;
             }
           }
-          totalSaques += dadosSaque.valorTotal || dadosSaque.valor || 0;
+          if (dadosSaque.valorTotal != null) {
+            saqueRegistrado = parseFloat(dadosSaque.valorTotal) || 0;
+            possuiValorDireto = true;
+          } else if (dadosSaque.valor != null) {
+            saqueRegistrado = parseFloat(dadosSaque.valor) || 0;
+            possuiValorDireto = true;
+          }
           const ownerUidSaques = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase()) ? docS.ref.parent.parent.id : usuarioLogado.uid;
           try {
             const subRefSaque = db.collection(`uid/${ownerUidSaques}/saques/${docS.id}/lojas`);
             const subSnapSaque = await subRefSaque.get();
+            let totalLojasDoc = 0;
             for (const lojaDoc of subSnapSaque.docs) {
               let dadosLoja = lojaDoc.data();
               if (dadosLoja.encrypted) {
@@ -5160,12 +5169,17 @@ let uids = [];
                 }
               }
               const valorLoja = parseFloat(dadosLoja.valor) || 0;
+              totalLojasDoc += valorLoja;
               const comissaoPct = parseFloat(dadosLoja.comissao) || 0;
               if (comissaoPct) totalComissao += (valorLoja * comissaoPct / 100);
+            }
+            if (!possuiValorDireto) {
+              saqueRegistrado = totalLojasDoc;
             }
           } catch (e) {
             console.error('Erro ao carregar comissão dos saques', e);
           }
+          totalSaques += saqueRegistrado;
         }
       } catch (e) {
         console.error('Erro ao carregar saques', e);
@@ -5209,7 +5223,6 @@ resumoEl.innerHTML = `
    <div class="resumo-card"><h4>Total Bruto</h4><p>R$ ${totais.bruto.toLocaleString('pt-BR')}</p>${resumoBrutoMeta}</div>
         <div class="resumo-card"><h4>Total Líquido</h4><p>R$ ${totais.liquido.toLocaleString('pt-BR')}</p>${resumoLiquidoMeta}</div>
         <div class="resumo-card"><h4>Total Vendido</h4><p>${totais.vendas}</p><button class="btn btn-secondary btn-sm" style="margin-top:0.5rem" onclick="mostrarDetalhesVendas()">Ver mais</button></div>
-        <div class="resumo-card"><h4>Total Sobra Esperada</h4><p>R$ ${totais.sobra.toLocaleString('pt-BR')}</p><button class="btn btn-secondary btn-sm" style="margin-top:0.5rem" onclick="mostrarDetalhesSobra()">Ver mais</button></div>
         <div class="resumo-card"><h4>Total Saques</h4><p>R$ ${totalSaques.toLocaleString('pt-BR')}</p></div>
         <div class="resumo-card"><h4>Comissão do Mês</h4><p>R$ ${totalComissao.toLocaleString('pt-BR')}</p></div>
         <div class="resumo-card"><h4>Ticket Médio</h4><p>R$ ${ticket.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</p></div>`;


### PR DESCRIPTION
## Summary
- remove o card de Total Sobra Esperada do acompanhamento mensal
- ajusta o cálculo exibido para Total de Saques usando apenas os registros do mês selecionado

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68dd0949ab48832abbc1727673f60146