### PR TITLE
Ajusta exibição de principais vinculados na aba de produtos vendidos

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -3808,43 +3808,38 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
         .map((item) => {
           const totalFormatado = item.total.toLocaleString('pt-BR');
           const valorLiquidoFormatado = formatCurrency(item.valorLiquido);
-          const vendidosChips = item.vendidosPorSku
-            .map(
-              ([sku, qtd]) =>
-                `<span class="inline-flex items-center gap-1 rounded-full bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-700"><span>${escapeHtml(
-                  sku,
-                )}</span><span class="font-semibold text-gray-600">${qtd.toLocaleString(
-                  'pt-BR',
-                )}</span></span>`,
-            )
-            .join('');
-          const vendidosHtml = vendidosChips
-            ? `<div class="mt-2 flex flex-wrap gap-2">${vendidosChips}</div>`
-            : '';
           const principaisDetalhes = Array.isArray(
             item.principaisVinculadosDetalhes,
           )
             ? item.principaisVinculadosDetalhes
             : [];
-          let extrasHtml = '';
-          if (principaisDetalhes.length) {
-            const linhasPrincipais = principaisDetalhes
-              .map(({ sku, quantidade }) => {
-                const quantidadeFormatada = Number(quantidade || 0).toLocaleString(
-                  'pt-BR',
-                );
-                return `<div class="flex items-center justify-between gap-2 rounded-lg bg-indigo-50 px-2 py-1 text-[11px] text-indigo-700"><span class="font-medium">${escapeHtml(
+          const temPrincipais = principaisDetalhes.length > 0;
+          const vendidosBase = temPrincipais
+            ? principaisDetalhes.map(({ sku, quantidade }) => ({
+                sku,
+                quantidade: Number(quantidade || 0),
+              }))
+            : item.vendidosPorSku.map(([sku, qtd]) => ({
+                sku,
+                quantidade: Number(qtd || 0),
+              }));
+          const vendidosChips = vendidosBase
+            .map(
+              ({ sku, quantidade }) =>
+                `<span class="inline-flex items-center gap-1 rounded-full bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-700"><span>${escapeHtml(
                   sku,
-                )}</span><span class="font-semibold text-gray-600">${quantidadeFormatada}</span></div>`;
-              })
-              .join('');
-            extrasHtml = `
-              <div class="mt-2 text-xs text-gray-500">
-                <div class="font-medium text-gray-600">Principais vinculados</div>
-                <div class="mt-1 space-y-1">${linhasPrincipais}</div>
-              </div>
-            `.trim();
-          } else {
+                )}</span><span class="font-semibold text-gray-600">${quantidade.toLocaleString(
+                  'pt-BR',
+                )}</span></span>`,
+            )
+            .join('');
+          const vendidosHtml = vendidosChips
+            ? temPrincipais
+              ? `<div class="mt-2 text-xs text-gray-500"><div class="font-medium text-gray-600">Principais vinculados</div><div class="mt-1 flex flex-wrap gap-2">${vendidosChips}</div></div>`
+              : `<div class="mt-2 flex flex-wrap gap-2">${vendidosChips}</div>`
+            : '';
+          let extrasHtml = '';
+          if (!temPrincipais) {
             const extrasLista = item.grupoCompleto
               .filter(
                 (skuExtra) =>


### PR DESCRIPTION
## Summary
- agrupa os SKUs principais vinculados na tabela de produtos vendidos
- exibe somente os principais vinculados com a soma das quantidades associadas quando disponíveis
- evita mostrar a lista de SKUs associados quando já há principais vinculados agregados

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd1eac2644832aa1277164a8af9614