### PR TITLE
Optimize fetching of sold products lists

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -8930,12 +8930,32 @@ const ownerUid = ["adm","admin"].includes(usuarioLogado.perfil.toLowerCase())
               .collection('skusVendidos')
               .get();
 
-            for (const docDia of vendasSnap.docs) {
+            const docsFiltrados = vendasSnap.docs.filter((docDia) => {
               const dataDoc = docDia.id || '';
-              if (dataInicio && dataDoc && dataDoc < dataInicio) continue;
-              if (dataFim && dataDoc && dataDoc > dataFim) continue;
+              if (dataInicio && dataDoc && dataDoc < dataInicio) return false;
+              if (dataFim && dataDoc && dataDoc > dataFim) return false;
+              return true;
+            });
 
-              const listaSnap = await docDia.ref.collection('lista').get();
+            const listasResultado = await Promise.all(
+              docsFiltrados.map(async (docDia) => {
+                try {
+                  const listaSnap = await docDia.ref.collection('lista').get();
+                  return { docDia, listaSnap };
+                } catch (listaErr) {
+                  console.error(
+                    'Erro ao carregar lista de SKUs vendidos',
+                    { uid, data: docDia.id },
+                    listaErr,
+                  );
+                  return null;
+                }
+              }),
+            );
+
+            for (const resultadoLista of listasResultado) {
+              if (!resultadoLista) continue;
+              const { listaSnap } = resultadoLista;
               listaSnap.forEach((itemDoc) => {
                 const dados = itemDoc.data() || {};
                 const skuOriginal = String(


### PR DESCRIPTION
## Summary
- avoid sequential loading of each sold-product list document when filtering manager data
- add scoped error logging so a single failing list does not block the entire load

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f233bc2660832ab2ffacc84271e4f1