### PR TITLE
Add user-managed product tab to Anúncios workflow

### DIFF
--- a/Gerenciamento de ANUNCIOS E DESEMPENHO.html
+++ b/Gerenciamento de ANUNCIOS E DESEMPENHO.html
@@ -32,6 +32,9 @@
       <button class="tab-button" data-tab="anuncios">
         <i class="fas fa-list mr-2"></i>Anúncios Salvos
       </button>
+      <button class="tab-button" data-tab="produtos-usuarios">
+        <i class="fas fa-boxes mr-2"></i>Produtos dos Usuários
+      </button>
       <button class="tab-button" data-tab="analise">
         <i class="fas fa-chart-line mr-2"></i>Análise/Sugestão
       </button>
@@ -48,6 +51,9 @@
 
     <!-- Anúncios Salvos -->
        <div id="anuncios" class="tab-content"></div>
+
+    <!-- Produtos dos Usuários -->
+       <div id="produtos-usuarios" class="tab-content"></div>
 
 
     <!-- Análise/Sugestão -->

--- a/anuncios-tabs/produtos-usuarios.html
+++ b/anuncios-tabs/produtos-usuarios.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>VendedorPro - Produtos de Usuários</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/styles.css?v=20240826">
+  <link rel="stylesheet" href="../css/tabs-mobile.css?v=20240826">
+</head>
+<body class="bg-gray-100 text-gray-800">
+  <div class="app-container">
+    <div id="sidebar-container"></div>
+    <div id="navbar-container"></div>
+    <div class="main-content">
+      <div id="tab-content">
+        <div class="card">
+          <div class="card-header">
+            <div class="flex items-center">
+              <i class="fas fa-box-open text-2xl text-green-600 mr-3"></i>
+              <h2 class="text-2xl font-bold">Produtos cadastrados pelos usuários</h2>
+            </div>
+          </div>
+          <div class="card-body">
+            <p class="text-gray-600 mb-6">
+              Registre manualmente informações de produtos para os usuários. Os cadastros são salvos no Firebase com o SKU como identificador principal.
+            </p>
+            <form id="produtoUsuarioForm" class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <div class="lg:col-span-1">
+                <label for="nomeProdutoUsuario" class="block text-sm font-medium text-gray-700 mb-2">Nome do produto *</label>
+                <input
+                  id="nomeProdutoUsuario"
+                  name="nome"
+                  type="text"
+                  required
+                  placeholder="Ex: Camiseta Minimalista"
+                  class="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-green-500 focus:border-green-500"
+                />
+              </div>
+              <div class="lg:col-span-1">
+                <label for="skuProdutoUsuario" class="block text-sm font-medium text-gray-700 mb-2">SKU *</label>
+                <input
+                  id="skuProdutoUsuario"
+                  name="sku"
+                  type="text"
+                  required
+                  placeholder="Ex: CAMI-001"
+                  class="w-full border border-gray-300 rounded-lg px-4 py-2 uppercase focus:ring-2 focus:ring-green-500 focus:border-green-500"
+                />
+              </div>
+              <div class="lg:col-span-1">
+                <label for="precoProdutoUsuario" class="block text-sm font-medium text-gray-700 mb-2">Preço (R$) *</label>
+                <input
+                  id="precoProdutoUsuario"
+                  name="preco"
+                  type="text"
+                  required
+                  inputmode="decimal"
+                  placeholder="Ex: 129,90"
+                  class="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-green-500 focus:border-green-500"
+                />
+              </div>
+              <div class="lg:col-span-1">
+                <label for="imagemProdutoUsuario" class="block text-sm font-medium text-gray-700 mb-2">Imagem do produto (opcional)</label>
+                <input
+                  id="imagemProdutoUsuario"
+                  name="imagem"
+                  type="file"
+                  accept="image/*"
+                  class="w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-green-50 file:text-green-700 hover:file:bg-green-100"
+                />
+                <div id="previewImagemProdutoUsuario" class="mt-3 hidden">
+                  <p class="text-xs text-gray-500 mb-2">Pré-visualização:</p>
+                  <img src="" alt="Pré-visualização do produto" class="h-32 w-32 object-cover rounded-lg shadow" />
+                </div>
+              </div>
+              <div class="lg:col-span-2">
+                <label for="descricaoProdutoUsuario" class="block text-sm font-medium text-gray-700 mb-2">Descrição *</label>
+                <textarea
+                  id="descricaoProdutoUsuario"
+                  name="descricao"
+                  rows="4"
+                  required
+                  placeholder="Adicione os principais detalhes do produto..."
+                  class="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-green-500 focus:border-green-500"
+                ></textarea>
+              </div>
+              <div class="lg:col-span-2 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                <div id="feedbackProdutosUsuarios" class="text-sm"></div>
+                <button
+                  type="submit"
+                  class="btn btn-primary bg-green-600 hover:bg-green-700 border border-green-600 px-6 py-2 text-white font-semibold rounded-lg flex items-center justify-center"
+                >
+                  <i class="fas fa-save mr-2"></i>Salvar produto
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+
+        <div class="card mt-8">
+          <div class="card-header">
+            <div class="flex items-center justify-between">
+              <div class="flex items-center">
+                <i class="fas fa-layer-group text-2xl text-green-600 mr-3"></i>
+                <h2 class="text-2xl font-bold">Produtos cadastrados</h2>
+              </div>
+            </div>
+          </div>
+          <div class="card-body">
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+              <div class="md:col-span-2">
+                <label for="filtroSkuUsuarios" class="block text-sm font-medium text-gray-700 mb-2">Filtrar por SKU</label>
+                <div class="relative">
+                  <i class="fas fa-filter absolute left-3 top-3 text-gray-400"></i>
+                  <input
+                    id="filtroSkuUsuarios"
+                    type="text"
+                    placeholder="Digite o SKU para filtrar"
+                    class="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-full shadow-sm focus:ring-2 focus:ring-green-500"
+                  />
+                </div>
+              </div>
+              <div class="md:col-span-1 flex items-end">
+                <button
+                  id="recarregarProdutosUsuarios"
+                  type="button"
+                  class="btn btn-secondary w-full md:w-auto px-4 py-2 flex items-center justify-center"
+                >
+                  <i class="fas fa-sync-alt mr-2"></i>Recarregar lista
+                </button>
+              </div>
+            </div>
+            <div id="carregandoProdutosUsuarios" class="hidden text-sm text-gray-500 flex items-center">
+              <i class="fas fa-spinner fa-spin mr-2"></i>Carregando produtos...
+            </div>
+            <div id="estadoVazioProdutosUsuarios" class="hidden text-sm text-gray-500">
+              Nenhum produto cadastrado até o momento.
+            </div>
+            <div id="cardsProdutosUsuarios" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script type="module" src="../firebase-config.js"></script>
+  <script type="module" src="../anuncios-usuarios.js"></script>
+  <script src="../shared.js"></script>
+</body>
+</html>

