### PR TITLE
Add manual entry form to VTS labels tab

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -2116,9 +2116,6 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
     }
 
     function atualizarDatalistLojasVts(registros = []) {
-      const datalist = document.getElementById('vtsDevolucaoLojas');
-      if (!datalist) return;
-
       const lojas = Array.from(
         new Set(
           registros
@@ -2127,11 +2124,16 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
         ),
       ).sort((a, b) => a.localeCompare(b, 'pt-BR', { sensitivity: 'base' }));
 
-      datalist.innerHTML = '';
-      lojas.forEach((loja) => {
-        const option = document.createElement('option');
-        option.value = loja;
-        datalist.appendChild(option);
+      ['vtsDevolucaoLojas', 'vtsManualLojas'].forEach((id) => {
+        const datalist = document.getElementById(id);
+        if (!datalist) return;
+
+        datalist.innerHTML = '';
+        lojas.forEach((loja) => {
+          const option = document.createElement('option');
+          option.value = loja;
+          datalist.appendChild(option);
+        });
       });
     }
 
@@ -2454,6 +2456,105 @@ containerAcoes.appendChild(botaoEditar);
       } catch (erro) {
         console.error('Erro ao excluir etiqueta VTS:', erro);
         setVtsFeedback('Não foi possível excluir o registro. Tente novamente mais tarde.', 'error');
+      }
+    }
+
+    async function registrarEntradaManualVts(event) {
+      event?.preventDefault?.();
+
+      if (!db || !usuarioLogado?.uid) {
+        setVtsFeedback('Não foi possível registrar a etiqueta manualmente no momento. Tente novamente mais tarde.', 'error');
+        return;
+      }
+
+      const formulario = document.getElementById('vtsEntradaManualForm');
+      if (!formulario) return;
+
+      const skuInput = document.getElementById('vtsManualSku');
+      const pedidoInput = document.getElementById('vtsManualPedido');
+      const rastreioInput = document.getElementById('vtsManualRastreio');
+      const lojaInput = document.getElementById('vtsManualLoja');
+      const dataInput = document.getElementById('vtsManualData');
+      const buyerInput = document.getElementById('vtsManualBuyer');
+      const botao = document.getElementById('vtsEntradaManualSubmit');
+
+      const skuValorBruto = skuInput?.value?.trim() || '';
+      const skuValorNormalizado = skuValorBruto ? limparValorSkuVts(skuValorBruto) : '';
+      const skuValor = skuValorNormalizado || skuValorBruto;
+
+      const pedidoValorBruto = pedidoInput?.value?.trim() || '';
+      const pedidoValor = pedidoValorBruto ? normalizarLinhaVts(pedidoValorBruto) : '';
+
+      const rastreioValorBruto = rastreioInput?.value?.trim() || '';
+      const rastreioValor = rastreioValorBruto ? normalizarLinhaVts(rastreioValorBruto) : '';
+
+      if (!pedidoValor && !rastreioValor) {
+        setVtsFeedback('Informe o número do pedido ou o código de rastreio para registrar a etiqueta manualmente.', 'warning');
+        (pedidoInput || rastreioInput)?.focus();
+        return;
+      }
+
+      let lojaValor = lojaInput?.value?.trim() || '';
+      if (lojaValor) {
+        const lojaLimpa = limparNomeLojaVts(lojaValor);
+        lojaValor = lojaLimpa || lojaValor;
+      }
+
+      const dataValor = dataInput?.value?.trim() || '';
+      let dataNormalizada = '';
+      let dataTexto = '';
+      if (dataValor) {
+        dataNormalizada = normalizeDate(dataValor);
+        if (dataNormalizada) {
+          const [ano, mes, dia] = dataNormalizada.split('-');
+          if (ano && mes && dia) {
+            dataTexto = `${dia}/${mes}/${ano}`;
+          }
+        }
+      }
+
+      const buyerValor = buyerInput?.value?.trim() || '';
+
+      const textoOriginalBotao = botao?.innerHTML;
+      if (botao) {
+        botao.disabled = true;
+        botao.innerHTML = '<i class="fas fa-circle-notch fa-spin mr-2"></i>Registrando etiqueta...';
+        botao.classList.add('opacity-70');
+      }
+
+      try {
+        const etiquetaManual = {
+          sku: skuValor,
+          pedido: pedidoValor,
+          rastreio: rastreioValor,
+          loja: lojaValor,
+          dataNormalizada,
+          dataTexto,
+          buyerUsername: buyerValor,
+          modelo: 'manual',
+        };
+
+        const { salvos = 0, ignorados = 0 } = await salvarEtiquetasVts([etiquetaManual], null, 'manual');
+
+        if (salvos > 0) {
+          setVtsFeedback('Etiqueta registrada manualmente com sucesso.', 'success');
+          formulario.reset();
+          skuInput?.focus();
+          await carregarEtiquetasVts();
+        } else if (ignorados > 0) {
+          setVtsFeedback('O pedido informado já possui uma etiqueta cadastrada anteriormente.', 'warning');
+        } else {
+          setVtsFeedback('Nenhum registro foi criado. Verifique os dados informados e tente novamente.', 'info');
+        }
+      } catch (erro) {
+        console.error('Erro ao registrar etiqueta manual VTS:', erro);
+        setVtsFeedback('Não foi possível registrar a etiqueta manualmente. Tente novamente mais tarde.', 'error');
+      } finally {
+        if (botao) {
+          botao.disabled = false;
+          botao.innerHTML = textoOriginalBotao || 'Registrar etiqueta manualmente';
+          botao.classList.remove('opacity-70');
+        }
       }
     }
 
