### PR TITLE
Increase PDF export canvas scale

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -4765,7 +4765,7 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
         filename: `produtos_vendidos_${new Date().toISOString().slice(0, 10)}.pdf`,
         image: { type: 'jpeg', quality: 0.98 },
         html2canvas: {
-          scale: Math.min(2, window.devicePixelRatio || 2),
+          scale: Math.max(2, window.devicePixelRatio || 1),
           useCORS: true,
           scrollY: 0,
         },


### PR DESCRIPTION
## Summary
- adjust the Produtos Vendidos PDF export to force html2canvas to render at a minimum 2x scale for sharper output on standard DPI screens

## Testing
- not run (requires browser context to generate sample PDF)

------
https://chatgpt.com/codex/tasks/task_e_68dd2f15cda4832aa5add3787a32e950