### PR TITLE
Atualiza layout do formulário de reembolsos

### DIFF
--- a/problemas.html
+++ b/problemas.html
@@ -31,13 +31,13 @@
             <h2 class="text-lg font-semibold text-slate-700">Novo Reembolso</h2>
             <p class="text-xs text-slate-500">Preencha as informações para registrar</p>
           </div>
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div class="flex flex-col">
               <label for="dataR" class="block text-sm font-medium text-slate-600">Data</label>
               <input type="date" id="dataR" name="data" class="mt-1 w-full rounded-xl border-slate-300 focus:border-violet-500 focus:ring-violet-500">
             </div>
             <div class="flex flex-col">
-              <label for="numeroR" class="block text-sm font-medium text-slate-600">Número</label>
+              <label for="numeroR" class="block text-sm font-medium text-slate-600">Número do Pedido</label>
               <input type="text" id="numeroR" name="numero" class="mt-1 w-full rounded-xl border-slate-300 focus:border-violet-500 focus:ring-violet-500">
             </div>
             <div class="flex flex-col">
@@ -53,19 +53,27 @@
               <input type="text" id="lojaR" name="loja" class="mt-1 w-full rounded-xl border-slate-300 focus:border-violet-500 focus:ring-violet-500">
             </div>
             <div class="flex flex-col">
-              <label for="problemaR" class="block text-sm font-medium text-slate-600">Problema</label>
-              <input type="text" id="problemaR" name="problema" class="mt-1 w-full rounded-xl border-slate-300 focus:border-violet-500 focus:ring-violet-500">
-            </div>
-            <div class="flex flex-col">
               <label for="valorR" class="block text-sm font-medium text-slate-600">Valor</label>
               <div class="relative mt-1">
                 <span class="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500">R$</span>
                 <input type="number" step="0.01" id="valorR" name="valor" class="w-full rounded-xl border-slate-300 pl-8 text-right focus:border-violet-500 focus:ring-violet-500">
               </div>
             </div>
-            <div class="flex flex-col md:col-span-2">
-              <label for="informacoesR" class="block text-sm font-medium text-slate-600">Informações</label>
-              <textarea id="informacoesR" name="informacoes" rows="2" class="mt-1 w-full rounded-xl border-slate-300 focus:border-violet-500 focus:ring-violet-500"></textarea>
+            <div class="flex flex-col">
+              <label for="pixR" class="block text-sm font-medium text-slate-600">PIX</label>
+              <input type="text" id="pixR" name="pix" class="mt-1 w-full rounded-xl border-slate-300 focus:border-violet-500 focus:ring-violet-500">
+            </div>
+            <div class="flex flex-col">
+              <label for="statusR" class="block text-sm font-medium text-slate-600">Status</label>
+              <select id="statusR" name="status" class="mt-1 w-full rounded-xl border-slate-300 focus:border-violet-500 focus:ring-violet-500">
+                <option value="AGUARDANDO PIX">Aguardando PIX</option>
+                <option value="AGUARDANDO MERCADO">Aguardando Mercado</option>
+                <option value="AGUARDANDO">Aguardando</option>
+                <option value="FEITO">Feito</option>
+                <option value="FEITO PIX">Feito PIX</option>
+                <option value="FEITO MERCADO">Feito Mercado</option>
+                <option value="CANCELADO">Cancelado</option>
+              </select>
             </div>
           </div>
           <div class="flex justify-end gap-2">
@@ -79,12 +87,12 @@
             <thead class="bg-slate-50 sticky top-0 z-10">
               <tr class="text-left">
                 <th class="p-2">Data</th>
-                <th class="p-2">Número</th>
+                <th class="p-2">Número do Pedido</th>
+                <th class="p-2">Loja</th>
                 <th class="p-2">Apelido</th>
                 <th class="p-2">NF</th>
-                <th class="p-2">Loja</th>
-                <th class="p-2">Problema</th>
-                <th class="p-2">Informações</th>
+                <th class="p-2">PIX</th>
+                <th class="p-2">Status</th>
                 <th class="p-2 text-right">Valor</th>
                 <th class="p-2 text-right">Ações</th>
               </tr>


### PR DESCRIPTION
## Summary
- reorganiza o formulário de reembolsos para refletir o novo layout com campos de PIX e status
- atualiza a renderização e persistência dos reembolsos para suportar os novos campos e opções de status

## Testing
- Not run (não aplicável)


------
https://chatgpt.com/codex/tasks/task_e_68f7d1b9959c832ab1122c893a74a558