### PR TITLE
Add manual user products tab for anuncios workflow

### DIFF
--- a/Gerenciamento de ANUNCIOS E DESEMPENHO.html
+++ b/Gerenciamento de ANUNCIOS E DESEMPENHO.html
@@ -41,6 +41,9 @@
       <button class="tab-button" data-tab="planilha-shopee">
         <i class="fas fa-file-excel mr-2"></i>PLANILHA SHOPEE
       </button>
+      <button class="tab-button" data-tab="produtos-usuarios">
+        <i class="fas fa-box-open mr-2"></i>Produtos dos Usuários
+      </button>
     </div>
 
     <!-- Cadastro/Atualização -->
@@ -59,6 +62,9 @@
 
     <!-- PLANILHA SHOPEE -->
        <div id="planilha-shopee" class="tab-content"></div>
+
+    <!-- Produtos dos Usuários -->
+       <div id="produtos-usuarios" class="tab-content"></div>
 
 
       </div>

--- a/anuncios-produtos-usuarios.js
+++ b/anuncios-produtos-usuarios.js
@@ -1,0 +1,241 @@
+import {
+  collection,
+  doc,
+  getDocs,
+  setDoc,
+  serverTimestamp,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { db, auth } from './firebase-config.js';
+
+const form = document.getElementById('formProdutoUsuario');
+const statusEl = document.getElementById('statusCadastroProdutoUsuario');
+const filtroSkuInput = document.getElementById('filtroSkuProdutosUsuarios');
+const cardsContainer = document.getElementById('cardsProdutosUsuarios');
+const emptyState = document.getElementById('emptyProdutosUsuarios');
+
+let produtosCache = [];
+let usuarioAtual = null;
+let carregando = false;
+
+const moedaFormatter = new Intl.NumberFormat('pt-BR', {
+  style: 'currency',
+  currency: 'BRL',
+});
+
+function setStatus(message, type = 'info') {
+  if (!statusEl) return;
+  if (!message) {
+    statusEl.textContent = '';
+    statusEl.className = 'text-sm';
+    return;
+  }
+  const baseClass =
+    type === 'success'
+      ? 'text-sm text-green-600'
+      : type === 'error'
+        ? 'text-sm text-red-600'
+        : 'text-sm text-gray-600';
+  statusEl.className = baseClass;
+  statusEl.textContent = message;
+}
+
+function normalizarSku(sku) {
+  return sku ? sku.trim().toUpperCase() : '';
+}
+
+function renderCards(lista) {
+  if (!cardsContainer || !emptyState) return;
+  cardsContainer.innerHTML = '';
+  if (!lista.length) {
+    emptyState.classList.remove('hidden');
+    return;
+  }
+  emptyState.classList.add('hidden');
+  const fragment = document.createDocumentFragment();
+  for (const produto of lista) {
+    const card = document.createElement('div');
+    card.className = 'bg-white border border-gray-200 rounded-lg shadow-sm p-4 flex flex-col h-full';
+
+    if (produto.imagemUrl) {
+      const img = document.createElement('img');
+      img.src = produto.imagemUrl;
+      img.alt = produto.nome || produto.sku;
+      img.className = 'w-full h-40 object-cover rounded mb-4';
+      img.onerror = () => {
+        img.classList.add('hidden');
+      };
+      card.appendChild(img);
+    }
+
+    const titulo = document.createElement('h3');
+    titulo.className = 'text-lg font-semibold text-gray-800 mb-1';
+    titulo.textContent = produto.nome || 'Produto sem nome';
+    card.appendChild(titulo);
+
+    const sku = document.createElement('p');
+    sku.className = 'text-sm font-mono text-gray-500 mb-2';
+    sku.textContent = `SKU: ${produto.sku}`;
+    card.appendChild(sku);
+
+    const descricao = document.createElement('p');
+    descricao.className = 'text-sm text-gray-600 flex-1';
+    descricao.textContent = produto.descricao || 'Sem descrição informada.';
+    card.appendChild(descricao);
+
+    const preco = document.createElement('p');
+    preco.className = 'text-base font-semibold text-orange-600 mt-4';
+    preco.textContent =
+      typeof produto.preco === 'number'
+        ? moedaFormatter.format(produto.preco)
+        : 'Preço não informado';
+    card.appendChild(preco);
+
+    const data = document.createElement('p');
+    data.className = 'text-xs text-gray-400 mt-2';
+    if (produto.updatedAt) {
+      const dt = produto.updatedAt.toDate
+        ? produto.updatedAt.toDate()
+        : new Date(produto.updatedAt);
+      if (!Number.isNaN(dt.getTime())) {
+        data.textContent = `Atualizado em ${dt.toLocaleString('pt-BR')}`;
+      }
+    }
+    if (!data.textContent) {
+      data.textContent = '—';
+    }
+    card.appendChild(data);
+
+    fragment.appendChild(card);
+  }
+  cardsContainer.appendChild(fragment);
+}
+
+function aplicarFiltro() {
+  const termo = normalizarSku(filtroSkuInput?.value || '');
+  if (!termo) {
+    renderCards(produtosCache);
+    return;
+  }
+  const filtrados = produtosCache.filter((produto) =>
+    normalizarSku(produto.sku).includes(termo),
+  );
+  renderCards(filtrados);
+}
+
+async function carregarProdutos(uid) {
+  if (!uid || carregando) return;
+  carregando = true;
+  try {
+    const colRef = collection(db, `uid/${uid}/produtosUsuarios`);
+    const snap = await getDocs(colRef);
+    produtosCache = snap.docs
+      .map((docSnap) => ({
+        id: docSnap.id,
+        ...docSnap.data(),
+        sku: docSnap.id,
+      }))
+      .sort((a, b) => {
+        const aTime = a.updatedAt?.toMillis
+          ? a.updatedAt.toMillis()
+          : new Date(a.updatedAt || a.createdAt || 0).getTime();
+        const bTime = b.updatedAt?.toMillis
+          ? b.updatedAt.toMillis()
+          : new Date(b.updatedAt || b.createdAt || 0).getTime();
+        return bTime - aTime;
+      });
+    aplicarFiltro();
+  } catch (err) {
+    console.error('Erro ao carregar produtos dos usuários:', err);
+    setStatus('Não foi possível carregar os produtos cadastrados.', 'error');
+  } finally {
+    carregando = false;
+  }
+}
+
+async function salvarProduto(event) {
+  event.preventDefault();
+  if (!usuarioAtual) {
+    setStatus('É necessário estar logado para salvar produtos.', 'error');
+    return;
+  }
+
+  const nomeInput = document.getElementById('nomeProdutoUsuario');
+  const skuInput = document.getElementById('skuProdutoUsuario');
+  const descricaoInput = document.getElementById('descricaoProdutoUsuario');
+  const precoInput = document.getElementById('precoProdutoUsuario');
+  const imagemInput = document.getElementById('imagemProdutoUsuario');
+
+  const sku = normalizarSku(skuInput?.value || '');
+  if (!sku) {
+    setStatus('Informe um SKU válido para o produto.', 'error');
+    return;
+  }
+
+  const precoTexto = `${precoInput?.value ?? ''}`.replace(',', '.');
+  const precoValor = parseFloat(precoTexto || '0');
+  if (Number.isNaN(precoValor) || precoValor < 0) {
+    setStatus('Informe um preço válido (maior ou igual a zero).', 'error');
+    return;
+  }
+
+  const jaExistente = produtosCache.some(
+    (produto) => normalizarSku(produto.sku) === sku,
+  );
+
+  const dados = {
+    nome: nomeInput?.value.trim() || '',
+    sku,
+    descricao: descricaoInput?.value.trim() || '',
+    preco: Number(precoValor.toFixed(2)),
+    imagemUrl: imagemInput?.value.trim() || '',
+    updatedAt: serverTimestamp(),
+    ...(jaExistente ? {} : { createdAt: serverTimestamp() }),
+  };
+
+  if (!dados.nome) {
+    setStatus('Informe o nome do produto.', 'error');
+    return;
+  }
+
+  setStatus('Salvando produto...', 'info');
+
+  try {
+    const docRef = doc(collection(db, `uid/${usuarioAtual}/produtosUsuarios`), sku);
+    await setDoc(docRef, dados, { merge: true });
+    setStatus('Produto salvo com sucesso!', 'success');
+    form?.reset();
+    if (nomeInput) nomeInput.focus();
+    await carregarProdutos(usuarioAtual);
+  } catch (err) {
+    console.error('Erro ao salvar produto personalizado:', err);
+    setStatus('Erro ao salvar o produto. Tente novamente.', 'error');
+  }
+}
+
+if (form) {
+  form.addEventListener('submit', salvarProduto);
+}
+
+if (filtroSkuInput) {
+  filtroSkuInput.addEventListener('input', aplicarFiltro);
+}
+
+onAuthStateChanged(auth, async (user) => {
+  if (!user) {
+    usuarioAtual = null;
+    produtosCache = [];
+    renderCards([]);
+    setStatus('Faça login para cadastrar e visualizar produtos.', 'info');
+    return;
+  }
+  usuarioAtual = user.uid;
+  setStatus('');
+  await carregarProdutos(usuarioAtual);
+});
+
+// Se o usuário já estiver autenticado (página carregada depois do login)
+if (auth.currentUser) {
+  usuarioAtual = auth.currentUser.uid;
+  carregarProdutos(usuarioAtual);
+}

--- a/anuncios-tabs/produtos-usuarios.html
+++ b/anuncios-tabs/produtos-usuarios.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Produtos dos Usuários</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet" />
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+  />
+  <link rel="stylesheet" href="../css/styles.css?v=20240826" />
+</head>
+<body>
+  <div id="tab-content">
+    <div class="space-y-6">
+      <div class="card">
+        <div class="card-header">
+          <div class="flex items-center">
+            <i class="fas fa-box-open text-2xl text-blue-600 mr-3"></i>
+            <h2 class="text-2xl font-bold">Cadastrar Produto Manualmente</h2>
+          </div>
+        </div>
+        <div class="card-body space-y-6">
+          <p class="text-gray-600">
+            Cadastre produtos personalizados informando nome, SKU, descrição e preço. A imagem é opcional.
+            Os dados ficam salvos no Firebase utilizando o SKU como chave única.
+          </p>
+          <form id="formProdutoUsuario" class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div class="md:col-span-1">
+              <label for="nomeProdutoUsuario" class="block text-sm font-medium text-gray-700 mb-1">Nome do Produto</label>
+              <input
+                type="text"
+                id="nomeProdutoUsuario"
+                class="w-full border rounded px-4 py-2 shadow-sm focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+                placeholder="Ex: Camiseta Premium"
+                required
+              />
+            </div>
+            <div class="md:col-span-1">
+              <label for="skuProdutoUsuario" class="block text-sm font-medium text-gray-700 mb-1">SKU (chave única)</label>
+              <input
+                type="text"
+                id="skuProdutoUsuario"
+                class="w-full border rounded px-4 py-2 shadow-sm focus:ring-2 focus:ring-orange-500 focus:border-orange-500 uppercase"
+                placeholder="Ex: SKU-001"
+                required
+              />
+            </div>
+            <div class="md:col-span-2">
+              <label for="descricaoProdutoUsuario" class="block text-sm font-medium text-gray-700 mb-1">Descrição</label>
+              <textarea
+                id="descricaoProdutoUsuario"
+                rows="4"
+                class="w-full border rounded px-4 py-2 shadow-sm focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+                placeholder="Detalhes importantes sobre o produto"
+              ></textarea>
+            </div>
+            <div>
+              <label for="precoProdutoUsuario" class="block text-sm font-medium text-gray-700 mb-1">Preço (R$)</label>
+              <input
+                type="number"
+                step="0.01"
+                id="precoProdutoUsuario"
+                class="w-full border rounded px-4 py-2 shadow-sm focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+                placeholder="Ex: 99.90"
+                required
+              />
+            </div>
+            <div>
+              <label for="imagemProdutoUsuario" class="block text-sm font-medium text-gray-700 mb-1">Imagem (URL opcional)</label>
+              <input
+                type="url"
+                id="imagemProdutoUsuario"
+                class="w-full border rounded px-4 py-2 shadow-sm focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+                placeholder="https://..."
+              />
+            </div>
+            <div class="md:col-span-2 flex justify-end">
+              <button type="submit" class="btn btn-primary px-6 py-2 flex items-center">
+                <i class="fas fa-save mr-2"></i>Salvar Produto
+              </button>
+            </div>
+          </form>
+          <div id="statusCadastroProdutoUsuario" class="text-sm"></div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div class="flex items-center">
+            <i class="fas fa-layer-group text-2xl text-green-600 mr-3"></i>
+            <h2 class="text-2xl font-bold">Produtos cadastrados</h2>
+          </div>
+          <div class="relative w-full sm:w-72">
+            <i class="fas fa-filter absolute left-3 top-3 text-gray-400"></i>
+            <input
+              type="text"
+              id="filtroSkuProdutosUsuarios"
+              placeholder="Filtrar por SKU"
+              class="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-full shadow-sm focus:ring-2 focus:ring-orange-500"
+            />
+          </div>
+        </div>
+        <div class="card-body">
+          <p id="emptyProdutosUsuarios" class="text-center text-gray-500 py-6 hidden">
+            Nenhum produto cadastrado até o momento.
+          </p>
+          <div id="cardsProdutosUsuarios" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="../firebase-config.js"></script>
+  <script type="module" src="../anuncios-produtos-usuarios.js"></script>
+</body>
+</html>

--- a/gerenciamento.js
+++ b/gerenciamento.js
@@ -26,7 +26,14 @@ import {
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 
 const BASE_PATH = new URL('.', import.meta.url);
-const tabs = ['cadastro', 'anuncios', 'analise', 'evolucao', 'planilha-shopee'];
+const tabs = [
+  'cadastro',
+  'anuncios',
+  'analise',
+  'evolucao',
+  'planilha-shopee',
+  'produtos-usuarios',
+];
 for (const t of tabs) {
   const container = document.getElementById(t);
   if (container) {


### PR DESCRIPTION
## Summary
- add a new "Produtos dos Usuários" tab to the anúncios workspace navigation
- create the tab layout with a registration form and SKU filter for user-defined products
- implement Firebase integration to persist manual products by SKU and render cards with the saved data

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7a8d4e3ac832aa9304f1e071c0922