### PR TITLE
Revamp expedition summary cards

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -202,23 +202,122 @@
 }
 
 .expedicao-summary-card {
-  padding: 0.75rem 0.875rem;
-  gap: 0.35rem;
-  text-align: center;
+  padding: 1.25rem 1.5rem;
+  gap: 1.1rem;
+  text-align: left;
+  border-radius: 1.25rem;
+  border: none;
+  box-shadow: 0 20px 40px -28px rgba(15, 23, 42, 0.65);
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+}
+
+.expedicao-summary-card[data-variant='primary'] {
+  box-shadow: 0 18px 35px -25px rgba(79, 70, 229, 0.65);
+}
+
+.expedicao-summary-card[data-variant='success'] {
+  box-shadow: 0 18px 35px -25px rgba(22, 163, 74, 0.55);
+}
+
+.expedicao-summary-card[data-variant='warning'] {
+  box-shadow: 0 18px 35px -25px rgba(249, 115, 22, 0.45);
+}
+
+.expedicao-summary-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
 }
 
 .expedicao-summary-title {
-  font-size: 0.7rem;
+  font-size: 0.95rem;
   font-weight: 600;
-  letter-spacing: 0.08em;
+  color: #1e293b;
+}
+
+.expedicao-summary-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 9999px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--text-light);
+  background-color: rgba(100, 116, 139, 0.12);
+  color: #475569;
+}
+
+.expedicao-summary-card[data-variant='success'] .expedicao-summary-chip {
+  background-color: rgba(22, 163, 74, 0.12);
+  color: #15803d;
+}
+
+.expedicao-summary-card[data-variant='primary'] .expedicao-summary-chip {
+  background-color: rgba(79, 70, 229, 0.12);
+  color: #4338ca;
+}
+
+.expedicao-summary-card[data-variant='warning'] .expedicao-summary-chip {
+  background-color: rgba(249, 115, 22, 0.12);
+  color: #c2410c;
 }
 
 .expedicao-summary-value {
-  font-size: 1.25rem;
+  font-size: 2rem;
   font-weight: 700;
-  color: var(--text);
+  color: #0f172a;
+  letter-spacing: -0.03em;
+}
+
+.expedicao-summary-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.expedicao-summary-bar {
+  position: relative;
+  height: 0.45rem;
+  border-radius: 9999px;
+  overflow: hidden;
+  background: rgba(226, 232, 240, 0.8);
+}
+
+.expedicao-summary-bar-fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  border-radius: inherit;
+  transition: width 0.35s ease;
+  background: linear-gradient(90deg, #94a3b8, #0f172a);
+}
+
+.expedicao-summary-card[data-variant='primary'] .expedicao-summary-bar-fill {
+  background: linear-gradient(90deg, #a855f7, #4f46e5);
+}
+
+.expedicao-summary-card[data-variant='success'] .expedicao-summary-bar-fill {
+  background: linear-gradient(90deg, #34d399, #15803d);
+}
+
+.expedicao-summary-card[data-variant='warning'] .expedicao-summary-bar-fill {
+  background: linear-gradient(90deg, #fbbf24, #f97316);
+}
+
+.expedicao-summary-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #475569;
+}
+
+.expedicao-summary-foot-value {
+  font-weight: 600;
+  color: #0f172a;
 }
 
 .expedicao-team-card {

--- a/expedicao.html
+++ b/expedicao.html
@@ -37,18 +37,54 @@
         <button id="sobrasBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-700"><i class="fas fa-box-open"></i><span>Sobras</span></button>
         <button id="checklistBtn" class="btn flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-700"><i class="fas fa-clipboard-list"></i><span>Checklist</span></button>
       </div>
-      <div id="totalsContainer" class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-        <div class="expedicao-card expedicao-summary-card">
-          <div class="expedicao-summary-title">A enviar hoje</div>
+      <div id="totalsContainer" class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div class="expedicao-card expedicao-summary-card" data-variant="primary">
+          <div class="expedicao-summary-header">
+            <div class="expedicao-summary-title">A enviar hoje</div>
+            <span class="expedicao-summary-chip">Total</span>
+          </div>
           <div id="totalAEnviar" class="expedicao-summary-value">0</div>
+          <div class="expedicao-summary-progress">
+            <div class="expedicao-summary-bar">
+              <div id="progressAEnviar" class="expedicao-summary-bar-fill"></div>
+            </div>
+            <div class="expedicao-summary-foot">
+              <span class="expedicao-summary-foot-label">Participação</span>
+              <span id="percentAEnviar" class="expedicao-summary-foot-value">0%</span>
+            </div>
+          </div>
         </div>
-        <div class="expedicao-card expedicao-summary-card">
-          <div class="expedicao-summary-title">Enviado</div>
+        <div class="expedicao-card expedicao-summary-card" data-variant="success">
+          <div class="expedicao-summary-header">
+            <div class="expedicao-summary-title">Enviado</div>
+            <span class="expedicao-summary-chip">Dentro do horário</span>
+          </div>
           <div id="totalEnviado" class="expedicao-summary-value">0</div>
+          <div class="expedicao-summary-progress">
+            <div class="expedicao-summary-bar">
+              <div id="progressEnviado" class="expedicao-summary-bar-fill"></div>
+            </div>
+            <div class="expedicao-summary-foot">
+              <span class="expedicao-summary-foot-label">Participação</span>
+              <span id="percentEnviado" class="expedicao-summary-foot-value">0%</span>
+            </div>
+          </div>
         </div>
-        <div class="expedicao-card expedicao-summary-card">
-          <div class="expedicao-summary-title">Não enviado</div>
+        <div class="expedicao-card expedicao-summary-card" data-variant="warning">
+          <div class="expedicao-summary-header">
+            <div class="expedicao-summary-title">Não enviado</div>
+            <span class="expedicao-summary-chip">Fora do horário</span>
+          </div>
           <div id="totalNaoEnviado" class="expedicao-summary-value">0</div>
+          <div class="expedicao-summary-progress">
+            <div class="expedicao-summary-bar">
+              <div id="progressNaoEnviado" class="expedicao-summary-bar-fill"></div>
+            </div>
+            <div class="expedicao-summary-foot">
+              <span class="expedicao-summary-foot-label">Participação</span>
+              <span id="percentNaoEnviado" class="expedicao-summary-foot-value">0%</span>
+            </div>
+          </div>
         </div>
       </div>
       <div id="statusFilters" class="flex flex-wrap gap-2">
@@ -861,6 +897,22 @@
       const totalAEnviarEl = document.getElementById('totalAEnviar');
       const totalEnviadoEl = document.getElementById('totalEnviado');
       const totalNaoEnviadoEl = document.getElementById('totalNaoEnviado');
+      const percentAEnviarEl = document.getElementById('percentAEnviar');
+      const percentEnviadoEl = document.getElementById('percentEnviado');
+      const percentNaoEnviadoEl = document.getElementById('percentNaoEnviado');
+      const progressAEnviarEl = document.getElementById('progressAEnviar');
+      const progressEnviadoEl = document.getElementById('progressEnviado');
+      const progressNaoEnviadoEl = document.getElementById('progressNaoEnviado');
+
+      const setSummary = (valueEl, value, percentEl, progressEl, percent) => {
+        const safeValue = Number.isFinite(value) ? value : 0;
+        const safePercent = Number.isFinite(percent)
+          ? Math.min(100, Math.max(0, percent))
+          : 0;
+        if (valueEl) valueEl.textContent = safeValue;
+        if (percentEl) percentEl.textContent = `${safePercent}%`;
+        if (progressEl) progressEl.style.width = `${safePercent}%`;
+      };
 
       const { start, end } = getResumoTimeWindow();
 
@@ -877,9 +929,9 @@
           if (checklistEnvioTotals) {
             checklistEnvioTotals.textContent = 'Total etiquetas: 0 | Dentro do horário: 0 | Fora do horário: 0';
           }
-          if (totalAEnviarEl) totalAEnviarEl.textContent = 0;
-          if (totalEnviadoEl) totalEnviadoEl.textContent = 0;
-          if (totalNaoEnviadoEl) totalNaoEnviadoEl.textContent = 0;
+          setSummary(totalAEnviarEl, 0, percentAEnviarEl, progressAEnviarEl, 0);
+          setSummary(totalEnviadoEl, 0, percentEnviadoEl, progressEnviadoEl, 0);
+          setSummary(totalNaoEnviadoEl, 0, percentNaoEnviadoEl, progressNaoEnviadoEl, 0);
           return;
         }
 
@@ -982,9 +1034,14 @@
         checklistRows = rows;
 
         const totalEnviar = totalDentro + totalFora;
-        if (totalAEnviarEl) totalAEnviarEl.textContent = totalEnviar;
-        if (totalEnviadoEl) totalEnviadoEl.textContent = totalDentro;
-        if (totalNaoEnviadoEl) totalNaoEnviadoEl.textContent = totalFora;
+        const baseTotal = totalEnviar > 0 ? totalEnviar : 0;
+        const percentEnviar = baseTotal ? Math.min(100, Math.max(0, Math.round((totalEnviar / baseTotal) * 100))) : 0;
+        const percentDentro = baseTotal ? Math.min(100, Math.max(0, Math.round((totalDentro / baseTotal) * 100))) : 0;
+        const percentFora = baseTotal ? Math.min(100, Math.max(0, Math.round((totalFora / baseTotal) * 100))) : 0;
+
+        setSummary(totalAEnviarEl, totalEnviar, percentAEnviarEl, progressAEnviarEl, percentEnviar);
+        setSummary(totalEnviadoEl, totalDentro, percentEnviadoEl, progressEnviadoEl, percentDentro);
+        setSummary(totalNaoEnviadoEl, totalFora, percentNaoEnviadoEl, progressNaoEnviadoEl, percentFora);
 
         if (checklistEnvioTotals) {
           checklistEnvioTotals.textContent = `Total etiquetas: ${totalEnviar} | Dentro do horário: ${totalDentro} | Fora do horário: ${totalFora}`;
@@ -1004,9 +1061,9 @@
         checklistBody.innerHTML = '<tr><td class="p-2 text-center text-red-500" colspan="6">Erro ao carregar</td></tr>';
         if (checklistTotals) checklistTotals.textContent = 'Erro ao carregar';
         if (checklistEnvioTotals) checklistEnvioTotals.textContent = 'Erro ao carregar';
-        if (totalAEnviarEl) totalAEnviarEl.textContent = 0;
-        if (totalEnviadoEl) totalEnviadoEl.textContent = 0;
-        if (totalNaoEnviadoEl) totalNaoEnviadoEl.textContent = 0;
+        setSummary(totalAEnviarEl, 0, percentAEnviarEl, progressAEnviarEl, 0);
+        setSummary(totalEnviadoEl, 0, percentEnviadoEl, progressEnviadoEl, 0);
+        setSummary(totalNaoEnviadoEl, 0, percentNaoEnviadoEl, progressNaoEnviadoEl, 0);
         await calcularTotalPedidosDia();
       }
     }


### PR DESCRIPTION
## Summary
- redesign the top expedition summary cards with modern headers, chips, and progress bars
- add percentage and progress updates for expedition totals in the checklist loader
- refresh CSS styling to match the new card layout variants

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8569b6d98832a954f33afcf04393b