### PR TITLE
Improve Firebase Storage upload robustness

### DIFF
--- a/atualizacoes.js
+++ b/atualizacoes.js
@@ -23,20 +23,19 @@ import {
   onAuthStateChanged,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 import {
-  getStorage,
   ref,
-  uploadBytes,
   getDownloadURL,
   deleteObject,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-storage.js';
 import { firebaseConfig, getPassphrase } from './firebase-config.js';
 import { decryptString } from './crypto.js';
 import { fetchResponsavelFinanceiroUsuarios } from './responsavel-financeiro.js';
+import { getConfiguredStorage, uploadFileWithRetry } from './storage-utils.js';
 
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app);
-const storage = getStorage(app);
+const storage = getConfiguredStorage(app);
 
 let currentUser = null;
 let initialLoad = true;
@@ -776,7 +775,7 @@ async function enviarAtualizacao(e) {
   for (const file of arquivos) {
     const path = `financeiroAtualizacoes/${currentUser.uid}/${docRef.id}/${file.name}`;
     const storageRef = ref(storage, path);
-    await uploadBytes(storageRef, file);
+    await uploadFileWithRetry(storage, path, file);
     const url = await getDownloadURL(storageRef);
     anexos.push({ nome: file.name, url });
   }

--- a/comunicacao.js
+++ b/comunicacao.js
@@ -24,18 +24,17 @@ import {
   limitToLast,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
 import {
-  getStorage,
   ref,
-  uploadBytes,
   getDownloadURL,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-storage.js';
 import { firebaseConfig } from './firebase-config.js';
 import { fetchResponsavelFinanceiroUsuarios } from './responsavel-financeiro.js';
+import { getConfiguredStorage, uploadFileWithRetry } from './storage-utils.js';
 
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const db = getFirestore(app);
-const storage = getStorage(app);
+const storage = getConfiguredStorage(app);
 
 const teamListEl = document.getElementById('teamList');
 const selectEls = [
@@ -282,12 +281,9 @@ onAuthStateChanged(auth, async (user) => {
       document.getElementById('fileRecipients').selectedOptions,
     ).map((o) => o.value);
     if (!file || dest.length === 0) return;
-    const storageRef = ref(
-      storage,
-      `comunicacao/${user.uid}/${Date.now()}_${file.name}`,
-    );
-    await uploadBytes(storageRef, file);
-    const url = await getDownloadURL(storageRef);
+    const path = `comunicacao/${user.uid}/${Date.now()}_${file.name}`;
+    await uploadFileWithRetry(storage, path, file);
+    const url = await getDownloadURL(ref(storage, path));
     await addDoc(collection(db, 'comunicacao'), {
       tipo: 'arquivo',
       arquivoNome: file.name,

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -14,7 +14,7 @@ export const firebaseConfig = {
   apiKey: 'AIzaSyC78l9b2DTNj64y_0fbRKofNupO6NHDmeo',
   authDomain: 'matheus-35023.firebaseapp.com',
   projectId: 'matheus-35023',
-  storageBucket: 'matheus-35023.firebasestorage.app',
+  storageBucket: 'matheus-35023.appspot.com',
   messagingSenderId: '1011113149395',
   appId: '1:1011113149395:web:c1f449e0e974ca8ecb2526',
   databaseURL: 'https://matheus-35023.firebaseio.com',

--- a/gestao-contas-fechamento.js
+++ b/gestao-contas-fechamento.js
@@ -7,16 +7,12 @@ import {
   collection,
   addDoc,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
-import {
-  getStorage,
-  ref,
-  uploadBytes,
-} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-storage.js';
 import { firebaseConfig } from './firebase-config.js';
+import { getConfiguredStorage, uploadFileWithRetry } from './storage-utils.js';
 
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
-const storage = getStorage(app);
+const storage = getConfiguredStorage(app);
 
 pdfjsLib.GlobalWorkerOptions.workerSrc =
   'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js';
@@ -45,7 +41,7 @@ btnProcessar?.addEventListener('click', async () => {
     const arrayBuffer = await file.arrayBuffer();
     const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
     const storagePath = `contasfechamento/${Date.now()}-${file.name}`;
-    await uploadBytes(ref(storage, storagePath), file);
+    await uploadFileWithRetry(storage, storagePath, file);
     for (let i = 1; i <= pdf.numPages; i++) {
       const page = await pdf.getPage(i);
       const textContent = await page.getTextContent();

--- a/gestor.js
+++ b/gestor.js
@@ -18,17 +18,16 @@ import {
   onAuthStateChanged,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 import {
-  getStorage,
   ref,
-  uploadBytes,
   getDownloadURL,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-storage.js';
 import { firebaseConfig } from './firebase-config.js';
+import { getConfiguredStorage, uploadFileWithRetry } from './storage-utils.js';
 
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app);
-const storage = getStorage(app);
+const storage = getConfiguredStorage(app);
 
 let currentUser = null;
 
@@ -128,9 +127,8 @@ async function enviarRelatorio(e) {
     const anexos = [];
     for (const file of arquivos) {
       const path = `reports/${currentUser.uid}/${docRef.id}/${file.name}`;
-      const storageRef = ref(storage, path);
-      await uploadBytes(storageRef, file);
-      const url = await getDownloadURL(storageRef);
+      await uploadFileWithRetry(storage, path, file);
+      const url = await getDownloadURL(ref(storage, path));
       anexos.push({ nome: file.name, url });
     }
     if (anexos.length) {

--- a/storage-utils.js
+++ b/storage-utils.js
@@ -1,0 +1,82 @@
+import {
+  getStorage,
+  ref,
+  uploadBytesResumable,
+  setMaxUploadRetryTime,
+  setMaxOperationRetryTime,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-storage.js';
+
+const configuredStorages = new WeakSet();
+
+function ensureStorageConfigured(storage) {
+  if (!configuredStorages.has(storage)) {
+    setMaxUploadRetryTime(storage, 90_000);
+    setMaxOperationRetryTime(storage, 5 * 60_000);
+    configuredStorages.add(storage);
+  }
+}
+
+export function getConfiguredStorage(app) {
+  const storage = getStorage(app);
+  ensureStorageConfigured(storage);
+  return storage;
+}
+
+const MAX_ATTEMPTS = 6;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isTransientStorageError(error) {
+  if (!error) return false;
+  const message =
+    `${error.message || ''} ${error.serverResponse || ''}`.toLowerCase();
+  return (
+    error.code === 'storage/retry-limit-exceeded' ||
+    error.code === 'storage/unknown' ||
+    message.includes('503') ||
+    message.includes('temporarily') ||
+    message.includes('timeout')
+  );
+}
+
+export async function uploadFileWithRetry(
+  storage,
+  path,
+  file,
+  metadata = {},
+  attempt = 0,
+) {
+  ensureStorageConfigured(storage);
+  const meta = { ...metadata };
+  if (!meta.contentType) {
+    const inferredType =
+      (file && typeof file.type === 'string' && file.type) ||
+      (file?.name?.toLowerCase().endsWith('.pdf') ? 'application/pdf' : '') ||
+      'application/octet-stream';
+    meta.contentType = inferredType;
+  }
+
+  const storageRef = ref(storage, path);
+
+  try {
+    const snapshot = await new Promise((resolve, reject) => {
+      const task = uploadBytesResumable(storageRef, file, meta);
+      task.on(
+        'state_changed',
+        null,
+        (error) => reject(error),
+        () => resolve(task.snapshot),
+      );
+    });
+    return snapshot;
+  } catch (error) {
+    if (attempt < MAX_ATTEMPTS && isTransientStorageError(error)) {
+      const waitTime = Math.min(2000 * 2 ** attempt, 20_000);
+      await sleep(waitTime);
+      return uploadFileWithRetry(storage, path, file, meta, attempt + 1);
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- point the Firebase Storage bucket at the canonical appspot domain
- add a shared helper that configures resumable uploads with generous retry/backoff settings
- update all storage upload callers to use the new helper so large files retry reliably

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f0f88dc504832abd4d78c47f65102f