### PR TITLE
Add comment field to expedição upload modal

### DIFF
--- a/expedicao.html
+++ b/expedicao.html
@@ -102,12 +102,13 @@
         class="form-control w-full"
         placeholder="Informe a loja"
       />
-      <label for="storeSituationSelect" class="block text-sm font-medium text-gray-700 mt-4 mb-2">Situação</label>
-      <select id="storeSituationSelect" class="form-control w-full">
-        <option value="nao_impresso">Não impresso</option>
-        <option value="impresso">Impresso</option>
-        <option value="concluido">Concluído</option>
-      </select>
+      <label for="storeCommentInput" class="block text-sm font-medium text-gray-700 mt-4 mb-2">Comentário</label>
+      <textarea
+        id="storeCommentInput"
+        class="form-control w-full"
+        rows="3"
+        placeholder="Adicione observações sobre a etiqueta"
+      ></textarea>
       <div id="storeResponsavelField" class="mt-4 hidden">
         <label for="storeResponsavelSelect" class="block text-sm font-medium text-gray-700 mb-2">Responsável</label>
         <select id="storeResponsavelSelect" class="form-control w-full"></select>
@@ -440,7 +441,7 @@
     const storeModal = document.getElementById('storeModal');
     const storeModalContent = document.getElementById('storeModalContent');
     const storeNameInput = document.getElementById('storeNameInput');
-    const storeSituationSelect = document.getElementById('storeSituationSelect');
+    const storeCommentInput = document.getElementById('storeCommentInput');
     const storeResponsavelField = document.getElementById('storeResponsavelField');
     const storeResponsavelSelect = document.getElementById('storeResponsavelSelect');
     const storeModalConfirm = document.getElementById('storeModalConfirm');
@@ -458,7 +459,7 @@
 
     function resetStoreModalState() {
       if (storeNameInput) storeNameInput.value = '';
-      if (storeSituationSelect) storeSituationSelect.value = 'nao_impresso';
+      if (storeCommentInput) storeCommentInput.value = '';
       if (storeResponsavelSelect) storeResponsavelSelect.innerHTML = '';
       if (storeResponsavelField) storeResponsavelField.classList.add('hidden');
       if (storeModalProgress) storeModalProgress.classList.add('hidden');
@@ -606,7 +607,7 @@
         alert('Informe o nome da loja.');
         return;
       }
-      const situacaoSelecionada = (storeSituationSelect?.value || 'nao_impresso').trim() || 'nao_impresso';
+      const comentario = (storeCommentInput?.value || '').trim();
       const emailsDisponiveis = Array.isArray(gestoresEmails)
         ? gestoresEmails.filter(email => typeof email === 'string' && email.trim().length > 0)
         : [];
@@ -626,7 +627,7 @@
       try {
         await uploadManualLabel(pendingManualFile, lojaNome, {
           gestoresSelecionados,
-          situacao: situacaoSelecionada,
+          comentario,
           onProgress: ({ text, percent }) => showStoreModalProgress(text, percent)
         });
         showStoreModalSuccess('Etiqueta salva com sucesso!');
@@ -1453,11 +1454,12 @@
         alert('Selecione um arquivo PDF.');
         throw new Error('Arquivo PDF não selecionado.');
       }
-      const { onProgress, gestoresSelecionados, situacao } = options;
+      const { onProgress, gestoresSelecionados, situacao, comentario } = options;
       const statusInput = typeof situacao === 'string' ? situacao.trim().toLowerCase() : '';
       const statusValido = ['nao_impresso', 'impresso', 'concluido'].includes(statusInput)
         ? statusInput
         : 'nao_impresso';
+      const observacaoInicial = typeof comentario === 'string' ? comentario : '';
       try {
         if (typeof onProgress === 'function') onProgress({ text: 'Contando páginas...', percent: 5 });
         const pageCount = await contarPaginasPdf(file);
@@ -1476,6 +1478,7 @@
           status: statusValido,
           foraHorario: foraHorarioAtual,
           loja: lojaNome || '',
+          observacao: observacaoInicial,
           totalPaginas: pageCount,
           pageCount
         });
@@ -1500,6 +1503,7 @@
           url: url,
           storagePath: fileRef.fullPath,
           loja: lojaNome || '',
+          observacao: observacaoInicial,
           totalPaginas: pageCount,
           pageCount
         });


### PR DESCRIPTION
## Summary
- replace the manual upload modal status selector with a comment field in the expedição page
- persist the optional comment alongside the uploaded label data and reset the modal state accordingly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc2422db20832ab83c1f3c71dc8dc1