### PR TITLE
Fix Firebase storage bucket domain for PDF uploads

### DIFF
--- a/firebase-config.js
+++ b/firebase-config.js
@@ -14,7 +14,7 @@ export const firebaseConfig = {
   apiKey: 'AIzaSyC78l9b2DTNj64y_0fbRKofNupO6NHDmeo',
   authDomain: 'matheus-35023.firebaseapp.com',
   projectId: 'matheus-35023',
-  storageBucket: 'matheus-35023.firebasestorage.app',
+  storageBucket: 'matheus-35023.appspot.com',
   messagingSenderId: '1011113149395',
   appId: '1:1011113149395:web:c1f449e0e974ca8ecb2526',
   databaseURL: 'https://matheus-35023.firebaseio.com',


### PR DESCRIPTION
## Summary
- point the Firebase configuration at the appspot.com storage bucket so Storage API uploads succeed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f0dd716e74832a8897478527502eb5