### PR TITLE
Atualiza cálculo de saques no acompanhamento mensal

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -5057,12 +5057,46 @@ let uids = [];
       const { decryptString } = await import('./crypto.js');
 
       const filtroMes = document.getElementById('filtroMesAcompanhamento')?.value;
+      const normalizarMes = valor => {
+        if (!valor) return '';
+        if (valor instanceof Date) {
+          return `${valor.getFullYear()}-${String(valor.getMonth() + 1).padStart(2, '0')}`;
+        }
+        if (typeof valor?.toDate === 'function') {
+          const dt = valor.toDate();
+          return `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}`;
+        }
+        const texto = String(valor);
+        const match = texto.match(/(\d{4})[-/_](\d{1,2})/);
+        if (match) {
+          return `${match[1]}-${match[2].padStart(2, '0')}`;
+        }
+        return '';
+      };
+      const extrairMesReferencia = (docId, dadosSaque) => {
+        const candidatos = [];
+        if (docId) candidatos.push(docId);
+        const campos = ['anoMes', 'mesReferencia', 'mes', 'competencia', 'data', 'dataReferencia'];
+        for (const campo of campos) {
+          if (dadosSaque && Object.prototype.hasOwnProperty.call(dadosSaque, campo)) {
+            const normalizado = normalizarMes(dadosSaque[campo]);
+            if (normalizado) return normalizado;
+            if (typeof dadosSaque[campo] === 'string') candidatos.push(dadosSaque[campo]);
+          }
+        }
+        for (const candidato of candidatos) {
+          const normalizado = normalizarMes(candidato);
+          if (normalizado) return normalizado;
+        }
+        return '';
+      };
       let dados = [];
-            dadosAcompanhamento = [];
+      dadosAcompanhamento = [];
       sobraPorSku = {};
       resumoSku = {};
       let totalBruto = 0, totalLiquido = 0, totalVendas = 0, totalSobra = 0;
       let totalSaques = 0, totalComissao = 0;
