### PR TITLE
Add date and store filters to VTS labels and summary

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -488,6 +488,194 @@ async function processarPlanilhaVendas({
       continue;
     }
 
+    function obterFiltrosSelecionadosVts({ dataInicioId = 'vtsFiltroDataInicio', dataFimId = 'vtsFiltroDataFim', lojaId = 'vtsFiltroLoja' } = {}) {
+      const inputInicio = document.getElementById(dataInicioId);
+      const inputFim = document.getElementById(dataFimId);
+      const selectLoja = document.getElementById(lojaId);
+
+      const valorInicio = normalizeDate(inputInicio?.value);
+      const valorFim = normalizeDate(inputFim?.value);
+
+      let dataInicio = valorInicio ? new Date(`${valorInicio}T00:00:00`) : null;
+      let dataFim = valorFim ? new Date(`${valorFim}T23:59:59.999`) : null;
+
+      if (dataInicio && dataFim && dataInicio > dataFim) {
+        const auxiliar = dataInicio;
+        dataInicio = dataFim;
+        dataFim = auxiliar;
+      }
+
+      const lojaTexto = selectLoja?.value ? selectLoja.value.toString().trim() : '';
+      const lojaNormalizada = lojaTexto ? normalizarComparacaoVts(lojaTexto) : '';
+
+      return {
+        dataInicio,
+        dataFim,
+        lojaTexto,
+        lojaNormalizada,
+      };
+    }
+
+    function aplicarFiltrosNosRegistrosVts(registros = [], filtros = {}) {
+      if (!Array.isArray(registros) || !registros.length) return [];
+
+      const { dataInicio = null, dataFim = null } = filtros || {};
+      const lojaNormalizada = filtros?.lojaNormalizada || filtros?.loja || '';
+      const lojaFiltro = lojaNormalizada ? normalizarComparacaoVts(lojaNormalizada) : '';
+
+      return registros.filter((registro) => {
+        const dataRegistro = obterDataRegistroVts(registro);
+
+        if (dataInicio && (!dataRegistro || dataRegistro < dataInicio)) {
+          return false;
+        }
+
+        if (dataFim && (!dataRegistro || dataRegistro > dataFim)) {
+          return false;
+        }
+
+        if (lojaFiltro) {
+          const lojaRegistro = normalizarComparacaoVts(registro?.loja);
+          if (lojaRegistro !== lojaFiltro) {
+            return false;
+          }
+        }
+
+        return true;
+      });
+    }
+
+    function atualizarOpcoesFiltroLojaVts(registros = []) {
+      const lojasOrdenadas = Array.from(
+        new Set(
+          (Array.isArray(registros) ? registros : [])
+            .map((item) => (item?.loja || '').toString().trim())
+            .filter(Boolean),
+        ),
+      ).sort((a, b) => a.localeCompare(b, 'pt-BR', { sensitivity: 'base' }));
+
+      ['vtsFiltroLoja', 'vtsResumoFiltroLoja'].forEach((id) => {
+        const select = document.getElementById(id);
+        if (!select) return;
+
+        const valorAtual = select.value;
+        select.innerHTML = '';
+
+        const opcaoTodas = document.createElement('option');
+        opcaoTodas.value = '';
+        opcaoTodas.textContent = 'Todas as lojas';
+        select.appendChild(opcaoTodas);
+
+        lojasOrdenadas.forEach((loja) => {
+          const option = document.createElement('option');
+          option.value = loja;
+          option.textContent = loja;
+          select.appendChild(option);
+        });
+
+        if (valorAtual && Array.from(select.options).some((option) => option.value === valorAtual)) {
+          select.value = valorAtual;
+        } else {
+          select.value = '';
+        }
+
+        // Mantém o valor selecionado apenas se ainda estiver disponível.
+      });
+    }
+
+    function sincronizarFiltrosResumoVts() {
+      const inicioPrincipal = document.getElementById('vtsFiltroDataInicio');
+      const fimPrincipal = document.getElementById('vtsFiltroDataFim');
+      const lojaPrincipal = document.getElementById('vtsFiltroLoja');
+
+      const inicioResumo = document.getElementById('vtsResumoFiltroDataInicio');
+      const fimResumo = document.getElementById('vtsResumoFiltroDataFim');
+      const lojaResumo = document.getElementById('vtsResumoFiltroLoja');
+
+      if (inicioResumo && !inicioResumo.value && inicioPrincipal?.value) {
+        inicioResumo.value = inicioPrincipal.value;
+      }
+
+      if (fimResumo && !fimResumo.value && fimPrincipal?.value) {
+        fimResumo.value = fimPrincipal.value;
+      }
+
+      if (lojaResumo && !lojaResumo.value && lojaPrincipal?.value) {
+        lojaResumo.value = lojaPrincipal.value;
+      }
+    }
+
+    function limparFiltrosVts() {
+      const inicio = document.getElementById('vtsFiltroDataInicio');
+      const fim = document.getElementById('vtsFiltroDataFim');
+      const loja = document.getElementById('vtsFiltroLoja');
+
+      if (inicio) inicio.value = '';
+      if (fim) fim.value = '';
+      if (loja) loja.value = '';
+
+      renderizarEtiquetasVts(vtsEtiquetasRegistros);
+    }
+
+    function limparFiltrosResumoVts() {
+      const inicio = document.getElementById('vtsResumoFiltroDataInicio');
+      const fim = document.getElementById('vtsResumoFiltroDataFim');
+      const loja = document.getElementById('vtsResumoFiltroLoja');
+
+      if (inicio) inicio.value = '';
+      if (fim) fim.value = '';
+      if (loja) loja.value = '';
+
+      atualizarResumoMensalVts();
+    }
+
+    function configurarFiltrosVts() {
+      const filtros = [
+        { id: 'vtsFiltroDataInicio', evento: 'change' },
+        { id: 'vtsFiltroDataFim', evento: 'change' },
+        { id: 'vtsFiltroLoja', evento: 'change' },
+      ];
+
+      filtros.forEach(({ id, evento }) => {
+        const elemento = document.getElementById(id);
+        if (!elemento || elemento.dataset.bound) return;
+
+        elemento.addEventListener(evento, () => {
+          renderizarEtiquetasVts(vtsEtiquetasRegistros);
+        });
+        elemento.dataset.bound = 'true';
+      });
+
+      const botaoLimpar = document.getElementById('vtsFiltrosLimpar');
+      if (botaoLimpar && !botaoLimpar.dataset.bound) {
+        botaoLimpar.addEventListener('click', () => limparFiltrosVts());
+        botaoLimpar.dataset.bound = 'true';
+      }
+    }
+
+    function configurarFiltrosResumoVts() {
+      const filtros = [
+        { id: 'vtsResumoFiltroDataInicio', evento: 'change' },
+        { id: 'vtsResumoFiltroDataFim', evento: 'change' },
+        { id: 'vtsResumoFiltroLoja', evento: 'change' },
+      ];
+
+      filtros.forEach(({ id, evento }) => {
+        const elemento = document.getElementById(id);
+        if (!elemento || elemento.dataset.bound) return;
+
+        elemento.addEventListener(evento, () => atualizarResumoMensalVts());
+        elemento.dataset.bound = id === 'vtsResumoFiltroLoja' ? 'change-sync' : 'true';
+      });
+
+      const botaoLimpar = document.getElementById('vtsResumoFiltrosLimpar');
+      if (botaoLimpar && !botaoLimpar.dataset.bound) {
+        botaoLimpar.addEventListener('click', () => limparFiltrosResumoVts());
+        botaoLimpar.dataset.bound = 'true';
+      }
+    }
+
+
     const {
       numeroVenda,
       estado = '',
@@ -1856,6 +2044,7 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
       });
 
       if (subtabId === 'resumo') {
+        sincronizarFiltrosResumoVts();
         atualizarResumoMensalVts();
       }
     }
