### PR TITLE
Add reusable alert banners for previsão PDF feedback

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -42,8 +42,26 @@
         <i class="fas fa-check-circle"></i>
         <h1>Vendedor Pro - Vendas e Faturamento</h1>
       </div>
-      
-      
+
+      <div class="alert-container">
+        <div id="alertSuccess" class="alert alert-success" role="status" style="display: none;">
+          <i class="fas fa-check-circle"></i>
+          <div class="alert-content"></div>
+          <button type="button" class="alert-close" aria-label="Fechar alerta de sucesso">
+            <i class="fas fa-times"></i>
+          </button>
+        </div>
+
+        <div id="alertError" class="alert alert-error" role="alert" style="display: none;">
+          <i class="fas fa-triangle-exclamation"></i>
+          <div class="alert-content"></div>
+          <button type="button" class="alert-close" aria-label="Fechar alerta de erro">
+            <i class="fas fa-times"></i>
+          </button>
+        </div>
+      </div>
+
+
       <div id="firebase-error" class="card" style="display: none;">
         <div class="card-header">
           <i class="fas fa-exclamation-triangle"></i>
@@ -1060,9 +1078,13 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
     
     function mostrarSucesso(mensagem) {
       const alerta = document.getElementById('alertSuccess');
+      if (!alerta) {
+        console.warn('Alerta de sucesso não encontrado na página.');
+        return;
+      }
       alerta.querySelector('.alert-content').textContent = mensagem;
       alerta.style.display = 'flex';
-      
+
       setTimeout(() => {
         alerta.style.display = 'none';
       }, 5000);
@@ -1070,13 +1092,26 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
 
     function mostrarErro(mensagem) {
       const alerta = document.getElementById('alertError');
+      if (!alerta) {
+        console.warn('Alerta de erro não encontrado na página.');
+        return;
+      }
       alerta.querySelector('.alert-content').textContent = mensagem;
       alerta.style.display = 'flex';
-      
+
       setTimeout(() => {
         alerta.style.display = 'none';
       }, 5000);
     }
+
+    document.addEventListener('click', (event) => {
+      if (event.target.closest('.alert-close')) {
+        const alerta = event.target.closest('.alert');
+        if (alerta) {
+          alerta.style.display = 'none';
+        }
+      }
+    });
 
     function toggleLoading(botao, texto) {
       const btnText = botao.querySelector('span') || botao;

--- a/css/styles.css
+++ b/css/styles.css
@@ -650,6 +650,38 @@ button:hover {
   align-items: center;
   gap: 12px;
 }
+
+.alert-container {
+  position: sticky;
+  top: calc(var(--navbar-height) + 1rem);
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.alert .alert-content {
+  flex: 1;
+}
+
+.alert-close {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  transition: background-color 0.2s ease;
+}
+
+.alert-close:hover,
+.alert-close:focus-visible {
+  background-color: rgba(17, 24, 39, 0.08);
+  outline: none;
+}
 .card-metric-novo {
   background: var(--secondary);
   border-radius: 1rem;


### PR DESCRIPTION
## Summary
- add success and error alert banners to the previsão interface so feedback elements exist in the DOM
- harden alert helper functions with null checks and manual close handling to avoid runtime errors
- style the shared alert container and close button for consistent presentation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd12160ba4832a85d4e6aeffb5fefd