### PR TITLE
Adicionar campo de problema aos reembolsos

### DIFF
--- a/problemas.html
+++ b/problemas.html
@@ -156,6 +156,19 @@
                       class="mt-1 w-full rounded-xl border-slate-300 focus:border-violet-500 focus:ring-violet-500"
                     />
                   </div>
+                  <div class="flex flex-col md:col-span-3">
+                    <label
+                      for="problemaR"
+                      class="block text-sm font-medium text-slate-600"
+                      >Problema</label
+                    >
+                    <input
+                      type="text"
+                      id="problemaR"
+                      name="problema"
+                      class="mt-1 w-full rounded-xl border-slate-300 focus:border-violet-500 focus:ring-violet-500"
+                    />
+                  </div>
                   <div class="flex flex-col">
                     <label
                       for="statusR"
@@ -286,6 +299,7 @@
                         <th class="p-2">Número do Pedido</th>
                         <th class="p-2">Loja</th>
                         <th class="p-2">Apelido</th>
+                        <th class="p-2">Problema</th>
                         <th class="p-2">NF</th>
                         <th class="p-2">PIX</th>
                         <th class="p-2">Status</th>

--- a/problemas.js
+++ b/problemas.js
@@ -313,6 +313,7 @@ async function salvarReembolso(ev) {
     nf: form.nf.value.trim(),
     valor: parseFloat(form.valor.value) || 0,
     pix: form.pix?.value.trim() || '',
+    problema: form.problema?.value.trim() || '',
     status: form.status?.value || 'AGUARDANDO PIX',
   };
   const baseDoc = doc(db, 'uid', uidAtual, 'problemas', 'reembolsos');
@@ -348,6 +349,7 @@ async function carregarReembolsos() {
           ? Number(dados.valor)
           : Number.parseFloat(dados.valor) || 0,
         pix: dados.pix || '',
+        problema: dados.problema || '',
         status: statusValido,
       };
     })
@@ -420,6 +422,15 @@ function renderReembolsos() {
         tipo: 'text',
         valor: d.apelido || '',
         onChange: (valor) => atualizarReembolso(d, { apelido: valor.trim() }),
+        classe: baseInputClass,
+      }),
+    );
+
+    tr.appendChild(
+      criarCelulaInput({
+        tipo: 'text',
+        valor: d.problema || '',
+        onChange: (valor) => atualizarReembolso(d, { problema: valor.trim() }),
         classe: baseInputClass,
       }),
     );


### PR DESCRIPTION
## Summary
- adiciona o campo "Problema" ao formulário e à tabela de reembolsos
- garante que o novo campo seja salvo e editável nos registros do Firestore

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f7d9e21f8c832ab6d6dbf57ba75977