### PR TITLE
Fix PDF uploads with resumable Firebase storage

### DIFF
--- a/etiquetas-ocr.html
+++ b/etiquetas-ocr.html
@@ -138,6 +138,7 @@
 
       <script type="module">
     import { firebaseConfig } from './firebase-config.js';
+    import { uploadPdfResumable } from './storage-upload.js';
 
     pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js';
 
@@ -145,7 +146,6 @@
       firebase.initializeApp(firebaseConfig);
     }
     const db = firebase.firestore();
-    const storage = firebase.storage();
     let currentUser = null;
     let responsavelExpedicaoUid = null;
     let horariosEtiquetas = [];
@@ -693,14 +693,14 @@ firebase.auth().onAuthStateChanged(async u => {
         if (contadorInicial !== null) docPayload.contadorInicial = contadorInicial;
         if (contadorFinal !== null) docPayload.contadorFinal = contadorFinal;
         const docRef = await db.collection('pdfDocs').add(docPayload);
-        const fileRef = storage.ref().child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
-        await fileRef.put(blob);
-        const url = await fileRef.getDownloadURL();
-        await docRef.update({ url: url, storagePath: fileRef.fullPath });
+        const storagePath = `pdfs/${currentUser.uid}/${docRef.id}.pdf`;
+        const uploadResult = await uploadPdfResumable(blob, storagePath);
+        const { url, fullPath } = uploadResult;
+        await docRef.update({ url: url, storagePath: fullPath });
         const record = {
           name: fileName,
           url: url,
-          path: fileRef.fullPath,
+          path: fullPath,
           createdAt: firebase.firestore.FieldValue.serverTimestamp(),
           totalPaginas,
           contadorInicial,
@@ -1099,14 +1099,14 @@ firebase.auth().onAuthStateChanged(async u => {
             name: fileName,
             foraHorario: foraDoHorario()
           });
-          const fileRef = storage.ref().child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
-          await fileRef.put(pdfFile);
-          const url = await fileRef.getDownloadURL();
-          await docRef.update({ url: url, storagePath: fileRef.fullPath });
+          const storagePath = `pdfs/${currentUser.uid}/${docRef.id}.pdf`;
+          const uploadResult = await uploadPdfResumable(pdfFile, storagePath);
+          const { url, fullPath } = uploadResult;
+          await docRef.update({ url: url, storagePath: fullPath });
           const record = {
             name: fileName,
             url: url,
-            path: fileRef.fullPath,
+            path: fullPath,
             createdAt: firebase.firestore.FieldValue.serverTimestamp()
           };
           await db.collection('users').doc(currentUser.uid).collection('etiquetaenvio').add({ ...record });
@@ -1114,7 +1114,7 @@ firebase.auth().onAuthStateChanged(async u => {
             const respRecord = {
               name: fileName,
               url: url,
-              path: fileRef.fullPath,
+              path: fullPath,
               createdAt: firebase.firestore.FieldValue.serverTimestamp()
             };
             await db.collection('users').doc(responsavelExpedicaoUid).collection('etiquetaenvio').add({ ...respRecord });

--- a/etiquetas-shopee.html
+++ b/etiquetas-shopee.html
@@ -486,13 +486,13 @@
 
   <script type="module">
     import { firebaseConfig } from './firebase-config.js';
+    import { uploadPdfResumable } from './storage-upload.js';
 
     if (!firebase.apps.length) {
       firebase.initializeApp(firebaseConfig);
     }
 
     const db = firebase.firestore();
-    const storage = firebase.storage();
 
     const fileInput = document.getElementById('file');
     const pickupFileInput = document.getElementById('pickupFile');
@@ -859,15 +859,15 @@
         }
 
         const docRef = await db.collection('pdfDocs').add(docPayload);
-        const fileRef = storage.ref().child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
-        await fileRef.put(blob);
-        const url = await fileRef.getDownloadURL();
-        await docRef.update({ url, storagePath: fileRef.fullPath });
+        const storagePath = `pdfs/${currentUser.uid}/${docRef.id}.pdf`;
+        const uploadResult = await uploadPdfResumable(blob, storagePath);
+        const { url, fullPath } = uploadResult;
+        await docRef.update({ url, storagePath: fullPath });
 
         const resumo = {
           name: fileName,
           url,
-          path: fileRef.fullPath,
+          path: fullPath,
           createdAt: firebase.firestore.FieldValue.serverTimestamp(),
         };
         if (lojaMeta) {
@@ -936,7 +936,7 @@
           await window.ExpedicaoNotifier.notifyNovaEtiqueta(notifyPayload);
         }
 
-        return { url, storagePath: fileRef.fullPath, docId: docRef.id };
+        return { url, storagePath: fullPath, docId: docRef.id };
       } catch (error) {
         console.error('Erro ao enviar PDF para o Firebase:', error);
         throw error;

--- a/expedicao.html
+++ b/expedicao.html
@@ -382,6 +382,7 @@
       <script type="module">
         import { firebaseConfig, getPassphrase } from './firebase-config.js';
         import { decryptString } from './crypto.js';
+        import { uploadPdfResumable } from './storage-upload.js';
 
         if (!firebase.apps.length) {
           firebase.initializeApp(firebaseConfig);
@@ -2088,39 +2089,23 @@
               totalPaginas: pageCount,
               pageCount,
             });
-            const fileRef = storage
-              .ref()
-              .child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
+            const storagePath = `pdfs/${currentUser.uid}/${docRef.id}.pdf`;
             if (typeof onProgress === 'function')
               onProgress({ text: 'Enviando arquivo...', percent: 25 });
-            await new Promise((resolve, reject) => {
-              const uploadTask = fileRef.put(file);
-              uploadTask.on(
-                'state_changed',
-                (snapshot) => {
-                  if (
-                    !snapshot ||
-                    !snapshot.totalBytes ||
-                    typeof onProgress !== 'function'
-                  )
-                    return;
-                  const percent = Math.round(
-                    (snapshot.bytesTransferred / snapshot.totalBytes) * 100,
-                  );
-                  const adjusted = Math.max(25, Math.min(95, percent));
-                  onProgress({
-                    text: `Enviando arquivo... ${percent}%`,
-                    percent: adjusted,
-                  });
-                },
-                (error) => reject(error),
-                () => resolve(),
-              );
+            const uploadResult = await uploadPdfResumable(file, storagePath, {
+              onProgress: ({ percent }) => {
+                if (typeof onProgress !== 'function') return;
+                const adjusted = Math.max(25, Math.min(95, percent));
+                onProgress({
+                  text: `Enviando arquivo... ${percent}%`,
+                  percent: adjusted,
+                });
+              },
             });
-            const url = await fileRef.getDownloadURL();
+            const { url, fullPath } = uploadResult;
             await docRef.update({
               url: url,
-              storagePath: fileRef.fullPath,
+              storagePath: fullPath,
               loja: lojaNome || '',
               totalPaginas: pageCount,
               pageCount,

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -14,7 +14,7 @@ export const firebaseConfig = {
   apiKey: 'AIzaSyC78l9b2DTNj64y_0fbRKofNupO6NHDmeo',
   authDomain: 'matheus-35023.firebaseapp.com',
   projectId: 'matheus-35023',
-  storageBucket: 'matheus-35023.firebasestorage.app',
+  storageBucket: 'matheus-35023.appspot.com',
   messagingSenderId: '1011113149395',
   appId: '1:1011113149395:web:c1f449e0e974ca8ecb2526',
   databaseURL: 'https://matheus-35023.firebaseio.com',

--- a/storage-upload.js
+++ b/storage-upload.js
@@ -1,0 +1,87 @@
+import { getApp } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import {
+  getStorage,
+  ref as storageRef,
+  uploadBytesResumable,
+  getDownloadURL,
+  setMaxUploadRetryTime,
+  setMaxOperationRetryTime,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-storage.js';
+
+const DEFAULT_BUCKET = 'gs://matheus-35023.appspot.com';
+const storageCache = new Map();
+
+function ensureStorage(bucket = DEFAULT_BUCKET) {
+  const key = bucket || 'default';
+  if (!storageCache.has(key)) {
+    const app = getApp();
+    const storage = bucket ? getStorage(app, bucket) : getStorage(app);
+    setMaxUploadRetryTime(storage, 10 * 60 * 1000);
+    setMaxOperationRetryTime(storage, 2 * 60 * 1000);
+    storageCache.set(key, storage);
+  }
+  return storageCache.get(key);
+}
+
+export function uploadPdfResumable(fileOrBlob, path, options = {}) {
+  if (!fileOrBlob) {
+    return Promise.reject(new Error('Nenhum arquivo informado para upload.'));
+  }
+  if (!path) {
+    return Promise.reject(
+      new Error('O caminho de armazenamento é obrigatório.'),
+    );
+  }
+  const { onProgress, metadata } = options;
+  const storage = ensureStorage(options.bucket || DEFAULT_BUCKET);
+  const meta = { contentType: 'application/pdf', ...(metadata || {}) };
+  const ref = storageRef(storage, path);
+  const task = uploadBytesResumable(ref, fileOrBlob, meta);
+
+  return new Promise((resolve, reject) => {
+    task.on(
+      'state_changed',
+      (snapshot) => {
+        if (typeof onProgress === 'function' && snapshot?.totalBytes) {
+          const percent = Math.round(
+            (snapshot.bytesTransferred / snapshot.totalBytes) * 100,
+          );
+          try {
+            onProgress({ snapshot, percent });
+          } catch (progressErr) {
+            console.warn('Upload progress callback error:', progressErr);
+          }
+        }
+      },
+      (error) => {
+        if (
+          error?.code === 'storage/retry-limit-exceeded' ||
+          error?.code === 'storage/unknown'
+        ) {
+          try {
+            task.resume?.();
+          } catch (_) {
+            // ignore resume errors
+          }
+        }
+        reject(error);
+      },
+      async () => {
+        try {
+          const url = await getDownloadURL(task.snapshot.ref);
+          resolve({
+            url,
+            fullPath: task.snapshot.ref.fullPath,
+            ref: task.snapshot.ref,
+          });
+        } catch (urlError) {
+          reject(urlError);
+        }
+      },
+    );
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.uploadPdfResumable = uploadPdfResumable;
+}

--- a/zpl-import-ocr.html
+++ b/zpl-import-ocr.html
@@ -108,6 +108,7 @@
   <script type="module">
   import { firebaseConfig } from './firebase-config.js';
   import { createOcrWorker } from './createWorker.js';
+  import { uploadPdfResumable } from './storage-upload.js';
   // ===== Utilitários UI =====
   const $ = (sel) => document.querySelector(sel);
   const sleep = (ms) => new Promise(r=>setTimeout(r, ms));
@@ -152,7 +153,6 @@
   }
   const auth = firebase.auth();
   const db = firebase.firestore();
-  const storage = firebase.storage();
   function showOk(msg){ const n=$(el.toastOk); n.textContent=msg; n.classList.remove('hidden'); }
   function hideOk(){ $(el.toastOk).classList.add('hidden'); }
   function showErr(msg){ const n=$(el.toastErr); n.textContent=msg; n.classList.remove('hidden'); }
@@ -613,12 +613,11 @@
       const pdfBytes = await pdfDoc.save();
       const pdfBlob = new Blob([pdfBytes], { type:'application/pdf' });
 
-      const ref = storage.ref().child(pdfPath);
-      await ref.put(pdfBlob);
-      const url = await ref.getDownloadURL();
+      const uploadResult = await uploadPdfResumable(pdfBlob, pdfPath);
+      const { url, fullPath } = uploadResult;
       console.log('[btnProcessar] PDF uploaded', url);
-      await metaRef.update({ url, storagePath: pdfPath, finishedAt: firebase.firestore.FieldValue.serverTimestamp() });
-      await savePdfRecord(url, pdfPath, name, responsavelUid, foraHorario, {
+      await metaRef.update({ url, storagePath: fullPath, finishedAt: firebase.firestore.FieldValue.serverTimestamp() });
+      await savePdfRecord(url, fullPath, name, responsavelUid, foraHorario, {
         destinatarioEmails: gestorEmail ? [gestorEmail] : [],
         totalEtiquetas: totalLabels,
         origem: 'ZPL Import (OCR)',

--- a/zpl-import.html
+++ b/zpl-import.html
@@ -82,11 +82,12 @@
 </div>
 
 <script src="expedicao-notifier.js"></script>
-<script>
+<script type="module">
+    import { uploadPdfResumable } from './storage-upload.js';
+
     document.addEventListener('DOMContentLoaded', () => {
         if (!firebase.apps.length) { firebase.initializeApp(firebaseConfig); }
         const db = firebase.firestore();
-        const storage = firebase.storage();
         let currentUser = null;
         let responsavelExpedicaoUid = null;
         let responsavelExpedicaoEmail = null;
@@ -173,14 +174,14 @@
                 name: name,
                 foraHorario: foraHorarioAtual
             });
-            const fileRef = storage.ref().child(`pdfs/${currentUser.uid}/${docRef.id}.pdf`);
-            await fileRef.put(blob);
-            const url = await fileRef.getDownloadURL();
-            await docRef.update({ url: url, storagePath: fileRef.fullPath });
+            const storagePath = `pdfs/${currentUser.uid}/${docRef.id}.pdf`;
+            const uploadResult = await uploadPdfResumable(blob, storagePath);
+            const { url, fullPath } = uploadResult;
+            await docRef.update({ url: url, storagePath: fullPath });
             const record = {
                 name: name,
                 url: url,
-                path: fileRef.fullPath,
+                path: fullPath,
                 createdAt: firebase.firestore.FieldValue.serverTimestamp()
             };
             await db.collection('users').doc(currentUser.uid).collection('etiquetaenvio').add({ ...record });
@@ -188,7 +189,7 @@
                 const respRecord = {
                     name: name,
                     url: url,
-                    path: fileRef.fullPath,
+                    path: fullPath,
                     createdAt: firebase.firestore.FieldValue.serverTimestamp()
                 };
                 await db.collection('users').doc(responsavelExpedicaoUid).collection('etiquetaenvio').add({ ...respRecord });


### PR DESCRIPTION
## Summary
- add a shared helper that uses Firebase Storage resumable uploads with higher retry timeouts
- update all label processing flows to call the resumable uploader and store the returned storage paths
- correct the Firebase storage bucket configuration to point at the gs://matheus-35023.appspot.com bucket

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68f1462fbe30832a856bbcc08a20849a