@@ -1936,27 +2125,43 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
       return null;
     }
 
-    function atualizarResumoMensalVts() {
+    function atualizarResumoMensalVts(registrosBase = vtsEtiquetasRegistros) {
       const tabelaCorpo = document.getElementById('vtsResumoTabelaCorpo');
       const totalVendidoEl = document.getElementById('vtsResumoTotalVendido');
       const totalCanceladoEl = document.getElementById('vtsResumoTotalCancelado');
       const totalEsperadoEl = document.getElementById('vtsResumoTotalEsperado');
       if (!tabelaCorpo || !totalVendidoEl || !totalCanceladoEl || !totalEsperadoEl) return;
 
+      const registrosFonte = Array.isArray(registrosBase) ? registrosBase : vtsEtiquetasRegistros;
+
+      const filtrosResumo = obterFiltrosSelecionadosVts({
+        dataInicioId: 'vtsResumoFiltroDataInicio',
+        dataFimId: 'vtsResumoFiltroDataFim',
+        lojaId: 'vtsResumoFiltroLoja',
+      });
+
       const seletorMes = document.getElementById('vtsResumoMes');
-      const periodo = obterPeriodoMesVts(seletorMes?.value);
-      if (!periodo) return;
+      const periodoMes = obterPeriodoMesVts(seletorMes?.value);
+
+      let dataInicio = filtrosResumo.dataInicio;
+      let dataFim = filtrosResumo.dataFim;
+
+      if (!dataInicio && !dataFim && periodoMes) {
+        dataInicio = periodoMes.inicio;
+        dataFim = new Date(periodoMes.fim.getTime() - 1);
+      }
+
+      const registrosFiltrados = aplicarFiltrosNosRegistrosVts(registrosFonte, {
+        dataInicio,
+        dataFim,
+        lojaNormalizada: filtrosResumo.lojaNormalizada,
+      });
 
       const resumoMapa = new Map();
       let totalVendido = 0;
       let totalCancelado = 0;
 
-      vtsEtiquetasRegistros.forEach((registro) => {
-        const dataRegistro = obterDataRegistroVts(registro);
-        if (!dataRegistro || dataRegistro < periodo.inicio || dataRegistro >= periodo.fim) {
-          return;
-        }
-
+      registrosFiltrados.forEach((registro) => {
         const skuOriginal = (registro.sku || '').trim();
         if (!skuOriginal) return;
 
@@ -2000,7 +2205,7 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
         const coluna = document.createElement('td');
         coluna.colSpan = 5;
         coluna.className = 'px-4 py-4 text-center text-sm text-slate-500';
-        coluna.textContent = 'Nenhum registro encontrado para o período selecionado.';
+        coluna.textContent = 'Nenhum registro encontrado para os filtros selecionados.';
         linha.appendChild(coluna);
         tabelaCorpo.appendChild(linha);
       } else {
@@ -2039,23 +2244,53 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
       });
 
       const possuiResultados = linhasOrdenadas.length > 0;
+
+      const detalhesMensagem = [];
+      if (dataInicio && dataFim) {
+        const inicioTexto = dataInicio.toLocaleDateString('pt-BR');
+        const fimTexto = dataFim.toLocaleDateString('pt-BR');
+        detalhesMensagem.push(
+          inicioTexto === fimTexto ? `dia ${inicioTexto}` : `período de ${inicioTexto} a ${fimTexto}`,
+        );
+      } else if (dataInicio) {
+        detalhesMensagem.push(`a partir de ${dataInicio.toLocaleDateString('pt-BR')}`);
+      } else if (dataFim) {
+        detalhesMensagem.push(`até ${dataFim.toLocaleDateString('pt-BR')}`);
+      } else if (periodoMes) {
+        detalhesMensagem.push(`mês ${String(periodoMes.mes).padStart(2, '0')}/${periodoMes.ano}`);
+      }
+
+      if (filtrosResumo.lojaTexto) {
+        detalhesMensagem.push(`loja ${filtrosResumo.lojaTexto}`);
+      }
+
+      const mensagemSucesso = detalhesMensagem.length
+        ? `Resumo atualizado para ${detalhesMensagem.join(' e ')}.`
+        : 'Resumo atualizado com todos os registros.';
+
       aplicarFeedbackGenericoVts(
         'vtsResumoFeedback',
-        possuiResultados
-          ? `Resumo atualizado para ${String(periodo.mes).padStart(2, '0')}/${periodo.ano}.`
-          : 'Não encontramos etiquetas para o mês selecionado.',
+        possuiResultados ? mensagemSucesso : 'Nenhum registro encontrado para os filtros selecionados.',
         possuiResultados ? 'info' : 'warning',
       );
     }
 
-    function atualizarResumoEtiquetasVts(total = vtsEtiquetasRegistros.length) {
+    function atualizarResumoEtiquetasVts(totalFiltrado = vtsEtiquetasRegistros.length, totalGeral = vtsEtiquetasRegistros.length) {
       const resumo = document.getElementById('vtsResumo');
       if (!resumo) return;
 
-      if (total > 0) {
-        resumo.textContent = `${total} etiqueta(s) importadas.`;
-      } else {
+      const totalImportado = Number.isFinite(Number(totalGeral)) ? Number(totalGeral) : 0;
+      const totalExibido = Number.isFinite(Number(totalFiltrado)) ? Number(totalFiltrado) : 0;
+
+      if (totalImportado <= 0) {
         resumo.textContent = 'Nenhuma etiqueta importada até o momento.';
+        return;
+      }
+
+      if (totalExibido === totalImportado) {
+        resumo.textContent = `${totalImportado} etiqueta(s) importadas.`;
+      } else {
+        resumo.textContent = `Exibindo ${totalExibido} de ${totalImportado} etiqueta(s) importadas.`;
       }
     }
 
@@ -2103,7 +2338,6 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
 
         renderizarEtiquetasVts(vtsEtiquetasRegistros);
         vtsCarregado = true;
-        atualizarResumoEtiquetasVts(vtsEtiquetasRegistros.length);
       } catch (erro) {
         console.error('Erro ao carregar etiquetas VTS:', erro);
         setVtsFeedback('Não foi possível carregar as etiquetas importadas. Tente novamente mais tarde.', 'error');
@@ -2141,22 +2375,29 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
       const corpoTabela = document.getElementById('vtsTabelaCorpo');
       if (!corpoTabela) return;
 
-      corpoTabela.innerHTML = '';
-      atualizarDatalistLojasVts(registros);
+      const todosRegistros = Array.isArray(registros) ? registros : [];
 
-      if (!registros.length) {
+      corpoTabela.innerHTML = '';
+      atualizarDatalistLojasVts(vtsEtiquetasRegistros);
+      atualizarOpcoesFiltroLojaVts(vtsEtiquetasRegistros);
+
+      const filtrosSelecionados = obterFiltrosSelecionadosVts();
+      const registrosFiltrados = aplicarFiltrosNosRegistrosVts(todosRegistros, filtrosSelecionados);
+
+      if (!registrosFiltrados.length) {
         const linha = document.createElement('tr');
         const coluna = document.createElement('td');
         coluna.colSpan = 8;
         coluna.className = 'px-4 py-4 text-center text-sm text-slate-500';
-        coluna.textContent = 'Nenhum registro encontrado.';
+        coluna.textContent = 'Nenhum registro encontrado para os filtros selecionados.';
         linha.appendChild(coluna);
         corpoTabela.appendChild(linha);
-        atualizarResumoMensalVts();
+        atualizarResumoEtiquetasVts(0, todosRegistros.length);
+        atualizarResumoMensalVts(todosRegistros);
         return;
       }
 
-      registros.forEach((item) => {
+      registrosFiltrados.forEach((item) => {
         const linha = document.createElement('tr');
         linha.className = 'border-b border-slate-100 transition-colors hover:bg-slate-50';
         let tituloModelo = '';
@@ -2231,23 +2472,20 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
 
         const colunaAcoes = document.createElement('td');
         colunaAcoes.className = 'px-4 py-3 text-sm';
-if (estaCancelado) {
-  // Mantém o destaque quando o item está cancelado
-  colunaAcoes.classList.add('text-rose-700');
-}
+        if (estaCancelado) {
+          colunaAcoes.classList.add('text-rose-700');
+        }
 
-// Container dos botões
-const containerAcoes = document.createElement('div');
-containerAcoes.className = 'flex flex-wrap items-center gap-2';
+        const containerAcoes = document.createElement('div');
+        containerAcoes.className = 'flex flex-wrap items-center gap-2';
 
-// Botão Editar
-const botaoEditar = document.createElement('button');
-botaoEditar.type = 'button';
-botaoEditar.className = 'btn btn-sm flex items-center gap-2 text-slate-600 hover:text-slate-700';
-botaoEditar.innerHTML = '<i class="fas fa-edit"></i><span>Editar</span>';
-botaoEditar.addEventListener('click', () => editarEtiquetaVts(item));
-containerAcoes.appendChild(botaoEditar);
-        
+        const botaoEditar = document.createElement('button');
+        botaoEditar.type = 'button';
+        botaoEditar.className = 'btn btn-sm flex items-center gap-2 text-slate-600 hover:text-slate-700';
+        botaoEditar.innerHTML = '<i class="fas fa-edit"></i><span>Editar</span>';
+        botaoEditar.addEventListener('click', () => editarEtiquetaVts(item));
+        containerAcoes.appendChild(botaoEditar);
+
         const botaoExcluir = document.createElement('button');
         botaoExcluir.type = 'button';
         botaoExcluir.className = 'btn btn-sm flex items-center gap-2 text-rose-600 hover:text-rose-700';
@@ -2261,7 +2499,8 @@ containerAcoes.appendChild(botaoEditar);
         corpoTabela.appendChild(linha);
       });
 
-      atualizarResumoMensalVts();
+      atualizarResumoEtiquetasVts(registrosFiltrados.length, todosRegistros.length);
+      atualizarResumoMensalVts(todosRegistros);
     }
 
     async function editarEtiquetaVts(registro) {
@@ -2414,7 +2653,6 @@ containerAcoes.appendChild(botaoEditar);
         );
 
         renderizarEtiquetasVts(vtsEtiquetasRegistros);
-        atualizarResumoEtiquetasVts();
         setVtsFeedback('Registro atualizado com sucesso.', 'success');
       } catch (erro) {
         console.error('Erro ao atualizar etiqueta VTS:', erro);
@@ -2451,7 +2689,6 @@ containerAcoes.appendChild(botaoEditar);
         await db.collection('vtsEtiquetas').doc(registroId).delete();
         vtsEtiquetasRegistros = vtsEtiquetasRegistros.filter((item) => item.id !== registroId);
         renderizarEtiquetasVts(vtsEtiquetasRegistros);
-        atualizarResumoEtiquetasVts();
         setVtsFeedback('Registro excluído com sucesso.', 'success');
       } catch (erro) {
         console.error('Erro ao excluir etiqueta VTS:', erro);
@@ -4035,6 +4272,8 @@ containerAcoes.appendChild(botaoEditar);
         }
         configurarSubtabsVts();
         configurarAssociacoesVts();
+        configurarFiltrosVts();
+        configurarFiltrosResumoVts();
         configurarResumoMesVts();
         container.dataset.initialized = 'true';
       }

--- a/sobras-tabs/vts.html
+++ b/sobras-tabs/vts.html
@@ -270,11 +270,39 @@
     </p>
   </div>
 </div>
-<div class="card max-w-6xl mx-auto mt-8">
+  <div class="card max-w-6xl mx-auto mt-8">
   <div class="card-header flex flex-wrap items-center justify-between gap-2">
     <div>
       <h3 class="text-lg font-semibold text-slate-800">Etiquetas importadas</h3>
       <p id="vtsResumo" class="text-sm text-slate-500">Carregando registros...</p>
+    </div>
+    <div class="flex flex-wrap items-end gap-3">
+      <div class="flex flex-col">
+        <label for="vtsFiltroDataInicio" class="text-xs font-medium text-slate-600 uppercase tracking-wide">
+          Data inicial
+        </label>
+        <input type="date" id="vtsFiltroDataInicio" class="form-control w-36" />
+      </div>
+      <div class="flex flex-col">
+        <label for="vtsFiltroDataFim" class="text-xs font-medium text-slate-600 uppercase tracking-wide">
+          Data final
+        </label>
+        <input type="date" id="vtsFiltroDataFim" class="form-control w-36" />
+      </div>
+      <div class="flex flex-col">
+        <label for="vtsFiltroLoja" class="text-xs font-medium text-slate-600 uppercase tracking-wide">Loja</label>
+        <select id="vtsFiltroLoja" class="form-control w-44">
+          <option value="">Todas as lojas</option>
+        </select>
+      </div>
+      <button
+        id="vtsFiltrosLimpar"
+        type="button"
+        class="btn btn-secondary whitespace-nowrap"
+      >
+        <i class="fas fa-eraser mr-2"></i>
+        Limpar filtros
+      </button>
     </div>
   </div>
   <div class="card-body p-0">
@@ -430,9 +458,37 @@
           O resumo consolida as etiquetas importadas agrupando por SKU principal e seus associados.
         </p>
       </div>
-      <div class="flex items-center gap-2">
-        <label for="vtsResumoMes" class="text-xs font-medium text-slate-600 uppercase tracking-wide">Mês de referência</label>
-        <input type="month" id="vtsResumoMes" class="form-control w-36" />
+      <div class="flex flex-wrap items-end gap-3">
+        <div class="flex flex-col">
+          <label for="vtsResumoMes" class="text-xs font-medium text-slate-600 uppercase tracking-wide">Mês de referência</label>
+          <input type="month" id="vtsResumoMes" class="form-control w-36" />
+        </div>
+        <div class="flex flex-col">
+          <label for="vtsResumoFiltroDataInicio" class="text-xs font-medium text-slate-600 uppercase tracking-wide">
+            Data inicial
+          </label>
+          <input type="date" id="vtsResumoFiltroDataInicio" class="form-control w-36" />
+        </div>
+        <div class="flex flex-col">
+          <label for="vtsResumoFiltroDataFim" class="text-xs font-medium text-slate-600 uppercase tracking-wide">
+            Data final
+          </label>
+          <input type="date" id="vtsResumoFiltroDataFim" class="form-control w-36" />
+        </div>
+        <div class="flex flex-col">
+          <label for="vtsResumoFiltroLoja" class="text-xs font-medium text-slate-600 uppercase tracking-wide">Loja</label>
+          <select id="vtsResumoFiltroLoja" class="form-control w-44">
+            <option value="">Todas as lojas</option>
+          </select>
+        </div>
+        <button
+          id="vtsResumoFiltrosLimpar"
+          type="button"
+          class="btn btn-secondary whitespace-nowrap"
+        >
+          <i class="fas fa-eraser mr-2"></i>
+          Limpar filtros
+        </button>
       </div>
     </div>
     <div class="card-body space-y-4">


### PR DESCRIPTION
## Summary
- add date range and store filters to the VTS etiquetas and resumo interfaces
- apply the new filters when rendering imported label rows and the monthly summary, updating feedback messages
- hook the filter controls into the VTS initialization flow with reset helpers and shared store options

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dfc164a31c832a8ff5c07c7cd4f99d