### PR TITLE
Add Firebase App Check initialization across clients

### DIFF
--- a/equipes.html
+++ b/equipes.html
@@ -919,7 +919,8 @@
         import { getAuth, signInWithCustomToken, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
         import { getFirestore, collection, addDoc, onSnapshot, query, where, updateDoc, doc, deleteDoc, getDocs, setDoc } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
         import { getStorage, ref, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
-        import { firebaseConfig as defaultFirebaseConfig } from './firebase-config.js';
+        import { initializeAppCheck, ReCaptchaV3Provider } from "https://www.gstatic.com/firebasejs/10.13.1/firebase-app-check.js";
+        import { firebaseConfig as defaultFirebaseConfig, APP_CHECK_SITE_KEY, ensureAppCheck } from './firebase-config.js';
 
         // Variáveis globais fornecidas pelo ambiente
         const appId = typeof __app_id !== 'undefined' ? __app_id : 'equipes';
@@ -1124,6 +1125,10 @@
 
             try {
                 app = initializeApp(firebaseConfig);
+                ensureAppCheck(app) ?? initializeAppCheck(app, {
+                    provider: new ReCaptchaV3Provider(APP_CHECK_SITE_KEY),
+                    isTokenAutoRefreshEnabled: true,
+                });
                 db = getFirestore(app);
                 auth = getAuth(app);
                 storage = getStorage(app);

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -3,6 +3,10 @@ import {
   getApps,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
 import {
+  initializeAppCheck,
+  ReCaptchaV3Provider,
+} from 'https://www.gstatic.com/firebasejs/10.13.1/firebase-app-check.js';
+import {
   getFirestore,
   enableIndexedDbPersistence,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
@@ -20,6 +24,8 @@ export const firebaseConfig = {
   databaseURL: 'https://matheus-35023.firebaseio.com',
 };
 
+export const APP_CHECK_SITE_KEY = '6Lf-MdsrAAAAAFxy7VBRagVA41djogpm2DC0f0xk';
+
 // Initialize Firebase app once and enable offline persistence
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
@@ -28,6 +34,66 @@ enableIndexedDbPersistence(db).catch((err) => {
   console.warn('Firestore persistence not enabled:', err.code);
 });
 const auth = getAuth(app);
+
+let appCheckInstance = null;
+
+export function ensureAppCheck(currentApp = app) {
+  const browserScope =
+    typeof window !== 'undefined'
+      ? window
+      : typeof self !== 'undefined'
+        ? self
+        : null;
+  if (appCheckInstance || !browserScope) {
+    return appCheckInstance;
+  }
+  if (!currentApp) {
+    return null;
+  }
+  appCheckInstance = initializeAppCheck(currentApp, {
+    provider: new ReCaptchaV3Provider(APP_CHECK_SITE_KEY),
+    isTokenAutoRefreshEnabled: true,
+  });
+  return appCheckInstance;
+}
+
+const appCheck = typeof window !== 'undefined' ? ensureAppCheck(app) : null;
+
+function setupCompatAppCheck() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const compat = window.firebase;
+  if (!compat?.initializeApp) {
+    if (!window.__appCheckCompatRetryScheduled) {
+      window.__appCheckCompatRetryScheduled = true;
+      setTimeout(() => {
+        window.__appCheckCompatRetryScheduled = false;
+        setupCompatAppCheck();
+      }, 0);
+    }
+    return;
+  }
+
+  if (!compat.__appCheckWrapped) {
+    const originalInitializeApp = compat.initializeApp.bind(compat);
+    compat.initializeApp = (...args) => {
+      const compatApp = originalInitializeApp(...args);
+      ensureAppCheck(compatApp);
+      return compatApp;
+    };
+    compat.__appCheckWrapped = true;
+  }
+
+  if (compat.apps?.length) {
+    try {
+      ensureAppCheck(compat.app());
+    } catch (error) {
+      console.warn('Failed to activate App Check for compat app:', error);
+    }
+  }
+}
 
 // Utility functions for storing the passphrase securely
 export function setPassphrase(pass) {
@@ -54,6 +120,9 @@ if (typeof window !== 'undefined') {
   window.firebaseApp = app;
   window.db = db;
   window.auth = auth;
+  window.appCheck = appCheck;
+  window.ensureAppCheck = ensureAppCheck;
+  setupCompatAppCheck();
   window.setPassphrase = setPassphrase;
   window.getPassphrase = getPassphrase;
   window.clearPassphrase = clearPassphrase;
@@ -66,10 +135,13 @@ if (typeof module !== 'undefined') {
     app,
     db,
     auth,
+    appCheck,
+    ensureAppCheck,
+    APP_CHECK_SITE_KEY,
     setPassphrase,
     getPassphrase,
     clearPassphrase,
   };
 }
 
-export { app, db, auth };
+export { app, db, auth, appCheck };

--- a/scripts/firebase-init.js
+++ b/scripts/firebase-init.js
@@ -1,10 +1,15 @@
 import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
 import {
+  initializeAppCheck,
+  ReCaptchaV3Provider,
+} from 'https://www.gstatic.com/firebasejs/10.13.1/firebase-app-check.js';
+import {
   getFirestore,
   collection,
   doc,
   setDoc
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { APP_CHECK_SITE_KEY, ensureAppCheck } from '../firebase-config.js';
 
 // Configuração Firebase
 const firebaseConfig = {
@@ -18,6 +23,10 @@ const firebaseConfig = {
 
 // Inicializa Firebase
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+ensureAppCheck(app) ?? initializeAppCheck(app, {
+  provider: new ReCaptchaV3Provider(APP_CHECK_SITE_KEY),
+  isTokenAutoRefreshEnabled: true,
+});
 const db = getFirestore(app);
 
 // 🔁 Exporte tudo que o background precisa:

--- a/shopee-hotline-autofill-extension/popup.js
+++ b/shopee-hotline-autofill-extension/popup.js
@@ -6,6 +6,22 @@ const firebaseConfig = {
 };
 firebase.initializeApp(firebaseConfig);
 
+const APP_CHECK_SITE_KEY = '6Lf-MdsrAAAAAFxy7VBRagVA41djogpm2DC0f0xk';
+
+(async () => {
+  if (window.__appCheckInstance) return;
+  const { initializeAppCheck, ReCaptchaV3Provider } = await import(
+    'https://www.gstatic.com/firebasejs/10.13.1/firebase-app-check.js'
+  );
+  const app = firebase.app();
+  window.__appCheckInstance =
+    (typeof window.ensureAppCheck === 'function' && window.ensureAppCheck(app)) ||
+    initializeAppCheck(app, {
+      provider: new ReCaptchaV3Provider(APP_CHECK_SITE_KEY),
+      isTokenAutoRefreshEnabled: true,
+    });
+})();
+
 const auth = firebase.auth();
 const db = firebase.firestore();
 

--- a/shopee-sync-extension/firebase-init.js
+++ b/shopee-sync-extension/firebase-init.js
@@ -1,10 +1,15 @@
-import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import {
+  initializeAppCheck,
+  ReCaptchaV3Provider,
+} from 'https://www.gstatic.com/firebasejs/10.13.1/firebase-app-check.js';
 import {
   getFirestore,
   collection,
   doc,
   setDoc
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { APP_CHECK_SITE_KEY, ensureAppCheck } from '../firebase-config.js';
 
 // Configuração Firebase
 const firebaseConfig = {
@@ -18,6 +23,10 @@ const firebaseConfig = {
 
 // Inicializa Firebase
 const app = initializeApp(firebaseConfig);
+ensureAppCheck(app) ?? initializeAppCheck(app, {
+  provider: new ReCaptchaV3Provider(APP_CHECK_SITE_KEY),
+  isTokenAutoRefreshEnabled: true,
+});
 const db = getFirestore(app);
 
 // 🔁 Exporte tudo que o background precisa:

--- a/shopee-sync-extension/popup.js
+++ b/shopee-sync-extension/popup.js
@@ -1,5 +1,10 @@
 import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import {
+  initializeAppCheck,
+  ReCaptchaV3Provider,
+} from 'https://www.gstatic.com/firebasejs/10.13.1/firebase-app-check.js';
 import { getAuth, signInWithEmailAndPassword, signOut } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { APP_CHECK_SITE_KEY, ensureAppCheck } from '../firebase-config.js';
 
 const firebaseConfig = {
   apiKey: "AIzaSyC78l9b2DTNj64y_0fbRKofNupO6NHDmeo",
@@ -11,6 +16,10 @@ const firebaseConfig = {
 };
 
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+ensureAppCheck(app) ?? initializeAppCheck(app, {
+  provider: new ReCaptchaV3Provider(APP_CHECK_SITE_KEY),
+  isTokenAutoRefreshEnabled: true,
+});
 const auth = getAuth(app);
 
 const loginSection = document.getElementById('loginSection');


### PR DESCRIPTION
## Summary
- integrate Firebase App Check with the shared firebase-config module and expose a reusable ensureAppCheck helper
- activate App Check when initializing Firebase in the Equipes experience and Chrome extension scripts, including the hotline popup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd6598c3e0832a8e4a74fe79536e7e