### PR TITLE
Fix Firebase storage bucket for expedição uploads

### DIFF
--- a/firebase-config.js
+++ b/firebase-config.js
@@ -14,7 +14,7 @@ export const firebaseConfig = {
   apiKey: 'AIzaSyC78l9b2DTNj64y_0fbRKofNupO6NHDmeo',
   authDomain: 'matheus-35023.firebaseapp.com',
   projectId: 'matheus-35023',
-  storageBucket: 'matheus-35023.firebasestorage.app',
+  storageBucket: 'matheus-35023.appspot.com',
   messagingSenderId: '1011113149395',
   appId: '1:1011113149395:web:c1f449e0e974ca8ecb2526',
   databaseURL: 'https://matheus-35023.firebaseio.com',


### PR DESCRIPTION
## Summary
- correct the Firebase Storage bucket configuration to use the proper appspot.com domain so manual label uploads can succeed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd5cac533c832a8e64bab657e37d84