### PR TITLE
Improve handling of Firebase Storage CORS errors

### DIFF
--- a/etiquetas-ocr.html
+++ b/etiquetas-ocr.html
@@ -745,6 +745,25 @@ firebase.auth().onAuthStateChanged(async u => {
         }
       } catch (err) {
         console.error('Erro ao enviar PDF para Firebase:', err);
+        const errorInfo =
+          typeof window.describeFirebaseStorageUploadError === 'function'
+            ? window.describeFirebaseStorageUploadError(err)
+            : null;
+        if (errorInfo && errorInfo.type === 'cors') {
+          const message =
+            errorInfo.userMessage +
+            ' Solicite ao administrador do Firebase que autorize a origem deste site nas configurações de CORS do bucket.';
+          const technicalDetails = errorInfo.technicalMessage
+            ? '\n\nDetalhes técnicos: ' + errorInfo.technicalMessage
+            : '';
+          showMessage(message);
+          alert(message + technicalDetails);
+          const friendlyError = new Error(message);
+          friendlyError.cause = err;
+          friendlyError.isCorsError = true;
+          friendlyError.details = errorInfo;
+          throw friendlyError;
+        }
         showMessage('Erro ao enviar PDF. Tente novamente mais tarde.');
         throw err;
       }

--- a/etiquetas-shopee.html
+++ b/etiquetas-shopee.html
@@ -939,6 +939,27 @@
         return { url, storagePath: fileRef.fullPath, docId: docRef.id };
       } catch (error) {
         console.error('Erro ao enviar PDF para o Firebase:', error);
+        const errorInfo =
+          typeof window.describeFirebaseStorageUploadError === 'function'
+            ? window.describeFirebaseStorageUploadError(error)
+            : null;
+        if (errorInfo && errorInfo.type === 'cors') {
+          const message =
+            errorInfo.userMessage +
+            ' Entre em contato com o responsável pelo bucket para configurar as regras de CORS.';
+          const technicalDetails = errorInfo.technicalMessage
+            ? '\n\nDetalhes técnicos: ' + errorInfo.technicalMessage
+            : '';
+          setStatus(message);
+          setStatus(message, pickupStatusEl);
+          log(message);
+          alert(message + technicalDetails);
+          const friendlyError = new Error(message);
+          friendlyError.cause = error;
+          friendlyError.isCorsError = true;
+          friendlyError.details = errorInfo;
+          throw friendlyError;
+        }
         throw error;
       }
     }

--- a/manual/firebase-storage-cors.md
+++ b/manual/firebase-storage-cors.md
@@ -1,0 +1,45 @@
+# Configurando CORS para o Firebase Storage
+
+Algumas páginas do VendedorPro enviam PDFs diretamente para o Firebase Storage. Quando o bucket não está configurado para aceitar requisições vindas do domínio do sistema, o navegador bloqueia o envio e mostra um erro como:
+
+```
+Access to XMLHttpRequest at 'https://firebasestorage.googleapis.com/v0/b/<bucket>/o?...' from origin 'https://www.provendedor.com.br' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: It does not have HTTP ok status.
+```
+
+Esse erro aparece porque o **preflight** `OPTIONS` enviado pelo navegador não recebe uma resposta com status `200` e com os cabeçalhos `Access-Control-Allow-Origin` e `Access-Control-Allow-Methods` apropriados. Para resolver é necessário definir uma política de CORS para o bucket do Firebase Storage autorizando o domínio do sistema.
+
+## Passos para configurar
+
+1. [Instale e autentique o Google Cloud CLI](https://cloud.google.com/sdk/docs/install) caso ainda não possua o `gcloud`/`gsutil` configurados.
+2. Gere um arquivo `cors.json` com a política desejada. Exemplo liberando os domínios de produção e homologação:
+
+    ```json
+    [
+      {
+        "origin": ["https://www.provendedor.com.br", "https://app.provendedor.com.br"],
+        "method": ["GET", "HEAD", "PUT", "POST", "OPTIONS"],
+        "responseHeader": ["Authorization", "Content-Type", "x-goog-resumable"],
+        "maxAgeSeconds": 3600
+      }
+    ]
+    ```
+
+3. Aplique o arquivo ao bucket do projeto:
+
+    ```bash
+    gsutil cors set cors.json gs://matheus-35023.appspot.com
+    ```
+
+4. Aguarde alguns minutos e tente o envio novamente.
+
+> **Importante:** Essa configuração é feita por bucket. Se houver buckets diferentes para ambientes distintos, repita o processo para cada um deles.
+
+## Diagnóstico rápido
+
+As páginas atualizadas exibem uma mensagem explicando quando o problema estiver relacionado a CORS. Caso o erro persista mesmo após a configuração, verifique:
+
+- Se o usuário está autenticado e possui permissão de escrita conforme as regras do Storage.
+- Se há algum proxy (Cloudflare, por exemplo) alterando os cabeçalhos de resposta.
+- Se o domínio utilizado na aplicação corresponde exatamente ao listado na política de CORS (incluindo protocolo e subdomínio).
+
+Com a política ajustada o upload volta a funcionar normalmente e o navegador deixa de bloquear a requisição.

--- a/shared.js
+++ b/shared.js
@@ -40,6 +40,46 @@
       });
   }
 
+  function extractFirebaseStorageErrorText(error) {
+    if (!error) return '';
+    if (typeof error === 'string') return error;
+    var pieces = [];
+    if (typeof error.message === 'string') {
+      pieces.push(error.message);
+    }
+    if (typeof error.code === 'string') {
+      pieces.push(error.code);
+    }
+    if (error.serverResponse) {
+      pieces.push(String(error.serverResponse));
+    }
+    if (error.customData && error.customData.serverResponse) {
+      pieces.push(String(error.customData.serverResponse));
+    }
+    if (error.cause) {
+      pieces.push(extractFirebaseStorageErrorText(error.cause));
+    }
+    return pieces.join(' ').trim();
+  }
+
+  window.describeFirebaseStorageUploadError = function (error) {
+    var combined = extractFirebaseStorageErrorText(error);
+    if (!combined) {
+      return null;
+    }
+
+    if (/CORS|Access-Control-Allow-Origin|preflight/i.test(combined)) {
+      return {
+        type: 'cors',
+        userMessage:
+          'Não foi possível enviar o PDF porque o Firebase Storage bloqueou a requisição (CORS). A origem do site precisa estar autorizada no bucket do Storage.',
+        technicalMessage: combined,
+      };
+    }
+
+    return null;
+  };
+
   function loadTailwind() {
     return new Promise(function (resolve, reject) {
       if (


### PR DESCRIPTION
## Summary
- add a shared helper to inspect Firebase Storage errors and detect missing CORS configuration
- surface actionable guidance in the etiquetas Shopee/OCR upload flows when CORS blocks the request
- document the required Firebase Storage CORS settings for the project

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd71822920832aae310ad21d3e992c