@@ -3906,6 +4007,11 @@ containerAcoes.appendChild(botaoEditar);
             inputModelo.dataset.bound = 'true';
           }
         });
+        const formularioManual = document.getElementById('vtsEntradaManualForm');
+        if (formularioManual && !formularioManual.dataset.bound) {
+          formularioManual.addEventListener('submit', registrarEntradaManualVts);
+          formularioManual.dataset.bound = 'true';
+        }
         const formularioDevolucao = document.getElementById('vtsDevolucaoForm');
         if (formularioDevolucao && !formularioDevolucao.dataset.bound) {
           formularioDevolucao.addEventListener('submit', registrarDevolucaoVts);

--- a/sobras-tabs/vts.html
+++ b/sobras-tabs/vts.html
@@ -130,6 +130,88 @@
   </div>
 </div>
 <div class="card max-w-5xl mx-auto mt-6">
+  <div class="card-header flex items-center gap-3">
+    <i class="fas fa-keyboard text-emerald-600"></i>
+    <div>
+      <h3 class="text-lg font-semibold text-slate-800">Entrada manual de etiqueta</h3>
+      <p class="text-sm text-slate-500">
+        Registre manualmente uma etiqueta quando não for possível processar o PDF. Informe pelo menos o número
+        do pedido ou o código de rastreio para localizar o registro futuramente.
+      </p>
+    </div>
+  </div>
+  <div class="card-body">
+    <form id="vtsEntradaManualForm" class="grid gap-4 md:grid-cols-2">
+      <div>
+        <label for="vtsManualSku" class="block text-xs font-medium text-slate-600">SKU</label>
+        <input
+          type="text"
+          id="vtsManualSku"
+          class="form-control"
+          placeholder="Informe o SKU (opcional)"
+          autocomplete="off"
+        />
+      </div>
+      <div>
+        <label for="vtsManualPedido" class="block text-xs font-medium text-slate-600">Número do pedido</label>
+        <input
+          type="text"
+          id="vtsManualPedido"
+          class="form-control"
+          placeholder="Obrigatório se não informar o rastreio"
+          autocomplete="off"
+        />
+      </div>
+      <div>
+        <label for="vtsManualRastreio" class="block text-xs font-medium text-slate-600">Código de rastreio</label>
+        <input
+          type="text"
+          id="vtsManualRastreio"
+          class="form-control"
+          placeholder="Obrigatório se não informar o pedido"
+          autocomplete="off"
+        />
+      </div>
+      <div>
+        <label for="vtsManualLoja" class="block text-xs font-medium text-slate-600">Loja</label>
+        <input
+          type="text"
+          id="vtsManualLoja"
+          class="form-control"
+          placeholder="Ex.: Shopee"
+          list="vtsManualLojas"
+          autocomplete="off"
+        />
+        <datalist id="vtsManualLojas"></datalist>
+      </div>
+      <div>
+        <label for="vtsManualData" class="block text-xs font-medium text-slate-600">Data da etiqueta</label>
+        <input type="date" id="vtsManualData" class="form-control" />
+      </div>
+      <div>
+        <label for="vtsManualBuyer" class="block text-xs font-medium text-slate-600">Usuário/comprador</label>
+        <input
+          type="text"
+          id="vtsManualBuyer"
+          class="form-control"
+          placeholder="Nome do comprador (opcional)"
+          autocomplete="off"
+        />
+      </div>
+      <div class="md:col-span-2 flex justify-end">
+        <button type="submit" id="vtsEntradaManualSubmit" class="btn btn-success">
+          <i class="fas fa-save mr-2"></i>
+          Registrar etiqueta manualmente
+        </button>
+      </div>
+    </form>
+    <p class="mt-3 text-xs text-slate-400">
+      Sempre que possível, utilize o processamento automático via PDF para evitar duplicidades. A entrada
+      manual registra as mesmas informações e fica disponível na lista de etiquetas importadas.
+    </p>
+  </div>
+</div>
+<div class="card max-w-5xl mx-auto mt-6">
   <div class="card-header">
     <h3 class="text-lg font-semibold text-slate-800">Devoluções e cancelamentos</h3>
     <p class="text-sm text-slate-500">


### PR DESCRIPTION
## Summary
- add a manual label entry form to the VTS "Etiquetas" tab so pedidos podem ser cadastrados sem PDF
- conectar o novo formulário ao fluxo existente para salvar etiquetas, atualizar feedbacks e recarregar a lista
- reutilizar a lista de lojas sugeridas tanto nas devoluções quanto na entrada manual

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68dfbde738c4832aa3c26dbd8e70541a