### PR TITLE
Add Firebase Storage CORS configuration

### DIFF
--- a/firebase-storage-cors.json
+++ b/firebase-storage-cors.json
@@ -1,0 +1,8 @@
+[
+  {
+    "origin": ["https://www.provendedor.com.br"],
+    "method": ["GET", "PUT", "POST", "DELETE", "OPTIONS"],
+    "maxAgeSeconds": 3600,
+    "responseHeader": ["Content-Type", "Authorization", "x-goog-meta-owner"]
+  }
+]

--- a/manual/firebase-storage-cors.md
+++ b/manual/firebase-storage-cors.md
@@ -1,0 +1,29 @@
+# Configuração de CORS para o Firebase Storage
+
+Para liberar o download e upload de arquivos do bucket `matheus-35023.appspot.com` a partir do domínio `https://www.provendedor.com.br`, é necessário aplicar a política de CORS abaixo usando a ferramenta `gsutil`.
+
+## Passos
+
+1. Instale e autentique o SDK do Google Cloud se ainda não estiver configurado.
+2. No diretório raiz do projeto, aplique a política executando:
+   ```bash
+   gsutil cors set firebase-storage-cors.json gs://matheus-35023.appspot.com
+   ```
+3. Aguarde alguns minutos para a propagação e repita o fluxo no site hospedado em `www.provendedor.com.br`.
+
+## Política utilizada
+
+O arquivo [`firebase-storage-cors.json`](../firebase-storage-cors.json) contém:
+
+```json
+[
+  {
+    "origin": ["https://www.provendedor.com.br"],
+    "method": ["GET", "PUT", "POST", "DELETE", "OPTIONS"],
+    "maxAgeSeconds": 3600,
+    "responseHeader": ["Content-Type", "Authorization", "x-goog-meta-owner"]
+  }
+]
+```
+
+Essa configuração garante que o bucket aceite requisições pré-flight (OPTIONS) e métodos utilizados pela aplicação sem bloquear o navegador.


### PR DESCRIPTION
## Summary
- add a reusable Firebase Storage CORS policy JSON that whitelists https://www.provendedor.com.br
- document how to apply the policy with gsutil so uploads and downloads from the site pass CORS preflight checks

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dd68ea2770832aa6a7be29e2ae1c06