### PR TITLE
Add multi-month filtering for withdrawals

### DIFF
--- a/saques.html
+++ b/saques.html
@@ -32,12 +32,25 @@
             <h1 class="text-lg md:text-xl font-semibold text-slate-900">
               Controle de Saques
             </h1>
-            <div class="flex items-center gap-3">
-              <input
-                type="month"
-                id="filtroMes"
-                class="h-10 rounded-xl border-slate-300 text-sm text-slate-700 focus:ring-2 focus:ring-indigo-500"
-              />
+            <div class="flex flex-wrap items-center gap-3">
+              <div class="flex items-center gap-2">
+                <span class="text-xs font-medium uppercase tracking-wide text-slate-500"
+                  >De</span>
+                <input
+                  type="month"
+                  id="filtroMesInicio"
+                  class="h-10 rounded-xl border-slate-300 text-sm text-slate-700 focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
+              <div class="flex items-center gap-2">
+                <span class="text-xs font-medium uppercase tracking-wide text-slate-500"
+                  >Até</span>
+                <input
+                  type="month"
+                  id="filtroMesFim"
+                  class="h-10 rounded-xl border-slate-300 text-sm text-slate-700 focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
               <button
                 onclick="imprimirFechamento()"
                 class="inline-flex items-center h-10 px-4 rounded-xl bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700"


### PR DESCRIPTION
## Summary
- replace the single month picker with a start/end month range on the withdrawals page
- load and render withdrawals for every month in the selected range while preserving store filtering and bulk actions
- guard monthly summary, closing, and export flows so they continue to work and show guidance when multiple months are selected

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f8cc8a6ed0832aaccb5ba4bce54860