### PR TITLE
Add store filtering and Excel export for saques

### DIFF
--- a/saques.html
+++ b/saques.html
@@ -1,135 +1,262 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="pt-BR">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Saques</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/styles.css?v=20240826" />
-  <style>
-  .backdrop-blur { -webkit-backdrop-filter: blur(8px); backdrop-filter: blur(8px); }
-  </style>
-</head>
-<body class="bg-slate-50 text-slate-800">
-  <div class="app-container">
-  <div id="sidebar-container"></div>
-  <div id="navbar-container"></div>
-  <main class="main-content space-y-6">
-    <!-- Header -->
-    <header class="sticky top-0 z-10 bg-white/70 backdrop-blur border-b border-slate-200">
-      <div class="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
-        <h1 class="text-lg md:text-xl font-semibold text-slate-900">Controle de Saques</h1>
-        <div class="flex items-center gap-3">
-          <input type="month" id="filtroMes" class="h-10 rounded-xl border-slate-300 text-sm text-slate-700 focus:ring-2 focus:ring-indigo-500" />
-          <button onclick="imprimirFechamento()" class="inline-flex items-center h-10 px-4 rounded-xl bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700">Exportar</button>
-        </div>
-      </div>
-    </header>
-
-    <!-- Formulários -->
-    <section class="max-w-7xl mx-auto px-4 space-y-6">
-      <!-- Registrar Saque -->
-      <div class="rounded-2xl border border-slate-200 bg-white shadow-sm">
-        <div class="flex items-center justify-between p-4 border-b border-slate-100">
-          <div class="flex items-center gap-2">
-            <div class="h-8 w-8 rounded-xl bg-gradient-to-tr from-indigo-500 to-cyan-500"></div>
-            <h2 class="text-sm font-semibold text-slate-800">Registrar Saque</h2>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Saques</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="css/styles.css?v=20240826" />
+    <style>
+      .backdrop-blur {
+        -webkit-backdrop-filter: blur(8px);
+        backdrop-filter: blur(8px);
+      }
+    </style>
+  </head>
+  <body class="bg-slate-50 text-slate-800">
+    <div class="app-container">
+      <div id="sidebar-container"></div>
+      <div id="navbar-container"></div>
+      <main class="main-content space-y-6">
+        <!-- Header -->
+        <header
+          class="sticky top-0 z-10 bg-white/70 backdrop-blur border-b border-slate-200"
+        >
+          <div
+            class="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between"
+          >
+            <h1 class="text-lg md:text-xl font-semibold text-slate-900">
+              Controle de Saques
+            </h1>
+            <div class="flex items-center gap-3">
+              <input
+                type="month"
+                id="filtroMes"
+                class="h-10 rounded-xl border-slate-300 text-sm text-slate-700 focus:ring-2 focus:ring-indigo-500"
+              />
+              <button
+                onclick="imprimirFechamento()"
+                class="inline-flex items-center h-10 px-4 rounded-xl bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700"
+              >
+                Exportar
+              </button>
+            </div>
           </div>
-        </div>
-        <div class="p-4">
-          <form class="grid grid-cols-1 md:grid-cols-5 gap-3">
-            <input type="date" id="dataSaque" class="h-11 rounded-xl border-slate-300 text-sm focus:ring-2 focus:ring-indigo-500" />
-            <input type="number" id="valorSaque" placeholder="Valor (R$)" step="0.01" class="h-11 rounded-xl border-slate-300 text-sm focus:ring-2 focus:ring-indigo-500" />
-            <input type="text" id="lojaSaque" placeholder="Loja" class="h-11 rounded-xl border-slate-300 text-sm focus:ring-2 focus:ring-indigo-500" />
-            <select id="percentualSaque" class="h-11 rounded-xl border-slate-300 text-sm focus:ring-2 focus:ring-indigo-500">
-              <option value="0">0%</option>
-              <option value="0.03">3%</option>
-              <option value="0.04">4%</option>
-              <option value="0.05">5%</option>
-            </select>
-            <button type="button" id="btnRegistrar" onclick="registrarSaque()" class="h-11 rounded-xl bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700">Registrar</button>
-          </form>
-        </div>
-      </div>
+        </header>
 
