### PR TITLE
Fix PDF storage uploads using resumable helper

### DIFF
--- a/etiquetas-ocr.html
+++ b/etiquetas-ocr.html
@@ -138,6 +138,7 @@
 
       <script type="module">
     import { firebaseConfig } from './firebase-config.js';
+    import { uploadPdf } from './storage-helpers.js';
 
     pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js';
 
@@ -145,7 +146,6 @@
       firebase.initializeApp(firebaseConfig);
     }
     const db = firebase.firestore();
-    const storage = firebase.storage();
     let currentUser = null;
     let responsavelExpedicaoUid = null;
     let horariosEtiquetas = [];
@@ -693,14 +693,15 @@ firebase.auth().onAuthStateChanged(async u => {
         if (contadorInicial !== null) docPayload.contadorInicial = contadorInicial;
         if (contadorFinal !== null) docPayload.contadorFinal = contadorFinal;
         const docRef = await db.collection('pdfDocs').add(docPayload);
-        const fileRef = storage.ref().child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
-        await fileRef.put(blob);
-        const url = await fileRef.getDownloadURL();
-        await docRef.update({ url: url, storagePath: fileRef.fullPath });
+        const uploadResult = await uploadPdf(blob, {
+          path: `pdfs/${currentUser.uid}/${docRef.id}.pdf`,
+        });
+        const { url, path: storagePath } = uploadResult;
+        await docRef.update({ url: url, storagePath });
         const record = {
           name: fileName,
           url: url,
-          path: fileRef.fullPath,
+          path: storagePath,
           createdAt: firebase.firestore.FieldValue.serverTimestamp(),
           totalPaginas,
           contadorInicial,
@@ -1099,14 +1100,15 @@ firebase.auth().onAuthStateChanged(async u => {
             name: fileName,
             foraHorario: foraDoHorario()
           });
-          const fileRef = storage.ref().child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
-          await fileRef.put(pdfFile);
-          const url = await fileRef.getDownloadURL();
-          await docRef.update({ url: url, storagePath: fileRef.fullPath });
+          const uploadResult = await uploadPdf(pdfFile, {
+            path: `pdfs/${currentUser.uid}/${docRef.id}.pdf`,
+          });
+          const { url, path: storagePath } = uploadResult;
+          await docRef.update({ url: url, storagePath });
           const record = {
             name: fileName,
             url: url,
-            path: fileRef.fullPath,
+            path: storagePath,
             createdAt: firebase.firestore.FieldValue.serverTimestamp()
           };
           await db.collection('users').doc(currentUser.uid).collection('etiquetaenvio').add({ ...record });
@@ -1114,7 +1116,7 @@ firebase.auth().onAuthStateChanged(async u => {
             const respRecord = {
               name: fileName,
               url: url,
-              path: fileRef.fullPath,
+              path: storagePath,
               createdAt: firebase.firestore.FieldValue.serverTimestamp()
             };
             await db.collection('users').doc(responsavelExpedicaoUid).collection('etiquetaenvio').add({ ...respRecord });

--- a/etiquetas-shopee.html
+++ b/etiquetas-shopee.html
@@ -486,13 +486,13 @@
 
   <script type="module">
     import { firebaseConfig } from './firebase-config.js';
+    import { uploadPdf } from './storage-helpers.js';
 
     if (!firebase.apps.length) {
       firebase.initializeApp(firebaseConfig);
     }
 
     const db = firebase.firestore();
-    const storage = firebase.storage();
 
     const fileInput = document.getElementById('file');
     const pickupFileInput = document.getElementById('pickupFile');
@@ -859,15 +859,16 @@
         }
 
         const docRef = await db.collection('pdfDocs').add(docPayload);
-        const fileRef = storage.ref().child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
-        await fileRef.put(blob);
-        const url = await fileRef.getDownloadURL();
-        await docRef.update({ url, storagePath: fileRef.fullPath });
+        const uploadResult = await uploadPdf(blob, {
+          path: `pdfs/${currentUser.uid}/${docRef.id}.pdf`,
+        });
+        const { url, path: storagePath } = uploadResult;
+        await docRef.update({ url, storagePath });
 
         const resumo = {
           name: fileName,
           url,
-          path: fileRef.fullPath,
+          path: storagePath,
           createdAt: firebase.firestore.FieldValue.serverTimestamp(),
         };
         if (lojaMeta) {
@@ -936,7 +937,7 @@
           await window.ExpedicaoNotifier.notifyNovaEtiqueta(notifyPayload);
         }
 
-        return { url, storagePath: fileRef.fullPath, docId: docRef.id };
+        return { url, storagePath, docId: docRef.id };
       } catch (error) {
         console.error('Erro ao enviar PDF para o Firebase:', error);
         throw error;

--- a/expedicao.html
+++ b/expedicao.html
@@ -382,6 +382,7 @@
       <script type="module">
         import { firebaseConfig, getPassphrase } from './firebase-config.js';
         import { decryptString } from './crypto.js';
+        import { uploadPdf } from './storage-helpers.js';
 
         if (!firebase.apps.length) {
           firebase.initializeApp(firebaseConfig);
@@ -2088,39 +2089,32 @@
               totalPaginas: pageCount,
               pageCount,
             });
-            const fileRef = storage
-              .ref()
-              .child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
             if (typeof onProgress === 'function')
               onProgress({ text: 'Enviando arquivo...', percent: 25 });
-            await new Promise((resolve, reject) => {
-              const uploadTask = fileRef.put(file);
-              uploadTask.on(
-                'state_changed',
-                (snapshot) => {
-                  if (
-                    !snapshot ||
-                    !snapshot.totalBytes ||
-                    typeof onProgress !== 'function'
-                  )
-                    return;
-                  const percent = Math.round(
-                    (snapshot.bytesTransferred / snapshot.totalBytes) * 100,
-                  );
-                  const adjusted = Math.max(25, Math.min(95, percent));
-                  onProgress({
-                    text: `Enviando arquivo... ${percent}%`,
-                    percent: adjusted,
-                  });
-                },
-                (error) => reject(error),
-                () => resolve(),
-              );
+            const uploadResult = await uploadPdf(file, {
+              path: `pdfs/${currentUser.uid}/${docRef.id}.pdf`,
+              onProgress: (snapshot) => {
+                if (
+                  !snapshot ||
+                  !snapshot.totalBytes ||
+                  typeof onProgress !== 'function'
+                ) {
+                  return;
+                }
+                const percent = Math.round(
+                  (snapshot.bytesTransferred / snapshot.totalBytes) * 100,
+                );
+                const adjusted = Math.max(25, Math.min(95, percent));
+                onProgress({
+                  text: `Enviando arquivo... ${percent}%`,
+                  percent: adjusted,
+                });
+              },
             });
-            const url = await fileRef.getDownloadURL();
+            const { url, path: storagePath } = uploadResult;
             await docRef.update({
               url: url,
-              storagePath: fileRef.fullPath,
+              storagePath,
               loja: lojaNome || '',
               totalPaginas: pageCount,
               pageCount,

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -14,7 +14,7 @@ export const firebaseConfig = {
   apiKey: 'AIzaSyC78l9b2DTNj64y_0fbRKofNupO6NHDmeo',
   authDomain: 'matheus-35023.firebaseapp.com',
   projectId: 'matheus-35023',
-  storageBucket: 'matheus-35023.firebasestorage.app',
+  storageBucket: 'matheus-35023.appspot.com',
   messagingSenderId: '1011113149395',
   appId: '1:1011113149395:web:c1f449e0e974ca8ecb2526',
   databaseURL: 'https://matheus-35023.firebaseio.com',

--- a/storage-helpers.js
+++ b/storage-helpers.js
@@ -1,0 +1,89 @@
+import {
+  getStorage,
+  ref,
+  uploadBytesResumable,
+  getDownloadURL,
+  setMaxUploadRetryTime,
+  setMaxOperationRetryTime,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-storage.js';
+import { app } from './firebase-config.js';
+
+const STORAGE_BUCKET_URL = 'gs://matheus-35023.appspot.com';
+const storage = getStorage(app, STORAGE_BUCKET_URL);
+
+setMaxUploadRetryTime(storage, 10 * 60 * 1000);
+setMaxOperationRetryTime(storage, 2 * 60 * 1000);
+
+export function sanitizeFileName(name = '') {
+  const base =
+    typeof name === 'string' && name.trim() ? name.trim() : 'arquivo.pdf';
+  return base.replace(/[^\w.\-]+/g, '_');
+}
+
+function toPdfBlob(fileOrBlob) {
+  if (!fileOrBlob) {
+    throw new Error('Arquivo PDF inválido.');
+  }
+  if (fileOrBlob instanceof Blob) {
+    if (fileOrBlob.type === 'application/pdf') {
+      return fileOrBlob;
+    }
+    return new Blob([fileOrBlob], { type: 'application/pdf' });
+  }
+  return new Blob([fileOrBlob], { type: 'application/pdf' });
+}
+
+export function uploadPdf(fileOrBlob, options = {}) {
+  const { path, metadata = {}, onProgress } = options;
+  const blob = toPdfBlob(fileOrBlob);
+  const defaultName =
+    fileOrBlob && typeof fileOrBlob.name === 'string'
+      ? fileOrBlob.name
+      : 'arquivo.pdf';
+  const targetPath =
+    path || `pdfs/${Date.now()}_${sanitizeFileName(defaultName)}`;
+  const storageRef = ref(storage, targetPath);
+  const uploadTask = uploadBytesResumable(storageRef, blob, {
+    contentType: 'application/pdf',
+    ...metadata,
+  });
+
+  return new Promise((resolve, reject) => {
+    uploadTask.on(
+      'state_changed',
+      (snapshot) => {
+        if (typeof onProgress === 'function' && snapshot) {
+          onProgress(snapshot);
+        }
+      },
+      (error) => {
+        if (
+          error &&
+          (error.code === 'storage/retry-limit-exceeded' ||
+            error.code === 'storage/unknown')
+        ) {
+          try {
+            uploadTask.resume?.();
+            return;
+          } catch (resumeError) {
+            console.warn(
+              'Não foi possível retomar upload automaticamente:',
+              resumeError,
+            );
+          }
+        }
+        reject(error);
+      },
+      async () => {
+        const url = await getDownloadURL(uploadTask.snapshot.ref);
+        resolve({
+          url,
+          path: uploadTask.snapshot.ref.fullPath,
+          ref: uploadTask.snapshot.ref,
+        });
+      },
+    );
+  });
+}
+
+export { storage };

--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -108,6 +108,7 @@
   <script type="module">
   import { firebaseConfig } from './firebase-config.js';
   import { createOcrWorker } from './createWorker.js';
+  import { uploadPdf } from './storage-helpers.js';
   // ===== Utilitários UI =====
   const $ = (sel) => document.querySelector(sel);
   const sleep = (ms) => new Promise(r=>setTimeout(r, ms));
@@ -152,7 +153,6 @@
   }
   const auth = firebase.auth();
   const db = firebase.firestore();
-  const storage = firebase.storage();
   function showOk(msg){ const n=$(el.toastOk); n.textContent=msg; n.classList.remove('hidden'); }
   function hideOk(){ $(el.toastOk).classList.add('hidden'); }
   function showErr(msg){ const n=$(el.toastErr); n.textContent=msg; n.classList.remove('hidden'); }
@@ -613,12 +613,11 @@
       const pdfBytes = await pdfDoc.save();
       const pdfBlob = new Blob([pdfBytes], { type:'application/pdf' });
 
-      const ref = storage.ref().child(pdfPath);
-      await ref.put(pdfBlob);
-      const url = await ref.getDownloadURL();
+      const uploadResult = await uploadPdf(pdfBlob, { path: pdfPath });
+      const { url, path: storagePath } = uploadResult;
       console.log('[btnProcessar] PDF uploaded', url);
-      await metaRef.update({ url, storagePath: pdfPath, finishedAt: firebase.firestore.FieldValue.serverTimestamp() });
-      await savePdfRecord(url, pdfPath, name, responsavelUid, foraHorario, {
+      await metaRef.update({ url, storagePath, finishedAt: firebase.firestore.FieldValue.serverTimestamp() });
+      await savePdfRecord(url, storagePath, name, responsavelUid, foraHorario, {
         destinatarioEmails: gestorEmail ? [gestorEmail] : [],
         totalEtiquetas: totalLabels,
         origem: 'ZPL Import (OCR)',

--- a/zpl-import.html
+++ b/zpl-import.html
@@ -82,11 +82,12 @@
 </div>
 
 <script src="expedicao-notifier.js"></script>
-<script>
+<script type="module">
+    import { uploadPdf } from './storage-helpers.js';
+
     document.addEventListener('DOMContentLoaded', () => {
         if (!firebase.apps.length) { firebase.initializeApp(firebaseConfig); }
         const db = firebase.firestore();
-        const storage = firebase.storage();
         let currentUser = null;
         let responsavelExpedicaoUid = null;
         let responsavelExpedicaoEmail = null;
@@ -173,14 +174,15 @@
                 name: name,
                 foraHorario: foraHorarioAtual
             });
-            const fileRef = storage.ref().child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
-            await fileRef.put(blob);
-            const url = await fileRef.getDownloadURL();
-            await docRef.update({ url: url, storagePath: fileRef.fullPath });
+            const uploadResult = await uploadPdf(blob, {
+                path: `pdfs/${currentUser.uid}/${docRef.id}.pdf`,
+            });
+            const { url, path: storagePath } = uploadResult;
+            await docRef.update({ url: url, storagePath });
             const record = {
                 name: name,
                 url: url,
-                path: fileRef.fullPath,
+                path: storagePath,
                 createdAt: firebase.firestore.FieldValue.serverTimestamp()
             };
             await db.collection('users').doc(currentUser.uid).collection('etiquetaenvio').add({ ...record });
@@ -188,7 +190,7 @@
                 const respRecord = {
                     name: name,
                     url: url,
-                    path: fileRef.fullPath,
+                    path: storagePath,
                     createdAt: firebase.firestore.FieldValue.serverTimestamp()
                 };
                 await db.collection('users').doc(responsavelExpedicaoUid).collection('etiquetaenvio').add({ ...respRecord });


### PR DESCRIPTION
## Summary
- add a shared Firebase Storage helper that configures resumable uploads with extended retry windows
- update PDF generation flows to upload blobs through the resumable helper instead of base put() calls
- point the Firebase configuration to the correct matheus-35023.appspot.com bucket to avoid mixed endpoints

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68f1462fbe30832a856bbcc08a20849a