### PR TITLE
Redirect www domain to apex to fix Firebase uploads

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -1,4 +1,16 @@
 (function () {
+  if (typeof window !== 'undefined') {
+    var host = window.location.hostname;
+    if (host === 'www.provendedor.com.br') {
+      var target =
+        'https://provendedor.com.br' +
+        window.location.pathname +
+        window.location.search +
+        window.location.hash;
+      window.location.replace(target);
+      return;
+    }
+  }
   // Determine base path of current script for loading partials
   var currentScript =
     document.currentScript ||


### PR DESCRIPTION
## Summary
- redirect traffic from www.provendedor.com.br to the apex domain before loading the app
- ensure Firebase storage requests originate from the allowed domain to avoid failing CORS preflight checks

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd62675604832aa734693e0b5150f5