### PR TITLE
Add Shopee-specific parser for VTS labels

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -160,6 +160,7 @@
 <script type="module">
     import { firebaseConfig } from './firebase-config.js';
     import { parseMagalu } from './parser-magalu.js';
+    import { parseShopeePage } from './parser-shopee.js';
   // =============================================
     // CONFIGURAÇÃO INICIAL E VARIÁVEIS GLOBAIS
     // =============================================
@@ -2515,9 +2516,47 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
     }
 
     function interpretarEtiquetaShopee(linhas, pagina) {
-      const resultadoMercadoLivre = interpretarEtiquetaMercadoLivre(linhas, pagina);
-      if (possuiInformacoesEtiquetaVts(resultadoMercadoLivre)) {
-        return resultadoMercadoLivre;
+      const textoCompleto = (linhas || [])
+        .map((valor) => (valor == null ? '' : String(valor)))
+        .join('\n');
+
+      const parsed = parseShopeePage({ text: textoCompleto, pagina }) || {};
+
+      const dadosShopee = {
+        pagina,
+        modelo: 'shopee',
+        sku: parsed.sku || '',
+        pedido: parsed.pedido || '',
+        rastreio: parsed.rastreio ? parsed.rastreio.toUpperCase() : '',
+        loja: parsed.loja || '',
+        dataTexto: parsed.dataPrevistaEnvio || '',
+        dataNormalizada: parsed.dataPrevistaEnvioISO || '',
+        produto: parsed.produto || '',
+        qtd: parsed.qtd || '',
+        nfeChave: parsed.nfeChave || '',
+        emissaoNFe: parsed.emissaoNFe || '',
+        emissaoNFeISO: parsed.emissaoNFeISO || '',
+        dataPrevistaEnvio: parsed.dataPrevistaEnvio || '',
+        dataPrevistaEnvioISO: parsed.dataPrevistaEnvioISO || '',
+      };
+
+      if (!dadosShopee.dataTexto && parsed.emissaoNFe) {
+        dadosShopee.dataTexto = parsed.emissaoNFe;
+        dadosShopee.dataNormalizada = parsed.emissaoNFeISO
+          ? parsed.emissaoNFeISO.split('T')[0]
+          : '';
+      }
+
+      if (!dadosShopee.sku && parsed.produto) {
+        dadosShopee.sku = parsed.produto;
+      }
+
+      if (!dadosShopee.qtd) {
+        dadosShopee.qtd = '1';
+      }
+
+      if (possuiInformacoesEtiquetaVts(dadosShopee)) {
+        return dadosShopee;
       }
 
       const resultadoGenerico = interpretarEtiquetaGenerica(linhas, pagina, {
@@ -2542,7 +2581,12 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
         return resultadoGenerico;
       }
 
-      return interpretarEtiquetaMercadoLivre(linhas, pagina);
+      const resultadoMercadoLivre = interpretarEtiquetaMercadoLivre(linhas, pagina);
+      if (possuiInformacoesEtiquetaVts(resultadoMercadoLivre)) {
+        return resultadoMercadoLivre;
+      }
+
+      return null;
     }
 
     function interpretarEtiquetaMagalu(linhas, pagina) {

--- a/parser-shopee.js
+++ b/parser-shopee.js
@@ -1,0 +1,80 @@
+export function parseShopeePage({ text = '', pagina } = {}) {
+  const normalizedText = (text || '').replace(/\r\n?/g, '\n');
+  const only = (re, i = 1) => {
+    const match = normalizedText.match(re);
+    return (match || [])[i] || '';
+  };
+
+  const nfeChave = only(/\b(\d{44})\b/);
+  const rastreio = only(/\b(BR[0-9A-Z]{8,})\b/i).toUpperCase();
+
+  const upCode = only(/\b(UP[0-9A-Z]+)\b/) || only(/#(UP[0-9A-Z]+)/);
+
+  const loja = (() => {
+    const [, afterRemetente = ''] = normalizedText.split(/REMETENTE/i);
+    const candidatos = afterRemetente
+      .split(/\n/)
+      .slice(0, 8)
+      .map((linha) => linha.trim())
+      .filter(
+        (linha) =>
+          linha &&
+          !/CEP|Envio previsto|AG[ÊE]NCIA|Rua|R\b|Avenida|Av\.|[0-9]{5}-[0-9]{3}/i.test(
+            linha,
+          ),
+      );
+
+    const prioridade = candidatos.find((linha) =>
+      /LTDA|EIRELI|ME|STORE|COM|IND|LTDA\.?/i.test(linha),
+    );
+
+    if (prioridade) return prioridade.replace(/\s{2,}/g, ' ').trim();
+
+    const fallback = candidatos.find((linha) => /\b\w+\s+\w+/.test(linha));
+    return (fallback || '').replace(/\s{2,}/g, ' ').trim();
+  })();
+
+  const dataPrevistaEnvioBR = only(/Envio previsto:\s*(\d{2}\/\d{2}\/\d{4})/i);
+  const emissaoNFeBR = only(
+    /Emiss[aã]o:\s*(\d{2})-(\d{2})-(\d{4})\s+(\d{2}:\d{2}:\d{2})/i,
+  );
+
+  const toISO_BR = (value) =>
+    value ? value.replace(/(\d{2})\/(\d{2})\/(\d{4})/, '$3-$2-$1') : '';
+
+  const emissaoNFeISO = emissaoNFeBR
+    ? emissaoNFeBR.replace(
+        /(\d{2})-(\d{2})-(\d{4})\s+(\d{2}:\d{2}:\d{2})/,
+        '$3-$2-$1T$4',
+      )
+    : '';
+
+  const itemLine = (normalizedText.match(/^\s*\d+\.\s+.+$/m) || [''])[0];
+  const produto = itemLine
+    .replace(/^\s*\d+\.\s+/, '')
+    .replace(/\s+\*[0-9]+$/, '')
+    .trim();
+  const qtd = (itemLine.match(/\*(\d+)\s*$/) || [])[1] || '1';
+
+  const skuHeader = only(/SKU:\s*([^\n]+)/i);
+  const skuInterno =
+    (skuHeader.match(/#(UP[0-9A-Z]+)/) || [])[1] || upCode || '';
+
+  const pedido = upCode || rastreio || '';
+
+  return {
+    modelo: 'shopee',
+    pagina,
+    nfeChave,
+    pedido,
+    rastreio,
+    loja,
+    sku: skuInterno,
+    produto,
+    qtd,
+    dataPrevistaEnvio: dataPrevistaEnvioBR,
+    dataPrevistaEnvioISO: toISO_BR(dataPrevistaEnvioBR),
+    emissaoNFe: emissaoNFeBR,
+    emissaoNFeISO,
+  };
+}


### PR DESCRIPTION
## Summary
- add a dedicated Shopee label parser that extracts NF-e key, tracking code, order identifier, item description and dates
- integrate the Shopee parser into the VTS import flow so Shopee labels map pedido, rastreio, loja and dates correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df1bbc4f18832a8f25398021b4fd57