### PR TITLE
Fix blank forecast PDF generation

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -4883,7 +4883,7 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
       container.innerHTML = `<div class="grid grid-cols-1 md:grid-cols-3 gap-4">${tabelas}</div>`;
     }
 
-    function baixarPrevisaoPdf() {
+    async function baixarPrevisaoPdf() {
       const area = document.getElementById('previsaoResumoPdf');
       if (!area) {
         mostrarErro('Conteúdo de previsão indisponível para exportação.');
@@ -4945,20 +4945,16 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
       exportWrapper.appendChild(conteudo);
       document.body.appendChild(exportWrapper);
 
-      html2pdf()
-        .set(opt)
-        .from(exportWrapper)
-        .save()
-        .then(() => {
-          mostrarSucesso('Arquivo PDF gerado com sucesso.');
-        })
-        .catch(err => {
-          console.error('Erro ao gerar PDF da previsão', err);
-          mostrarErro('Não foi possível gerar o PDF da previsão.');
-        })
-        .finally(() => {
-          exportWrapper.remove();
-        });
+      try {
+        await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+        await html2pdf().set(opt).from(exportWrapper).save();
+        mostrarSucesso('Arquivo PDF gerado com sucesso.');
+      } catch (err) {
+        console.error('Erro ao gerar PDF da previsão', err);
+        mostrarErro('Não foi possível gerar o PDF da previsão.');
+      } finally {
+        exportWrapper.remove();
+      }
     }
 
     function gerarDatas(qtd, endDate = new Date()) {


### PR DESCRIPTION
## Summary
- ensure the Previsão PDF export waits for layout before invoking html2pdf
- convert the export function to async/await and improve error handling while cleaning up the temporary wrapper safely

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd1c8652f0832abd525dbc1511aeaa