-      <!-- Comissão Recebida -->
-      <div class="rounded-2xl border border-slate-200 bg-white shadow-sm">
-        <div class="flex items-center justify-between p-4 border-b border-slate-100">
-          <div class="flex items-center gap-2">
-            <div class="h-8 w-8 rounded-xl bg-gradient-to-tr from-indigo-500 to-cyan-500"></div>
-            <h2 class="text-sm font-semibold text-slate-800">Comissão Recebida</h2>
+        <!-- Formulários -->
+        <section class="max-w-7xl mx-auto px-4 space-y-6">
+          <!-- Registrar Saque -->
+          <div class="rounded-2xl border border-slate-200 bg-white shadow-sm">
+            <div
+              class="flex items-center justify-between p-4 border-b border-slate-100"
+            >
+              <div class="flex items-center gap-2">
+                <div
+                  class="h-8 w-8 rounded-xl bg-gradient-to-tr from-indigo-500 to-cyan-500"
+                ></div>
+                <h2 class="text-sm font-semibold text-slate-800">
+                  Registrar Saque
+                </h2>
+              </div>
+            </div>
+            <div class="p-4">
+              <form class="grid grid-cols-1 md:grid-cols-5 gap-3">
+                <input
+                  type="date"
+                  id="dataSaque"
+                  class="h-11 rounded-xl border-slate-300 text-sm focus:ring-2 focus:ring-indigo-500"
+                />
+                <input
+                  type="number"
+                  id="valorSaque"
+                  placeholder="Valor (R$)"
+                  step="0.01"
+                  class="h-11 rounded-xl border-slate-300 text-sm focus:ring-2 focus:ring-indigo-500"
+                />
+                <input
+                  type="text"
+                  id="lojaSaque"
+                  placeholder="Loja"
+                  class="h-11 rounded-xl border-slate-300 text-sm focus:ring-2 focus:ring-indigo-500"
+                />
+                <select
+                  id="percentualSaque"
+                  class="h-11 rounded-xl border-slate-300 text-sm focus:ring-2 focus:ring-indigo-500"
+                >
+                  <option value="0">0%</option>
+                  <option value="0.03">3%</option>
+                  <option value="0.04">4%</option>
+                  <option value="0.05">5%</option>
+                </select>
+                <button
+                  type="button"
+                  id="btnRegistrar"
+                  onclick="registrarSaque()"
+                  class="h-11 rounded-xl bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700"
+                >
+                  Registrar
+                </button>
+              </form>
+            </div>
           </div>
-        </div>
-        <div class="p-4">
-          <form class="grid grid-cols-1 md:grid-cols-3 gap-3">
-            <input type="date" id="dataComissao" class="h-11 rounded-xl border-slate-300 text-sm focus:ring-2 focus:ring-indigo-500" />
-            <input type="number" id="valorComissao" placeholder="Valor (R$)" step="0.01" class="h-11 rounded-xl border-slate-300 text-sm focus:ring-2 focus:ring-indigo-500" />
-            <button type="button" onclick="registrarComissaoRecebida()" class="h-11 rounded-xl bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700">Registrar</button>
-          </form>
-        </div>
-      </div>
-    </section>
 
