### PR TITLE
Fix PDF page breaks in acompanhamento export

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -5801,6 +5801,12 @@ function mostrarDetalhesSobra(data = sobraPorSku) {
 
       const clone = element.cloneNode(true);
       clone.style.marginTop = '16px';
+      clone.style.pageBreakInside = 'avoid';
+
+      clone.querySelectorAll('table, thead, tbody, tr, .resumo-grid, .resumo-card').forEach(el => {
+        el.style.breakInside = 'avoid';
+        el.style.pageBreakInside = 'avoid';
+      });
 
       const wrapper = document.createElement('div');
       wrapper.style.fontFamily = "'Inter', 'Segoe UI', sans-serif";
@@ -5822,7 +5828,18 @@ function mostrarDetalhesSobra(data = sobraPorSku) {
         </div>
       `;
 
+      const inlineStyles = document.createElement('style');
+      inlineStyles.textContent = `
+        * { box-sizing: border-box; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { padding: 8px 12px; }
+        .resumo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; }
+        .resumo-card { border: 1px solid #e5e7eb; border-radius: 12px; padding: 12px; background: #f9fafb; }
+        .resumo-card, tr { break-inside: avoid; page-break-inside: avoid; }
+      `;
+
       wrapper.appendChild(header);
+      wrapper.appendChild(inlineStyles);
       wrapper.appendChild(clone);
 
       const tempContainer = document.createElement('div');
@@ -5840,7 +5857,8 @@ function mostrarDetalhesSobra(data = sobraPorSku) {
         filename: 'acompanhamento.pdf',
         image: { type: 'jpeg', quality: 0.98 },
         html2canvas: { scale: 2 },
-        jsPDF: { unit: 'cm', format: 'a4', orientation: 'portrait' }
+        jsPDF: { unit: 'cm', format: 'a4', orientation: 'portrait' },
+        pagebreak: { mode: ['css', 'legacy', 'avoid-all'] }
       };
 
       try {


### PR DESCRIPTION
## Summary
- prevent PDF page breaks from cutting acompanhamento mensal table and summary cards
- inject inline print styles for the export wrapper to keep elements grouped and well formatted
- configure html2pdf pagebreak options to respect the new layout hints

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68dd14649194832aadcabc64bce8bb09