### PR TITLE
Fix pdf.js integrity hash for sobras page

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -21,7 +21,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-auth-compat.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js" integrity="sha512-OtV7YCOguBF5B8Vg2ACHDj7Lpj4IJ05Kd1OkmPgFWbcgNAeqszDzf3FJ0rLZTSJytXBKJu9956PoAdStdc/GtA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js" integrity="sha512-q+4liFwdPC/bNdhUpZx6aXDx/h77yEQtn4I1slHydcbZK34nLaR3cAeYSJshoxIOq3mjEf7xJE8YWIUHMn+oCQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script type="module" src="firebase-config.js"></script>
 
 


### PR DESCRIPTION
## Summary
- update the pdf.js script tag on the Sobras Shopee page with the correct SRI hash to prevent loading failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dec6aef158832abc97cca3c2829ea1