### PR TITLE
Show top 10 SKUs in forecast views

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -4642,7 +4642,7 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
             return { sku, quantidade, bruto, sobra };
           })
           .sort((a, b) => b.quantidade - a.quantidade)
-          .slice(0, 5);
+          .slice(0, 10);
 
         if (!lista.length) {
           return '<p class="text-gray-500">Nenhuma previsão disponível.</p>';
@@ -4658,7 +4658,7 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
 
         return `
           <div class="overflow-x-auto">
-            <h4 class="font-bold mb-2 text-center">Top 5 SKUs projeção ${c.titulo}</h4>
+            <h4 class="font-bold mb-2 text-center">Top 10 SKUs projeção ${c.titulo}</h4>
             <table class="min-w-full text-sm text-left">
               <thead>
                 <tr>

--- a/dashboard-geral.js
+++ b/dashboard-geral.js
@@ -792,7 +792,7 @@ function renderPrevisaoTopSkus(container, previsao, precos, metas) {
       return { sku, quantidade, bruto };
     })
     .sort((a, b) => b.quantidade - a.quantidade)
-    .slice(0, 5);
+    .slice(0, 10);
 
   const cenarios = [
     { titulo: 'Pessimista', fator: 0.85 },
@@ -817,7 +817,7 @@ function renderPrevisaoTopSkus(container, previsao, precos, metas) {
 
       return `
         <div class="overflow-x-auto">
-          <h4 class="font-bold mb-2 text-center">Top 5 SKUs projeção ${c.titulo}</h4>
+          <h4 class="font-bold mb-2 text-center">Top 10 SKUs projeção ${c.titulo}</h4>
           <table class="min-w-full text-sm text-left">
             <thead>
               <tr>


### PR DESCRIPTION
## Summary
- expand the forecast projections to present the top 10 SKUs instead of only the top 5 across all scenarios
- update section titles to reflect the new top 10 SKU listings

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd0a8ee584832a8f34c6881c45a665