### PR TITLE
Trigger automatic download for Shopee labels

### DIFF
--- a/etiquetas-shopee.html
+++ b/etiquetas-shopee.html
@@ -686,6 +686,22 @@
       }
     }
 
+    function triggerAutomaticDownload(blob, fileName) {
+      try {
+        const downloadUrl = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = downloadUrl;
+        link.download = fileName;
+        link.style.display = 'none';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        setTimeout(() => URL.revokeObjectURL(downloadUrl), 4000);
+      } catch (error) {
+        console.error('Erro ao iniciar o download automático do PDF:', error);
+      }
+    }
+
     function escolherGestorEmail(emails) {
       return new Promise((resolve) => {
         if (!emails || !emails.length) {
@@ -1210,6 +1226,8 @@
         const finalFileName = `${storeFileSegment}-${shortDate}.pdf`;
         log(`Arquivo final: ${finalFileName}`);
 
+        triggerAutomaticDownload(outBlob, finalFileName);
+        log('Download automático do PDF final iniciado.');
         const contadorFinal = contadorInicializado ? (proximoNumeroEtiqueta - 1) : null;
         const uploadInfo = await uploadPdfToFirebase(outBlob, finalFileName, {
           totalPaginas: totalOutPages,
@@ -1539,6 +1557,8 @@
           const finalFileName = `${storeFileSegment}-retirada-${shortDate}.pdf`;
           log(`Arquivo final: ${finalFileName}`);
 
+          triggerAutomaticDownload(outBlob, finalFileName);
+          log('Download automático do PDF final iniciado.');
           const contadorFinal = contadorInicializado ? proximoNumeroEtiqueta - 1 : null;
           const uploadInfo = await uploadPdfToFirebase(outBlob, finalFileName, {
             totalPaginas: outDoc.getPageCount(),


### PR DESCRIPTION
## Summary
- add a helper to trigger the automatic download of the generated PDF on the Shopee labels page
- start the download before uploading to Firebase for both etiqueta flows and log the action for the user

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd64d78d90832ab76066fa69c29647