--- a/anuncios-usuarios.js
+++ b/anuncios-usuarios.js
@@ -1,0 +1,319 @@
+import {
+  initializeApp,
+  getApps,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import {
+  getFirestore,
+  doc,
+  setDoc,
+  collection,
+  getDocs,
+  query,
+  orderBy,
+  serverTimestamp,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import {
+  getAuth,
+  onAuthStateChanged,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { firebaseConfig } from './firebase-config.js';
+
+const form = document.getElementById('produtoUsuarioForm');
+if (!form) {
+  // Página não carregada, encerra o script.
+  console.debug('[anuncios-usuarios] Formulário não encontrado na página atual.');
+} else {
+  const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+  const db = getFirestore(app);
+  const auth = getAuth(app);
+
+  const nomeInput = document.getElementById('nomeProdutoUsuario');
+  const skuInput = document.getElementById('skuProdutoUsuario');
+  const precoInput = document.getElementById('precoProdutoUsuario');
+  const descricaoInput = document.getElementById('descricaoProdutoUsuario');
+  const imagemInput = document.getElementById('imagemProdutoUsuario');
+  const imagemPreviewWrapper = document.getElementById('previewImagemProdutoUsuario');
+  const imagemPreview = imagemPreviewWrapper?.querySelector('img');
+  const feedback = document.getElementById('feedbackProdutosUsuarios');
+  const filtroSkuInput = document.getElementById('filtroSkuUsuarios');
+  const recarregarButton = document.getElementById('recarregarProdutosUsuarios');
+  const cardsContainer = document.getElementById('cardsProdutosUsuarios');
+  const vazioState = document.getElementById('estadoVazioProdutosUsuarios');
+  const loadingState = document.getElementById('carregandoProdutosUsuarios');
+  const submitButton = form.querySelector('button[type="submit"]');
+
+  let usuarioAtual = null;
+  let produtosCache = [];
+
+  function normalizarSku(valor) {
+    if (!valor) return '';
+    const semEspacos = valor.trim().replace(/\s+/g, '-');
+    const caracteresInvalidos = /[./#$\[\]\/\\]/g;
+    return semEspacos.replace(caracteresInvalidos, '-').toUpperCase();
+  }
+
+  function setFeedback(message, type = 'success') {
+    if (!feedback) return;
+    feedback.textContent = message;
+    feedback.className = `text-sm font-medium ${
+      type === 'error' ? 'text-red-600' : 'text-green-600'
+    }`;
+  }
+
+  function limparFeedback() {
+    if (!feedback) return;
+    feedback.textContent = '';
+    feedback.className = 'text-sm';
+  }
+
+  function mostrarLoading(flag) {
+    if (!loadingState) return;
+    loadingState.classList.toggle('hidden', !flag);
+  }
+
+  function atualizarEstadosLista(temItens) {
+    if (cardsContainer) {
+      cardsContainer.classList.toggle('hidden', !temItens);
+    }
+    if (vazioState) {
+      vazioState.classList.toggle('hidden', temItens);
+    }
+  }
+
+  function formatarPreco(preco) {
+    if (typeof preco === 'number') {
+      return preco.toLocaleString('pt-BR', {
+        style: 'currency',
+        currency: 'BRL',
+        minimumFractionDigits: 2,
+      });
+    }
+    return preco;
+  }
+
+  function criarCard(produto) {
+    const card = document.createElement('div');
+    card.className = 'bg-white rounded-xl shadow p-5 flex flex-col';
+
+    if (produto.imagem) {
+      const img = document.createElement('img');
+      img.src = produto.imagem;
+      img.alt = `Imagem do produto ${produto.nome}`;
+      img.className = 'h-40 w-full object-cover rounded-lg mb-4';
+      card.appendChild(img);
+    }
+
+    const titulo = document.createElement('h3');
+    titulo.className = 'text-lg font-semibold text-gray-800';
+    titulo.textContent = produto.nome;
+    card.appendChild(titulo);
+
+    const sku = document.createElement('p');
+    sku.className = 'text-sm text-gray-500 mt-1';
+    sku.innerHTML = `<span class="font-semibold">SKU:</span> ${produto.sku}`;
+    card.appendChild(sku);
+
+    const preco = document.createElement('p');
+    preco.className = 'text-sm text-gray-500 mt-1';
+    preco.innerHTML = `<span class="font-semibold">Preço:</span> ${formatarPreco(
+      produto.preco,
+    )}`;
+    card.appendChild(preco);
+
+    const descricao = document.createElement('p');
+    descricao.className = 'text-sm text-gray-600 mt-3 whitespace-pre-line';
+    descricao.textContent = produto.descricao;
+    card.appendChild(descricao);
+
+    if (produto.atualizadoEm) {
+      const atualizado = document.createElement('p');
+      atualizado.className = 'text-xs text-gray-400 mt-4';
+      const data = produto.atualizadoEm.toDate
+        ? produto.atualizadoEm.toDate()
+        : produto.atualizadoEm;
+      if (data instanceof Date && !Number.isNaN(data.getTime())) {
+        atualizado.textContent = `Atualizado em ${data.toLocaleString('pt-BR')}`;
+        card.appendChild(atualizado);
+      }
+    }
+
+    return card;
+  }
+
+  function renderizarProdutos() {
+    if (!cardsContainer) return;
+    const filtro = filtroSkuInput?.value.trim().toLowerCase() || '';
+    cardsContainer.innerHTML = '';
+
+    const produtosFiltrados = produtosCache.filter((produto) =>
+      filtro ? produto.sku.toLowerCase().includes(filtro) : true,
+    );
+
+    if (!produtosFiltrados.length) {
+      atualizarEstadosLista(false);
+      return;
+    }
+
+    atualizarEstadosLista(true);
+    produtosFiltrados.forEach((produto) => {
+      cardsContainer.appendChild(criarCard(produto));
+    });
+  }
+
+  async function carregarProdutos() {
+    if (!usuarioAtual) return;
+    mostrarLoading(true);
+    try {
+      const colecao = collection(
+        db,
+        'uid',
+        usuarioAtual.uid,
+        'anunciosUsuarios',
+      );
+      const consulta = query(colecao, orderBy('nome'));
+      const snapshot = await getDocs(consulta);
+      produtosCache = snapshot.docs.map((docSnap) => ({
+        id: docSnap.id,
+        ...docSnap.data(),
+      }));
+      renderizarProdutos();
+      if (!produtosCache.length) {
+        atualizarEstadosLista(false);
+      }
+    } catch (error) {
+      console.error('Erro ao carregar produtos de usuários:', error);
+      setFeedback('Não foi possível carregar os produtos. Tente novamente.', 'error');
+      atualizarEstadosLista(false);
+    } finally {
+      mostrarLoading(false);
+    }
+  }
+
+  function lerArquivoComoDataUrl(arquivo) {
+    return new Promise((resolve, reject) => {
+      if (!arquivo) {
+        resolve(null);
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(reader.error);
+      reader.readAsDataURL(arquivo);
+    });
+  }
+
+  imagemInput?.addEventListener('change', async () => {
+    if (!imagemPreviewWrapper || !imagemPreview) return;
+    const arquivo = imagemInput.files?.[0];
+    if (!arquivo) {
+      imagemPreviewWrapper.classList.add('hidden');
+      imagemPreview.src = '';
+      return;
+    }
+    try {
+      const dataUrl = await lerArquivoComoDataUrl(arquivo);
+      if (dataUrl) {
+        imagemPreview.src = dataUrl;
+        imagemPreviewWrapper.classList.remove('hidden');
+      }
+    } catch (error) {
+      console.error('Erro ao ler a imagem selecionada:', error);
+      setFeedback('Não foi possível carregar a imagem selecionada.', 'error');
+    }
+  });
+
+  filtroSkuInput?.addEventListener('input', () => {
+    renderizarProdutos();
+  });
+
+  recarregarButton?.addEventListener('click', () => {
+    limparFeedback();
+    carregarProdutos();
+  });
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    limparFeedback();
+
+    if (!usuarioAtual) {
+      setFeedback('Você precisa estar logado para salvar produtos.', 'error');
+      return;
+    }
+
+    const nome = nomeInput?.value.trim();
+    const sku = skuInput?.value.trim();
+    const precoTexto = precoInput?.value.trim();
+    const descricao = descricaoInput?.value.trim();
+
+    if (!nome || !sku || !precoTexto || !descricao) {
+      setFeedback('Preencha todos os campos obrigatórios.', 'error');
+      return;
+    }
+
+    const precoNormalizado = Number(
+      precoTexto.replace(/\./g, '').replace(',', '.'),
+    );
+    if (Number.isNaN(precoNormalizado)) {
+      setFeedback('Informe um preço válido.', 'error');
+      return;
+    }
+
+    const arquivoImagem = imagemInput?.files?.[0];
+    let imagemDataUrl = null;
+    try {
+      imagemDataUrl = await lerArquivoComoDataUrl(arquivoImagem);
+    } catch (error) {
+      console.error('Erro ao converter imagem para base64:', error);
+      setFeedback('Não foi possível processar a imagem selecionada.', 'error');
+      return;
+    }
+
+    const skuNormalizado = normalizarSku(sku);
+    if (!skuNormalizado) {
+      setFeedback('Informe um SKU válido.', 'error');
+      return;
+    }
+
+    try {
+      submitButton?.setAttribute('disabled', 'disabled');
+      submitButton?.classList.add('opacity-60');
+
+      await setDoc(
+        doc(db, 'uid', usuarioAtual.uid, 'anunciosUsuarios', skuNormalizado),
+        {
+          nome,
+          sku: skuNormalizado,
+          descricao,
+          preco: precoNormalizado,
+          imagem: imagemDataUrl,
+          atualizadoEm: serverTimestamp(),
+        },
+      );
+
+      setFeedback('Produto salvo com sucesso!');
+      form.reset();
+      if (imagemPreviewWrapper && imagemPreview) {
+        imagemPreviewWrapper.classList.add('hidden');
+        imagemPreview.src = '';
+      }
+      await carregarProdutos();
+    } catch (error) {
+      console.error('Erro ao salvar produto do usuário:', error);
+      setFeedback('Não foi possível salvar o produto. Tente novamente.', 'error');
+    } finally {
+      submitButton?.removeAttribute('disabled');
+      submitButton?.classList.remove('opacity-60');
+    }
+  });
+
+  onAuthStateChanged(auth, (user) => {
+    usuarioAtual = user;
+    if (!usuarioAtual) {
+      produtosCache = [];
+      renderizarProdutos();
+      atualizarEstadosLista(false);
+      return;
+    }
+    carregarProdutos();
+  });
+}

--- a/gerenciamento.js
+++ b/gerenciamento.js
@@ -26,7 +26,14 @@ import {
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 
 const BASE_PATH = new URL('.', import.meta.url);
-const tabs = ['cadastro', 'anuncios', 'analise', 'evolucao', 'planilha-shopee'];
+const tabs = [
+  'cadastro',
+  'anuncios',
+  'produtos-usuarios',
+  'analise',
+  'evolucao',
+  'planilha-shopee',
+];
 for (const t of tabs) {
   const container = document.getElementById(t);
   if (container) {

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -885,6 +885,13 @@
         </li>
         <li>
           <a
+            href="/anuncios-tabs/produtos-usuarios.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Produtos dos Usuários</a
+          >
+        </li>
+        <li>
+          <a
             href="/anuncios-tabs/analise.html"
             class="sidebar-link block py-2 px-4 transition-colors"
             >Análise IA</a


### PR DESCRIPTION
## Summary
- add a "Produtos dos Usuários" tab to the anúncios dashboard and navigation
- provide a manual product form that saves name, SKU, description, price, and optional image to Firestore using the SKU as the document key
- list saved products on the same page with SKU filtering, reload controls, and card-based presentation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e7a8d4e3ac832aa9304f1e071c0922