### PR TITLE
Corrige agrupamento do dia 1º nos saques

### DIFF
--- a/comissoes-service.js
+++ b/comissoes-service.js
@@ -24,7 +24,7 @@ export async function registrarSaque({
   if (![0, 0.03, 0.04, 0.05].includes(percentualPago))
     throw new Error('percentualPago inválido');
 
-  const anoMes = anoMesBR(new Date(dataISO));
+  const anoMes = anoMesBR(dataISO);
   const col = collection(db, 'usuarios', uid, 'comissoes', anoMes, 'saques');
   const comissaoPaga = valor * percentualPago;
   await addDoc(col, {
@@ -42,7 +42,7 @@ export async function registrarComissaoRecebida({ db, uid, dataISO, valor }) {
   if (!dataISO) throw new Error('dataISO obrigatório');
   if (typeof valor !== 'number') throw new Error('valor inválido');
 
-  const anoMes = anoMesBR(new Date(dataISO));
+  const anoMes = anoMesBR(dataISO);
   const col = collection(db, 'usuarios', uid, 'comissoes', anoMes, 'recebidas');
   await addDoc(col, {
     data: dataISO,

--- a/comissoes-utils.js
+++ b/comissoes-utils.js
@@ -18,10 +18,36 @@ export function faltasParaTiers(total) {
 }
 
 // Chave mensal no fuso Brasil
-export function anoMesBR(d = new Date()) {
-  const dt = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
-  const mm = String(dt.getMonth() + 1).padStart(2, '0');
-  return `${dt.getFullYear()}-${mm}`;
+export function anoMesBR(origem = new Date()) {
+  if (typeof origem === 'string') {
+    const [data] = origem.split('T');
+    if (data) {
+      const [ano, mes] = data.split('-');
+      if (ano && mes) {
+        return `${ano}-${mes}`;
+      }
+    }
+  }
+
+  const data =
+    origem instanceof Date || typeof origem === 'number'
+      ? new Date(origem)
+      : new Date();
+
+  const partes = new Intl.DateTimeFormat('pt-BR', {
+    timeZone: 'America/Sao_Paulo',
+    year: 'numeric',
+    month: '2-digit',
+  }).formatToParts(data);
+
+  const ano = partes.find((p) => p.type === 'year')?.value;
+  const mes = partes.find((p) => p.type === 'month')?.value;
+
+  if (!ano || !mes) {
+    return `${data.getFullYear()}-${String(data.getMonth() + 1).padStart(2, '0')}`;
+  }
+
+  return `${ano}-${mes}`;
 }
 
 // Utilitário para calcular resumo mensal a partir de uma lista de saques


### PR DESCRIPTION
## Summary
- ajusta a função `anoMesBR` para lidar corretamente com datas ISO e aplicar o fuso de São Paulo
- utiliza a data original ao calcular a chave mensal ao registrar saques e comissões

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f8ca07b488832a8c6f84d04e51d8e8