### PR TITLE
Remover botão duplicado de upload na expedição

### DIFF
--- a/expedicao.html
+++ b/expedicao.html
@@ -31,7 +31,6 @@
       <div id="actionBar" class="flex flex-wrap items-center gap-2">
         <button id="startDayBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg bg-green-600 text-white"><i class="fas fa-play"></i><span>Iniciar Dia</span></button>
         <button id="closeDayBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg bg-green-600 text-white hidden"><i class="fas fa-check"></i><span>Concluir</span></button>
-        <label for="manualPdfInput" class="btn flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-700 cursor-pointer"><i class="fas fa-file-upload"></i><span>Escolher Arquivo</span></label>
         <input type="file" id="manualPdfInput" accept="application/pdf" class="hidden" />
         <button id="uploadManualBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-700"><i class="fas fa-plus"></i><span>Adicionar Etiqueta</span></button>
         <button id="gestorUsersBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-700"><i class="fas fa-users"></i><span>Equipe</span></button>


### PR DESCRIPTION
## Summary
- remove the extra "Escolher Arquivo" action from the expedição toolbar to avoid duplicated upload buttons
- keep the hidden file input so the existing "Adicionar Etiqueta" flow continues to trigger uploads

## Testing
- no automated tests were run (markup-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e847161a18832a86ddc392f890ae83