### PR TITLE
Default Mercado Livre VTS labels to Mercado livre store name

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -1651,6 +1651,7 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
           console.warn('Não foi possível verificar etiqueta existente:', erro);
         }
 
+        const modeloEtiqueta = etiqueta.modelo || modelo || '';
         const payload = {
           usuarioId: usuarioLogado.uid,
           sku: etiqueta.sku || '',
@@ -1661,10 +1662,14 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
           dataEtiquetaTexto: etiqueta.dataTexto || '',
           origemArquivo: arquivo?.name || '',
           paginaArquivo: etiqueta.pagina || indice + 1,
-          modeloEtiqueta: etiqueta.modelo || modelo || '',
+          modeloEtiqueta,
           buyerUsername: etiqueta.buyerUsername || '',
           atualizadoEm: firebase.firestore.FieldValue.serverTimestamp(),
         };
+
+        if (!payload.loja && modeloEtiqueta === 'mercadoLivre') {
+          payload.loja = 'Mercado livre';
+        }
 
         if (!existente || !existente.exists) {
           payload.importadoEm = firebase.firestore.FieldValue.serverTimestamp();


### PR DESCRIPTION
## Summary
- set a default loja value of "Mercado livre" when saving Mercado Livre VTS etiquetas that do not include store information

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df1fc5ca74832abfa70330accbc386