-    <!-- Resumo do mês -->
-    <section class="max-w-7xl mx-auto px-4">
-      <div id="cardsResumo" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4"></div>
-      <p id="faltasTexto" class="mt-4 text-center text-sm text-slate-500"></p>
-    </section>
-
-    <!-- Tabela de Saques -->
-    <section class="max-w-7xl mx-auto px-4">
-      <div class="rounded-2xl border border-slate-200 bg-white shadow-sm overflow-hidden">
-        <div class="flex items-center justify-between p-4 border-b border-slate-100">
-          <h2 class="text-sm font-semibold text-slate-800">Saques Registrados</h2>
-          <div class="flex items-center gap-2">
-            <input placeholder="Buscar..." class="h-9 rounded-lg border-slate-300 text-sm px-3 focus:ring-2 focus:ring-indigo-500" />
+          <!-- Comissão Recebida -->
+          <div class="rounded-2xl border border-slate-200 bg-white shadow-sm">
+            <div
+              class="flex items-center justify-between p-4 border-b border-slate-100"
+            >
+              <div class="flex items-center gap-2">
+                <div
+                  class="h-8 w-8 rounded-xl bg-gradient-to-tr from-indigo-500 to-cyan-500"
+                ></div>
+                <h2 class="text-sm font-semibold text-slate-800">
+                  Comissão Recebida
+                </h2>
+              </div>
+            </div>
+            <div class="p-4">
+              <form class="grid grid-cols-1 md:grid-cols-3 gap-3">
+                <input
+                  type="date"
+                  id="dataComissao"
+                  class="h-11 rounded-xl border-slate-300 text-sm focus:ring-2 focus:ring-indigo-500"
+                />
+                <input
+                  type="number"
+                  id="valorComissao"
+                  placeholder="Valor (R$)"
+                  step="0.01"
+                  class="h-11 rounded-xl border-slate-300 text-sm focus:ring-2 focus:ring-indigo-500"
+                />
+                <button
+                  type="button"
+                  onclick="registrarComissaoRecebida()"
+                  class="h-11 rounded-xl bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700"
+                >
+                  Registrar
+                </button>
+              </form>
+            </div>
           </div>
