### PR TITLE
Add fechamento mensal download button to acompanhamento tab

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -6433,6 +6433,72 @@ async function exportarAcompanhamentoPDF() {
   }
 }
 
+const aguardarEntreDownloads = (tempo = 900) =>
+  new Promise((resolve) => setTimeout(resolve, tempo));
+
+async function baixarFechamentoMensal() {
+  const botao = document.getElementById('btnFechamentoMensal');
+  let htmlOriginal = '';
+
+  if (botao) {
+    htmlOriginal = botao.innerHTML;
+    botao.disabled = true;
+    botao.classList.add('opacity-80', 'pointer-events-none');
+    botao.innerHTML =
+      '<span class="flex items-center gap-2"><i class="fas fa-spinner fa-spin"></i> Gerando PDFs...</span>';
+  }
+
+  const etapas = [
+    { nome: 'Fechamento de Saques', chave: 'imprimirFechamento' },
+    { nome: 'Produtos Vendidos', chave: 'exportarProdutosVendidosPDF' },
+    { nome: 'Top 15 SKUs', chave: 'exportarResumoTopSkus' },
+    { nome: 'Previsão', chave: 'baixarPrevisaoPdf' },
+    { nome: 'Acompanhamento', chave: 'exportarAcompanhamentoPDF' },
+  ];
+
+  const erros = [];
+
+  for (const etapa of etapas) {
+    const fn = window[etapa.chave];
+    if (typeof fn !== 'function') {
+      erros.push(`${etapa.nome} indisponível`);
+      continue;
+    }
+
+    try {
+      const retorno = fn();
+      if (retorno instanceof Promise) {
+        await retorno;
+      }
+      await aguardarEntreDownloads();
+    } catch (error) {
+      console.error(`Erro ao gerar PDF de ${etapa.nome}`, error);
+      erros.push(`${etapa.nome} falhou`);
+    }
+  }
+
+  if (botao) {
+    botao.disabled = false;
+    botao.classList.remove('opacity-80', 'pointer-events-none');
+    botao.innerHTML = htmlOriginal;
+  }
+
+  if (erros.length) {
+    if (typeof mostrarErro === 'function') {
+      mostrarErro(`Não foi possível gerar todos os PDFs: ${erros.join(' | ')}`);
+    } else {
+      alert(`Não foi possível gerar todos os PDFs: ${erros.join(' | ')}`);
+    }
+    return;
+  }
+
+  if (typeof mostrarSucesso === 'function') {
+    mostrarSucesso('Fechamento do mês gerado! Verifique os downloads em seu navegador.');
+  } else {
+    alert('Fechamento do mês gerado! Verifique os downloads em seu navegador.');
+  }
+}
+
     function printAcompanhamento() {
       const element = document.getElementById('areaImpressao');
       if (!element) return;
@@ -6766,6 +6832,7 @@ window.exportarProdutosVendidosPDF = exportarProdutosVendidosPDF;
 window.exportarAcompanhamentoExcel = exportarAcompanhamentoExcel;
 window.exportarResumoTopSkus = exportarResumoTopSkus;
 window.exportarAcompanhamentoPDF = exportarAcompanhamentoPDF;
+window.baixarFechamentoMensal = baixarFechamentoMensal;
 window.printAcompanhamento = printAcompanhamento;
   window.salvarMetasAcompanhamento = salvarMetasAcompanhamento;
 window.atualizarResponsavelFinanceiro = atualizarResponsavelFinanceiro;

--- a/sobras-tabs/acompanhamento.html
+++ b/sobras-tabs/acompanhamento.html
@@ -71,8 +71,19 @@
         <tbody class="bg-white divide-y divide-gray-100"></tbody>
       </table>
     </div>
-    
+
     <div id="resumoAcompanhamento" class="resumo-grid mt-6 p-4 bg-white rounded-lg text-sm text-gray-700 shadow"></div>
   </div> <!-- ✅ AGORA FECHOU CORRETAMENTE o #areaImpressao -->
+
+  <div class="px-6 pb-6 flex justify-end">
+    <button
+      id="btnFechamentoMensal"
+      onclick="baixarFechamentoMensal()"
+      class="flex items-center gap-2 px-5 py-2.5 bg-purple-600 hover:bg-purple-700 text-white font-semibold rounded-lg shadow transition duration-150"
+    >
+      <i class="fas fa-box-archive"></i>
+      <span>Fechamento do Mês</span>
+    </button>
+  </div>
 
 </div> <!-- fecha .card -->


### PR DESCRIPTION
## Summary
- add a Fechamento do Mês button to the acompanhamento tab so the closure can be downloaded from one place
- orchestrate sequential calls to the existing PDF exporters with loading feedback and error handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd4989f8cc832a8b4849ca235dbef2