+      const ownerUidsFiltro = new Set();
 
       for (const doc of snap.docs) {
         if (filtroMes) {
@@ -5074,6 +5108,7 @@ let uids = [];
   const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
           ? doc.ref.parent.parent.id
           : usuarioLogado.uid;
+        if (ownerUid) ownerUidsFiltro.add(ownerUid);
         const subRef = db.collection(`uid/${ownerUid}/faturamento/${doc.id}/lojas`);
         const subSnap = await subRef.get();
         let bruto = 0, liquido = 0, vendas = 0;
@@ -5119,56 +5154,107 @@ let uids = [];
         totalSobra += sobraDia;
       }
 
-      try {
-        let refSaques;
-        if (["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())) {
-          refSaques = db.collectionGroup('saques');
-        } else {
-          refSaques = db.collection('uid').doc(usuarioLogado.uid).collection('saques');
-        }
-        const snapSaques = await refSaques.get();
-        for (const docS of snapSaques.docs) {
-          if (filtroMes) {
-            const [anoFiltro, mesFiltro] = filtroMes.split('-');
-            const [anoS, mesS] = docS.id.split('-');
-            if (anoS !== anoFiltro || mesS !== mesFiltro) continue;
-          }
-          let dadosSaque = docS.data();
-          if (dadosSaque.encrypted) {
-            try {
-              const txt = await decryptString(dadosSaque.encrypted, getPassphrase() || `chave-${dadosSaque.uid || usuarioLogado.uid}`);
-              dadosSaque = JSON.parse(txt);
-            } catch (e) {
-              console.error('Erro ao descriptografar saque', e);
-              continue;
-            }
-          }
-          totalSaques += dadosSaque.valorTotal || dadosSaque.valor || 0;
-          const ownerUidSaques = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase()) ? docS.ref.parent.parent.id : usuarioLogado.uid;
+      if (!ownerUidsFiltro.size && usuarioLogado?.uid) ownerUidsFiltro.add(usuarioLogado.uid);
+      const mesSelecionado = filtroMes || (dados.length ? normalizarMes(dados[0].data) : '');
+      let encontrouSaquesMensais = false;
+      if (mesSelecionado && ownerUidsFiltro.size) {
+        for (const uidFiltro of ownerUidsFiltro) {
           try {
-            const subRefSaque = db.collection(`uid/${ownerUidSaques}/saques/${docS.id}/lojas`);
-            const subSnapSaque = await subRefSaque.get();
-            for (const lojaDoc of subSnapSaque.docs) {
-              let dadosLoja = lojaDoc.data();
-              if (dadosLoja.encrypted) {
-                try {
-                  const txtLoja = await decryptString(dadosLoja.encrypted, getPassphrase() || `chave-${dadosSaque.uid || ownerUidSaques}`);
-                  dadosLoja = JSON.parse(txtLoja);
-                } catch (e) {
-                  console.error('Erro ao descriptografar loja saque', e);
-                  continue;
+            const resumoRef = db.collection('usuarios').doc(uidFiltro).collection('comissoes').doc(mesSelecionado);
+            const resumoSnap = await resumoRef.get();
+            let usouResumo = false;
+            try {
+              const saquesSnap = await resumoRef.collection('saques').get();
+              if (!saquesSnap.empty) {
+                encontrouSaquesMensais = true;
+                for (const saqueDoc of saquesSnap.docs) {
+                  const dadosMensais = saqueDoc.data() || {};
+                  const valorSaque = Number(dadosMensais.valor) || 0;
+                  totalSaques += valorSaque;
+                  const percentualPago = Number(dadosMensais.percentualPago);
+                  if (Number.isFinite(percentualPago) && percentualPago > 0) {
+                    totalComissao += valorSaque * percentualPago;
+                  } else {
+                    const comissaoPaga = Number(dadosMensais.comissaoPaga);
+                    if (Number.isFinite(comissaoPaga)) totalComissao += comissaoPaga;
+                  }
                 }
+                usouResumo = true;
               }
-              const valorLoja = parseFloat(dadosLoja.valor) || 0;
-              const comissaoPct = parseFloat(dadosLoja.comissao) || 0;
-              if (comissaoPct) totalComissao += (valorLoja * comissaoPct / 100);
+            } catch (e) {
+              console.error('Erro ao carregar saques mensais detalhados', e);
+            }
+            if (!usouResumo && resumoSnap.exists) {
+              const dadosResumo = resumoSnap.data() || {};
+              const totalSacadoResumo = Number(dadosResumo.totalSacado);
+              if (Number.isFinite(totalSacadoResumo)) {
+                totalSaques += totalSacadoResumo;
+                encontrouSaquesMensais = true;
+              }
+              const comissaoResumo = dadosResumo.comissaoJaPaga ?? dadosResumo.comissaoPrevista;
+              const comissaoNumero = Number(comissaoResumo);
+              if (Number.isFinite(comissaoNumero)) {
+                totalComissao += comissaoNumero;
+                encontrouSaquesMensais = true;
+              }
             }
           } catch (e) {
-            console.error('Erro ao carregar comissão dos saques', e);
+            console.error('Erro ao carregar resumo de saques mensais', e);
           }
         }
-      } catch (e) {
-        console.error('Erro ao carregar saques', e);
+      }
+      if (!encontrouSaquesMensais) {
+        try {
+          let refSaques;
+          if (["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())) {
+            refSaques = db.collectionGroup('saques');
+          } else {
+            refSaques = db.collection('uid').doc(usuarioLogado.uid).collection('saques');
+          }
+          const snapSaques = await refSaques.get();
+          for (const docS of snapSaques.docs) {
+            const ownerUidSaques = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase()) ? docS.ref.parent.parent.id : usuarioLogado.uid;
+            if (!ownerUidSaques) continue;
+            if (ownerUidsFiltro.size && !ownerUidsFiltro.has(ownerUidSaques)) continue;
+            let dadosSaque = docS.data();
+            if (dadosSaque.encrypted) {
+              try {
+                const txt = await decryptString(dadosSaque.encrypted, getPassphrase() || `chave-${dadosSaque.uid || ownerUidSaques || usuarioLogado.uid}`);
+                dadosSaque = JSON.parse(txt);
+              } catch (e) {
+                console.error('Erro ao descriptografar saque', e);
+                continue;
+              }
+            }
+            const mesDoc = extrairMesReferencia(docS.id, dadosSaque);
+            if (mesSelecionado && mesDoc && mesDoc !== mesSelecionado) continue;
+            if (mesSelecionado && !mesDoc) continue;
+            totalSaques += Number(dadosSaque.valorTotal || dadosSaque.valor || 0) || 0;
+            try {
+              const subRefSaque = db.collection(`uid/${ownerUidSaques}/saques/${docS.id}/lojas`);
+              const subSnapSaque = await subRefSaque.get();
+              for (const lojaDoc of subSnapSaque.docs) {
+                let dadosLoja = lojaDoc.data();
+                if (dadosLoja.encrypted) {
+                  try {
+                    const txtLoja = await decryptString(dadosLoja.encrypted, getPassphrase() || `chave-${dadosSaque.uid || ownerUidSaques}`);
+                    dadosLoja = JSON.parse(txtLoja);
+                  } catch (e) {
+                    console.error('Erro ao descriptografar loja saque', e);
+                    continue;
+                  }
+                }
+                const valorLoja = parseFloat(dadosLoja.valor) || 0;
+                const comissaoPct = parseFloat(dadosLoja.comissao) || 0;
+                if (comissaoPct) totalComissao += (valorLoja * comissaoPct / 100);
+              }
+            } catch (e) {
+              console.error('Erro ao carregar comissão dos saques', e);
+            }
+          }
+        } catch (e) {
+          console.error('Erro ao carregar saques', e);
+        }
       }
       totalSaquesAcompanhamento = totalSaques;
       totalComissaoAcompanhamento = totalComissao;
@@ -5209,7 +5295,6 @@ resumoEl.innerHTML = `
    <div class="resumo-card"><h4>Total Bruto</h4><p>R$ ${totais.bruto.toLocaleString('pt-BR')}</p>${resumoBrutoMeta}</div>
         <div class="resumo-card"><h4>Total Líquido</h4><p>R$ ${totais.liquido.toLocaleString('pt-BR')}</p>${resumoLiquidoMeta}</div>
         <div class="resumo-card"><h4>Total Vendido</h4><p>${totais.vendas}</p><button class="btn btn-secondary btn-sm" style="margin-top:0.5rem" onclick="mostrarDetalhesVendas()">Ver mais</button></div>
-        <div class="resumo-card"><h4>Total Sobra Esperada</h4><p>R$ ${totais.sobra.toLocaleString('pt-BR')}</p><button class="btn btn-secondary btn-sm" style="margin-top:0.5rem" onclick="mostrarDetalhesSobra()">Ver mais</button></div>
         <div class="resumo-card"><h4>Total Saques</h4><p>R$ ${totalSaques.toLocaleString('pt-BR')}</p></div>
         <div class="resumo-card"><h4>Comissão do Mês</h4><p>R$ ${totalComissao.toLocaleString('pt-BR')}</p></div>
         <div class="resumo-card"><h4>Ticket Médio</h4><p>R$ ${ticket.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</p></div>`;


### PR DESCRIPTION
## Summary
- remove o card de "Total Sobra Esperada" do resumo do acompanhamento mensal
- soma os saques do mês selecionado usando os registros de comissões por usuário, com fallback para a estrutura legada e filtragem pelo mês
- adiciona utilitários para normalizar o mês de referência antes de consolidar os valores

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd0949ab48832abbc1727673f60146