### PR TITLE
Ajusta parser das etiquetas Magalu na aba VTS

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -159,6 +159,7 @@
 
 <script type="module">
     import { firebaseConfig } from './firebase-config.js';
+    import { parseMagalu } from './parser-magalu.js';
   // =============================================
     // CONFIGURAÇÃO INICIAL E VARIÁVEIS GLOBAIS
     // =============================================
@@ -2543,6 +2544,7 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
       const pdf = await window.pdfjsLib.getDocument({ data: arrayBuffer }).promise;
       const resultados = [];
       const diagnostico = [];
+      const paginasMagalu = [];
 
       for (let pagina = 1; pagina <= pdf.numPages; pagina += 1) {
         const paginaPdf = await pdf.getPage(pagina);
@@ -2571,18 +2573,73 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
           linhas.push(atual);
         }
 
-        const interpretadoBase = interpretador(linhas, pagina);
-        const interpretado = interpretadoBase
-          ? { ...interpretadoBase, modelo }
-          : null;
-        diagnostico.push({
-          pagina,
-          modelo,
-          linhas: linhas.slice(),
-          interpretado: interpretado ? { ...interpretado } : null,
-        });
-        if (interpretado) {
-          resultados.push(interpretado);
+        if (modelo === 'magalu') {
+          paginasMagalu.push({
+            pagina,
+            linhas: linhas.slice(),
+            texto: linhas.join('\n'),
+          });
+        } else {
+          const interpretadoBase = interpretador(linhas, pagina);
+          const interpretado = interpretadoBase
+            ? { ...interpretadoBase, modelo }
+            : null;
+          diagnostico.push({
+            pagina,
+            modelo,
+            linhas: linhas.slice(),
+            interpretado: interpretado ? { ...interpretado } : null,
+          });
+          if (interpretado) {
+            resultados.push(interpretado);
+          }
+        }
+      }
+
+      if (modelo === 'magalu') {
+        for (let indice = 0; indice < paginasMagalu.length; indice += 2) {
+          const atual = paginasMagalu[indice] || null;
+          const proxima = paginasMagalu[indice + 1] || null;
+
+          const paginasParaParser = [];
+          if (atual) paginasParaParser.push({ pagina: 1, text: atual.texto });
+          if (proxima) {
+            paginasParaParser.push({
+              pagina: paginasParaParser.length ? 2 : 1,
+              text: proxima.texto,
+            });
+          }
+
+          const interpretadoBase = parseMagalu(paginasParaParser);
+          const interpretadoValido =
+            interpretadoBase && possuiInformacoesEtiquetaVts(interpretadoBase)
+              ? {
+                  ...interpretadoBase,
+                  modelo,
+                  pagina: proxima?.pagina ?? atual?.pagina ?? indice + 1,
+                }
+              : null;
+
+          if (atual) {
+            diagnostico.push({
+              pagina: atual.pagina,
+              modelo,
+              linhas: atual.linhas.slice(),
+              interpretado: interpretadoValido ? { ...interpretadoValido } : null,
+            });
+          }
+          if (proxima) {
+            diagnostico.push({
+              pagina: proxima.pagina,
+              modelo,
+              linhas: proxima.linhas.slice(),
+              interpretado: interpretadoValido ? { ...interpretadoValido } : null,
+            });
+          }
+
+          if (interpretadoValido) {
+            resultados.push(interpretadoValido);
+          }
         }
       }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vendedorpro",
   "type": "module",
   "scripts": {
-    "test": "node tests/comissoes.test.js",
+    "test": "node tests/comissoes.test.js && node tests/parser-magalu.test.js",
     "lint": "eslint \"*.js\"",
     "format": "prettier --write \"*.js\" \"css/*.css\"",
     "prepare": "husky install"

--- a/parser-magalu.js
+++ b/parser-magalu.js
@@ -1,0 +1,122 @@
+export function parseMagalu(pages = []) {
+  const getPageText = (numero) => {
+    const pagina = pages.find((p) => Number(p?.pagina) === numero);
+    return (pagina?.text || '').replace(/\r\n?/g, '\n');
+  };
+
+  const p1 = getPageText(1);
+  const p2 = getPageText(2);
+
+  const pedido = (p1.match(/Pedido:\s*(\d{10,})/) || [])[1] || '';
+  const dataEntregaPrevista =
+    (p1.match(/Data\s+estimada:\s*(\d{2}\/\d{2}\/\d{4})/) || [])[1] || '';
+
+  const rastreio =
+    (p2.match(/C[oó]digo\s+de\s+Rastreamento:\s*([A-Z0-9-]{8,})/i) || [])[1] ||
+    '';
+
+  const loja = (() => {
+    let nome =
+      (p1.match(/REMETENTE\s*\n\s*([^\n]+)/i) || [])[1] ||
+      (p1.match(/REMETENTE\s+([^\n]+)/i) || [])[1] ||
+      (p2.match(/REMETENTE[\s\S]*?NOME:\s*([^\n]+)/i) || [])[1] ||
+      '';
+
+    nome = nome
+      .replace(/^Magalu\s+/i, '')
+      .replace(/\s{2,}/g, ' ')
+      .trim();
+    return nome ? nome.toUpperCase() : '';
+  })();
+
+  const norm = (data) =>
+    data ? data.replace(/(\d{2})\/(\d{2})\/(\d{4})/, '$3-$2-$1') : '';
+
+  const itens = (() => {
+    const bloco =
+      (p2.match(
+        /IDENTIFICA[ÇC][AÃ]O DOS BENS([\s\S]+?)(?:\n{2,}|UPNDA|CPF\/CNPJ|Total\s+\d+|$)/i,
+      ) || [])[1] || '';
+
+    const linhas = bloco
+      .split(/\n+/)
+      .map((linha) => linha.trim())
+      .filter(Boolean);
+
+    const linhaItem = linhas.find((linha) => /^\d+\s+\S+/.test(linha)) || '';
+
+    let sku = '';
+    let variacao = '';
+    if (linhaItem) {
+      const partes = linhaItem.match(/^\d+\s+([^\s]+)(?:\s+([^\s]+))?/);
+      if (partes) {
+        sku = partes[1] || '';
+        const possivelVariacao = partes[2] || '';
+        if (
+          possivelVariacao &&
+          !/^DESCRI(?:[CÇ][AÃ]O)?$/i.test(possivelVariacao)
+        ) {
+          variacao = possivelVariacao;
+        }
+      }
+    }
+
+    const startIndex = linhaItem ? linhas.indexOf(linhaItem) : -1;
+    const descricaoLinhas = [];
+    if (startIndex >= 0) {
+      for (let i = startIndex + 1; i < linhas.length; i += 1) {
+        const atual = linhas[i];
+        if (!atual) continue;
+        if (/^QTD\b/i.test(atual)) continue;
+        if (/^\d+$/.test(atual)) break;
+        if (/^CPF\/CNPJ/i.test(atual)) break;
+        if (/^\d{2}\/\d{2}\/\d{4}$/.test(atual)) break;
+        descricaoLinhas.push(atual);
+      }
+    }
+
+    const descricao = descricaoLinhas
+      .join(' ')
+      .replace(/\s{2,}/g, ' ')
+      .trim();
+
+    const qtd =
+      (bloco.match(/\bQTD\b[\s\S]*?(\d+)/i) || [])[1] ||
+      linhas.find((linha) => /^\d+$/.test(linha)) ||
+      '1';
+
+    return {
+      sku,
+      variacao,
+      descricao,
+      qtd: String(qtd).trim() || '1',
+    };
+  })();
+
+  const dataEnvio =
+    (p2.match(/(\d{2}\/\d{2}\/\d{4})\s+\d{2}:\d{2}:\d{2}/) || [])[1] ||
+    (p1.match(/\b(\d{2}\/\d{2}\/\d{4})\b/) || [])[1] ||
+    '';
+
+  const dataEntregaPrevistaISO = norm(dataEntregaPrevista);
+  const dataEnvioISO = norm(dataEnvio);
+  const dataTexto = dataEntregaPrevista || dataEnvio || '';
+  const dataNormalizada = dataEntregaPrevistaISO || dataEnvioISO || '';
+
+  return {
+    modelo: 'magalu',
+    pedido,
+    dataEntregaPrevista,
+    dataEntregaPrevistaISO,
+    rastreio,
+    loja,
+    sku: itens.sku,
+    variacao: itens.variacao,
+    descricao: itens.descricao,
+    qtd: itens.qtd,
+    dataEnvio,
+    dataEnvioISO,
+    dataTexto,
+    dataNormalizada,
+  };
+}

--- a/tests/parser-magalu.test.js
+++ b/tests/parser-magalu.test.js
@@ -1,0 +1,33 @@
+import { parseMagalu } from '../parser-magalu.js';
+
+const p1 = `Pedido: 1457770464822704
+Data estimada: 08/08/2025
+REMETENTE
+COLLORE
+...`;
+const p2 = `DECLARAÇÃO DE CONTEÚDO
+Código de Rastreamento: B2D076FCCCE26813
+REMETENTE
+NOME: Magalu Collore
+IDENTIFICAÇÃO DOS BENS
+Nº SKU DESCRIÇÃO VARIAÇÃO QTD
+1 InfantilRosa 28
+Penteadeira Rosa MDF com
+Espelho Infantil - Estilo
+Camarim para Crianças
+1
+CPF/CNPJ: 27870958875
+`;
+
+const out = parseMagalu([
+  { pagina: 1, text: p1 },
+  { pagina: 2, text: p2 },
+]);
+console.assert(out.pedido === '1457770464822704');
+console.assert(out.rastreio === 'B2D076FCCCE26813');
+console.assert(out.loja === 'COLLORE');
+console.assert(out.sku === 'InfantilRosa');
+console.assert(out.descricao.toLowerCase().includes('penteadeira rosa mdf'));
+console.assert(out.qtd === '1');
+console.assert(out.dataEntregaPrevistaISO === '2025-08-08');
+console.assert(/2025-08-/.test(out.dataEnvioISO) || out.dataEnvioISO === '');


### PR DESCRIPTION
## Summary
- implementa um parser dedicado para etiquetas Magalu que unifica dados das duas páginas, normaliza datas e evita capturar CPF/CNPJ como rastreio
- integra o novo parser ao fluxo de extração da aba VTS, gerando diagnósticos por página e preenchendo campos de pedido, loja, SKU, descrição, variação e quantidade
- adiciona teste automatizado de parse Magalu e atualiza o script de testes para executá-lo junto com os existentes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df153656ec832a8ac995b55d4971fc