### PR TITLE
Handle Firestore persistence warning and improve CORS errors

### DIFF
--- a/etiquetas-shopee.html
+++ b/etiquetas-shopee.html
@@ -989,8 +989,21 @@
 
         return { url, storagePath: finalStoragePath, docId: docRef.id };
       } catch (error) {
-        console.error('Erro ao enviar PDF para o Firebase:', error);
-        throw error;
+        let normalizedError = error;
+        const message = error?.message || '';
+        const isFetchFailure =
+          error instanceof TypeError || message.toLowerCase().includes('failed to fetch');
+
+        if (isFetchFailure) {
+          normalizedError = new Error(
+            'Não foi possível enviar o PDF: o servidor de upload bloqueou a requisição (CORS).',
+          );
+          normalizedError.code = 'cors-blocked';
+          normalizedError.cause = error;
+        }
+
+        console.error('Erro ao enviar PDF para o Firebase:', normalizedError);
+        throw normalizedError;
       }
     }
 
@@ -1321,9 +1334,19 @@
         console.error(error);
         setStatus('Erro.');
         outEl.innerHTML = '';
-        log(`ERRO: ${error?.message || error}`);
-        alert('Erro ao processar o PDF.');
-        failProcessingModal('Não foi possível concluir o processamento. Tente novamente.');
+        const errorMessage = error?.message || error;
+        log(`ERRO: ${errorMessage}`);
+        if (error?.code === 'cors-blocked') {
+          alert(
+            'Não foi possível enviar o PDF porque o servidor bloqueou a requisição (CORS). Solicite ao suporte a liberação do domínio https://www.provendedor.com.br.',
+          );
+          failProcessingModal(
+            'Envio bloqueado pelo servidor de upload (CORS). Avise o suporte para liberar o domínio.',
+          );
+        } else {
+          alert('Erro ao processar o PDF.');
+          failProcessingModal('Não foi possível concluir o processamento. Tente novamente.');
+        }
       } finally {
         toggleProcessingState(false);
       }
@@ -1654,9 +1677,19 @@
           console.error(error);
           setStatus('Erro.', pickupStatusEl);
           outEl.innerHTML = '';
-          log(`ERRO: ${error?.message || error}`);
-          alert('Erro ao processar o PDF.');
-          failProcessingModal('Não foi possível concluir o processamento. Tente novamente.');
+          const errorMessage = error?.message || error;
+          log(`ERRO: ${errorMessage}`);
+          if (error?.code === 'cors-blocked') {
+            alert(
+              'Não foi possível enviar o PDF porque o servidor bloqueou a requisição (CORS). Solicite ao suporte a liberação do domínio https://www.provendedor.com.br.',
+            );
+            failProcessingModal(
+              'Envio bloqueado pelo servidor de upload (CORS). Avise o suporte para liberar o domínio.',
+            );
+          } else {
+            alert('Erro ao processar o PDF.');
+            failProcessingModal('Não foi possível concluir o processamento. Tente novamente.');
+          }
         } finally {
           toggleProcessingState(false);
         }

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -4,7 +4,10 @@ import {
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
 import {
   getFirestore,
-  enableIndexedDbPersistence,
+  initializeFirestore,
+  persistentLocalCache,
+  persistentSingleTabManager,
+  memoryLocalCache,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
 import { getAuth } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 
@@ -22,11 +25,72 @@ export const firebaseConfig = {
 
 // Initialize Firebase app once and enable offline persistence
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
-const db = getFirestore(app);
-// Best-effort enable persistence; ignore if not supported or already enabled
-enableIndexedDbPersistence(db).catch((err) => {
-  console.warn('Firestore persistence not enabled:', err.code);
-});
+
+function configureFirestore(appInstance) {
+  const hasNewPersistenceApi =
+    typeof initializeFirestore === 'function' &&
+    typeof persistentLocalCache === 'function';
+
+  if (!hasNewPersistenceApi) {
+    return getFirestore(appInstance);
+  }
+
+  const initializeWithSettings = (settings) => {
+    try {
+      return initializeFirestore(appInstance, settings);
+    } catch (error) {
+      if (error?.code === 'already-initialized') {
+        return getFirestore(appInstance);
+      }
+      throw error;
+    }
+  };
+
+  const buildPersistentCache = () => {
+    try {
+      if (typeof persistentSingleTabManager === 'function') {
+        return persistentLocalCache({ tabManager: persistentSingleTabManager() });
+      }
+      return persistentLocalCache();
+    } catch (error) {
+      console.warn('Não foi possível configurar o cache persistente do Firestore:', error);
+      return null;
+    }
+  };
+
+  try {
+    const persistentCache = buildPersistentCache();
+    if (persistentCache) {
+      return initializeWithSettings({ localCache: persistentCache });
+    }
+    if (typeof memoryLocalCache === 'function') {
+      return initializeWithSettings({ localCache: memoryLocalCache() });
+    }
+  } catch (error) {
+    if (error?.code === 'failed-precondition' || error?.code === 'unimplemented') {
+      console.warn(
+        'Cache persistente do Firestore indisponível neste navegador. Usando cache em memória.',
+        error.code,
+      );
+      if (typeof memoryLocalCache === 'function') {
+        try {
+          return initializeWithSettings({ localCache: memoryLocalCache() });
+        } catch (memoryError) {
+          console.warn('Falha ao configurar o cache em memória do Firestore:', memoryError);
+        }
+      }
+      return getFirestore(appInstance);
+    }
+
+    console.warn('Firestore persistence not enabled:', error?.code || error);
+    return getFirestore(appInstance);
+  }
+
+  // Se chegamos aqui é porque não foi possível criar o cache persistente, então usamos o padrão.
+  return getFirestore(appInstance);
+}
+
+const db = configureFirestore(app);
 const auth = getAuth(app);
 
 // Utility functions for storing the passphrase securely


### PR DESCRIPTION
## Summary
- replace the deprecated enableIndexedDbPersistence call with initializeFirestore using the modern cache API and fallbacks
- add richer error handling in etiquetas-shopee uploads to surface CORS blocks with actionable messaging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f10069e178832ab4f726a7ea5c6d49