-        </div>
-        <h3 id="tituloVendedor" class="px-4 pt-4 text-sm font-medium text-slate-500"></h3>
-        <div class="max-h-[60vh] overflow-auto">
-          <table class="w-full text-sm">
-            <thead class="sticky top-0 bg-slate-50 text-slate-600">
-              <tr>
-                <th class="px-4 py-3 text-center">
-                  <input type="checkbox" onchange="toggleSelecaoTodos(this.checked)" class="h-4 w-4 rounded border-slate-300" />
-                </th>
-                <th class="text-left font-medium px-4 py-3">Data</th>
-                <th class="text-left font-medium px-4 py-3">Loja</th>
-                <th class="text-right font-medium px-4 py-3">Saque</th>
-                <th class="text-right font-medium px-4 py-3">% Comissão</th>
-                <th class="text-right font-medium px-4 py-3">Comissão</th>
-                <th class="text-left font-medium px-4 py-3">Status</th>
-                <th class="text-right font-medium px-4 py-3">Ações</th>
-              </tr>
-            </thead>
-            <tbody id="tbodySaques" class="divide-y divide-slate-100"></tbody>
-            <tfoot id="tfootResumo" class="bg-slate-50"></tfoot>
-          </table>
-        </div>
-        <div id="acoesSelecionados" style="display:none" class="flex flex-col md:flex-row items-center gap-2 p-4 border-t border-slate-100">
-          <span id="resumoSelecionados" class="text-sm"></span>
-          <select id="percentualSelecionado" class="h-10 rounded-xl border-slate-300 text-sm focus:ring-2 focus:ring-indigo-500">
-            <option value="0.03">3%</option>
-            <option value="0.04">4%</option>
-            <option value="0.05">5%</option>
-          </select>
-          <div class="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
-            <button onclick="marcarComoPagoSelecionados()" class="h-10 px-4 rounded-xl bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700">Marcar como Pago</button>
-            <button onclick="exportarSelecionadosPDF()" class="h-10 px-4 rounded-xl border border-indigo-600 text-indigo-600 text-sm font-medium hover:bg-indigo-50">Exportar PDF</button>
-          </div>
-        </div>
-      </div>
-    </section>
-  </main>
+        </section>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.25/jspdf.plugin.autotable.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script type="module" src="firebase-config.js"></script>
-    <script type="module" src="saques.js"></script>
-  <script>window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';</script>
-  <script src="shared.js"></script>
-  </div>
-</body>
+        <!-- Resumo do mês -->
+        <section class="max-w-7xl mx-auto px-4">
+          <div
+            id="cardsResumo"
+            class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4"
+          ></div>
+          <p
+            id="faltasTexto"
+            class="mt-4 text-center text-sm text-slate-500"
+          ></p>
+        </section>
+
+        <!-- Tabela de Saques -->
+        <section class="max-w-7xl mx-auto px-4">
+          <div
+            class="rounded-2xl border border-slate-200 bg-white shadow-sm overflow-hidden"
+          >
+            <div
+              class="flex items-center justify-between p-4 border-b border-slate-100"
+            >
+              <h2 class="text-sm font-semibold text-slate-800">
+                Saques Registrados
+              </h2>
+              <div class="flex items-center gap-2">
+                <select
+                  id="filtroLoja"
+                  class="h-9 rounded-lg border-slate-300 text-sm px-3 focus:ring-2 focus:ring-indigo-500"
+                >
+                  <option value="__todas__">Todas as lojas</option>
+                </select>
+              </div>
+            </div>
+            <h3
+              id="tituloVendedor"
+              class="px-4 pt-4 text-sm font-medium text-slate-500"
+            ></h3>
+            <div class="max-h-[60vh] overflow-auto">
+              <table class="w-full text-sm">
+                <thead class="sticky top-0 bg-slate-50 text-slate-600">
+                  <tr>
+                    <th class="px-4 py-3 text-center">
+                      <input
+                        id="checkboxSelecionarTodos"
+                        type="checkbox"
+                        onchange="toggleSelecaoTodos(this.checked)"
+                        class="h-4 w-4 rounded border-slate-300"
+                      />
+                    </th>
+                    <th class="text-left font-medium px-4 py-3">Data</th>
+                    <th class="text-left font-medium px-4 py-3">Loja</th>
+                    <th class="text-right font-medium px-4 py-3">Saque</th>
+                    <th class="text-right font-medium px-4 py-3">% Comissão</th>
+                    <th class="text-right font-medium px-4 py-3">Comissão</th>
+                    <th class="text-left font-medium px-4 py-3">Status</th>
+                    <th class="text-right font-medium px-4 py-3">Ações</th>
+                  </tr>
+                </thead>
+                <tbody
+                  id="tbodySaques"
+                  class="divide-y divide-slate-100"
+                ></tbody>
+                <tfoot id="tfootResumo" class="bg-slate-50"></tfoot>
+              </table>
+            </div>
+            <div
+              id="acoesSelecionados"
+              style="display: none"
+              class="flex flex-col md:flex-row items-center gap-2 p-4 border-t border-slate-100"
+            >
+              <span id="resumoSelecionados" class="text-sm"></span>
+              <select
+                id="percentualSelecionado"
+                class="h-10 rounded-xl border-slate-300 text-sm focus:ring-2 focus:ring-indigo-500"
+              >
+                <option value="0.03">3%</option>
+                <option value="0.04">4%</option>
+                <option value="0.05">5%</option>
+              </select>
+              <div class="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+                <button
+                  onclick="marcarComoPagoSelecionados()"
+                  class="h-10 px-4 rounded-xl bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700"
+                >
+                  Marcar como Pago
+                </button>
+                <button
+                  onclick="exportarSelecionadosExcel()"
+                  class="h-10 px-4 rounded-xl border border-emerald-600 text-emerald-600 text-sm font-medium hover:bg-emerald-50"
+                >
+                  Exportar Excel
+                </button>
+                <button
+                  onclick="exportarSelecionadosPDF()"
+                  class="h-10 px-4 rounded-xl border border-indigo-600 text-indigo-600 text-sm font-medium hover:bg-indigo-50"
+                >
+                  Exportar PDF
+                </button>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.25/jspdf.plugin.autotable.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+      <script type="module" src="firebase-config.js"></script>
+      <script type="module" src="saques.js"></script>
+      <script>
+        window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';
+      </script>
+      <script src="shared.js"></script>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- add a store filter dropdown to the saques page and rebuild the rendering logic to honour the selection
- keep the select-all checkbox state in sync while users toggle selections
- enable Excel export for selected saques, including a summarized breakdown by store

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f8c4b5e4d4832a9d3c92b5c810108b