### PR TITLE
Adjust product cards grid layout

### DIFF
--- a/anuncios-tabs/produtos-usuarios.html
+++ b/anuncios-tabs/produtos-usuarios.html
@@ -139,7 +139,7 @@
             <div id="estadoVazioProdutosUsuarios" class="hidden text-sm text-gray-500">
               Nenhum produto cadastrado até o momento.
             </div>
-            <div id="cardsProdutosUsuarios" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6"></div>
+            <div id="cardsProdutosUsuarios" class="grid grid-cols-1 md:grid-cols-3 gap-6"></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- force the saved product cards grid on the Produtos Usuários tab to render three cards per row on medium viewports and above

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e7c331af04832a96c3ba0eba84f761