### PR TITLE
Corrige agrupamento de saques do dia 1

### DIFF
--- a/comissoes-service.js
+++ b/comissoes-service.js
@@ -8,7 +8,11 @@ import {
   getDoc,
   onSnapshot,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
-import { anoMesBR, calcularResumo } from './comissoes-utils.js';
+import {
+  anoMesBR,
+  anoMesPorDataISO,
+  calcularResumo,
+} from './comissoes-utils.js';
 
 export async function registrarSaque({
   db,
@@ -24,7 +28,7 @@ export async function registrarSaque({
   if (![0, 0.03, 0.04, 0.05].includes(percentualPago))
     throw new Error('percentualPago inválido');
 
-  const anoMes = anoMesBR(new Date(dataISO));
+  const anoMes = anoMesPorDataISO(dataISO);
   const col = collection(db, 'usuarios', uid, 'comissoes', anoMes, 'saques');
   const comissaoPaga = valor * percentualPago;
   await addDoc(col, {
@@ -42,7 +46,7 @@ export async function registrarComissaoRecebida({ db, uid, dataISO, valor }) {
   if (!dataISO) throw new Error('dataISO obrigatório');
   if (typeof valor !== 'number') throw new Error('valor inválido');
 
-  const anoMes = anoMesBR(new Date(dataISO));
+  const anoMes = anoMesPorDataISO(dataISO);
   const col = collection(db, 'usuarios', uid, 'comissoes', anoMes, 'recebidas');
   await addDoc(col, {
     data: dataISO,

--- a/comissoes-utils.js
+++ b/comissoes-utils.js
@@ -24,6 +24,25 @@ export function anoMesBR(d = new Date()) {
   return `${dt.getFullYear()}-${mm}`;
 }
 
+export function anoMesPorDataISO(dataISO) {
+  if (!dataISO) return anoMesBR();
+
+  const [dataParte] = String(dataISO).split('T');
+  if (dataParte) {
+    const [ano, mes] = dataParte.split('-');
+    if (ano && mes) {
+      return `${ano}-${mes}`;
+    }
+  }
+
+  const data = new Date(dataISO);
+  if (!Number.isNaN(data.getTime())) {
+    return anoMesBR(data);
+  }
+
+  return anoMesBR();
+}
+
 // Utilitário para calcular resumo mensal a partir de uma lista de saques
 export function calcularResumo(saques = []) {
   const totalSacado = saques.reduce((s, x) => s + (x.valor || 0), 0);

--- a/tests/comissoes.test.js
+++ b/tests/comissoes.test.js
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
-import { calcularResumo } from '../comissoes-utils.js';
+import { calcularResumo, anoMesPorDataISO } from '../comissoes-utils.js';
 
 function testeAbaixo150k() {
   const saques = [
     { valor: 50_000, percentualPago: 0.03 },
-    { valor: 40_000, percentualPago: 0.04 }
+    { valor: 40_000, percentualPago: 0.04 },
   ];
   const r = calcularResumo(saques);
   assert.equal(r.totalSacado, 90_000);
@@ -19,7 +19,7 @@ function testeAbaixo150k() {
 function testeCruza150k() {
   const saques = [
     { valor: 100_000, percentualPago: 0.03 },
-    { valor: 60_000, percentualPago: 0.03 }
+    { valor: 60_000, percentualPago: 0.03 },
   ];
   const r = calcularResumo(saques);
   assert.equal(r.totalSacado, 160_000);
@@ -34,7 +34,7 @@ function testeCruza150k() {
 function testeCruza250k() {
   const saques = [
     { valor: 200_000, percentualPago: 0.04 },
-    { valor: 60_000, percentualPago: 0.04 }
+    { valor: 60_000, percentualPago: 0.04 },
   ];
   const r = calcularResumo(saques);
   assert.equal(r.totalSacado, 260_000);
@@ -46,7 +46,14 @@ function testeCruza250k() {
   assert.equal(r.faltamPara5, 0);
 }
 
+function testeAnoMesPorDataISO() {
+  assert.equal(anoMesPorDataISO('2024-05-01'), '2024-05');
+  assert.equal(anoMesPorDataISO('2024-05-01T00:00:00-03:00'), '2024-05');
+  assert.equal(anoMesPorDataISO('2024-05-01T03:00:00.000Z'), '2024-05');
+}
+
 testeAbaixo150k();
 testeCruza150k();
 testeCruza250k();
+testeAnoMesPorDataISO();
 console.log('Tests passed');


### PR DESCRIPTION
## Summary
- garantimos que o cadastro de saques e comissões utilize a parte de data do ISO para definir o mês correto
- adicionamos testes que cobrem o cálculo do ano/mês para datas no primeiro dia do mês, inclusive com timezones diferentes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f8ca07b488832a8c6f84d04e51d8e8