### PR TITLE
Fix acompanhamento PDF export to include full width

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -5923,6 +5923,12 @@ function mostrarDetalhesSobra(data = sobraPorSku) {
       clone.style.width = '100%';
       clone.style.maxWidth = '100%';
 
+      clone.querySelectorAll('.table-container').forEach(container => {
+        container.style.overflow = 'visible';
+        container.style.width = '100%';
+        container.style.maxWidth = '100%';
+      });
+
       const resumoClone = clone.querySelector('#resumoAcompanhamento');
       if (resumoClone) {
         resumoClone.style.display = 'grid';
@@ -6014,7 +6020,14 @@ function mostrarDetalhesSobra(data = sobraPorSku) {
         margin: [10, 12, 16, 12],
         filename: 'acompanhamento.pdf',
         image: { type: 'jpeg', quality: 0.98 },
-        html2canvas: { scale: 2, useCORS: true, windowWidth: wrapper.scrollWidth },
+        html2canvas: {
+          scale: 2,
+          useCORS: true,
+          windowWidth: wrapper.scrollWidth,
+          windowHeight: wrapper.scrollHeight,
+          scrollX: 0,
+          scrollY: -window.scrollY
+        },
         jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' }
       };
 


### PR DESCRIPTION
## Summary
- ensure the acompanhamento report PDF export removes overflow clipping from the table container
- adjust the html2canvas rendering options to capture the full width and height of the report content

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd1cc7c398832ab236988740fdf7a9