### PR TITLE
Fix resumo snapshot existence check

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -5317,7 +5317,11 @@ let uids = [];
             } catch (e) {
               console.error('Erro ao carregar saques mensais detalhados', e);
             }
-            if (resumoSnap.exists()) {
+            const resumoExiste =
+              typeof resumoSnap.exists === 'function'
+                ? resumoSnap.exists()
+                : resumoSnap.exists;
+            if (resumoExiste) {
               let utilizouResumo = false;
               const dadosResumo = resumoSnap.data() || {};
               const totalSacadoResumo = Number(dadosResumo.totalSacado);


### PR DESCRIPTION
## Summary
- guard the resumo snapshot existence check in the acompanhamento loader so Firestore SDKs with a boolean `exists` property no longer throw

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd1291a3cc832a810243d3e8628b28