### PR TITLE
Improve Firebase storage uploads with retries

### DIFF
--- a/firebase-config.js
+++ b/firebase-config.js
@@ -14,7 +14,7 @@ export const firebaseConfig = {
   apiKey: 'AIzaSyC78l9b2DTNj64y_0fbRKofNupO6NHDmeo',
   authDomain: 'matheus-35023.firebaseapp.com',
   projectId: 'matheus-35023',
-  storageBucket: 'matheus-35023.firebasestorage.app',
+  storageBucket: 'matheus-35023.appspot.com',
   messagingSenderId: '1011113149395',
   appId: '1:1011113149395:web:c1f449e0e974ca8ecb2526',
   databaseURL: 'https://matheus-35023.firebaseio.com',

--- a/gestao-contas-fechamento.js
+++ b/gestao-contas-fechamento.js
@@ -7,16 +7,14 @@ import {
   collection,
   addDoc,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
-import {
-  getStorage,
-  ref,
-  uploadBytes,
-} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-storage.js';
+import { getStorage } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-storage.js';
 import { firebaseConfig } from './firebase-config.js';
+import { configureStorageRetries, uploadWithRetry } from './storage-uploads.js';
 
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const storage = getStorage(app);
+configureStorageRetries(storage);
 
 pdfjsLib.GlobalWorkerOptions.workerSrc =
   'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js';
@@ -45,7 +43,7 @@ btnProcessar?.addEventListener('click', async () => {
     const arrayBuffer = await file.arrayBuffer();
     const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
     const storagePath = `contasfechamento/${Date.now()}-${file.name}`;
-    await uploadBytes(ref(storage, storagePath), file);
+    await uploadWithRetry(storage, storagePath, file);
     for (let i = 1; i <= pdf.numPages; i++) {
       const page = await pdf.getPage(i);
       const textContent = await page.getTextContent();

--- a/storage-uploads.js
+++ b/storage-uploads.js
@@ -1,0 +1,89 @@
+import {
+  ref,
+  uploadBytesResumable,
+  setMaxUploadRetryTime,
+  setMaxOperationRetryTime,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-storage.js';
+
+const configuredStorages = new WeakSet();
+
+const DEFAULT_CHUNK_RETRY_TIME = 90_000;
+const DEFAULT_OPERATION_RETRY_TIME = 5 * 60_000;
+
+export function configureStorageRetries(
+  storage,
+  {
+    chunkRetryTime = DEFAULT_CHUNK_RETRY_TIME,
+    operationRetryTime = DEFAULT_OPERATION_RETRY_TIME,
+  } = {},
+) {
+  if (!storage || configuredStorages.has(storage)) {
+    return;
+  }
+  setMaxUploadRetryTime(storage, chunkRetryTime);
+  setMaxOperationRetryTime(storage, operationRetryTime);
+  configuredStorages.add(storage);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function guessContentType(file) {
+  if (file?.type) {
+    return file.type;
+  }
+  const name = typeof file?.name === 'string' ? file.name.toLowerCase() : '';
+  if (name.endsWith('.pdf')) {
+    return 'application/pdf';
+  }
+  return 'application/octet-stream';
+}
+
+export async function uploadWithRetry(storage, path, file, metadata = {}) {
+  if (!storage) {
+    throw new Error('Instância do Storage é obrigatória.');
+  }
+  if (!path) {
+    throw new Error('O caminho do arquivo é obrigatório.');
+  }
+  if (!file) {
+    throw new Error('É necessário informar um arquivo para upload.');
+  }
+
+  const meta = {
+    contentType: guessContentType(file),
+    ...metadata,
+  };
+
+  const maxAttempts = 6;
+  const backoff = (attempt) => Math.min(2000 * 2 ** attempt, 20000);
+  let lastError;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      const snapshot = await new Promise((resolve, reject) => {
+        const uploadTask = uploadBytesResumable(ref(storage, path), file, meta);
+        uploadTask.on(
+          'state_changed',
+          null,
+          (error) => reject(error),
+          () => resolve(uploadTask.snapshot),
+        );
+      });
+      return snapshot;
+    } catch (error) {
+      lastError = error;
+      const message = `${error?.message || ''} ${error?.serverResponse || ''}`;
+      const shouldRetry =
+        String(message).includes('503') ||
+        error?.code === 'storage/retry-limit-exceeded';
+      if (!shouldRetry || attempt === maxAttempts - 1) {
+        break;
+      }
+      await sleep(backoff(attempt));
+    }
+  }
+
+  throw lastError || new Error('Falha ao enviar arquivo para o Storage.');
+}


### PR DESCRIPTION
## Summary
- fix the Firebase storage bucket configuration to use the appspot domain
- add a shared storage upload helper that configures retry tolerances and resumable uploads
- update upload flows to use resumable uploads with backoff handling for large files

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f0f88dc504832abd4d78c47f65102f