### PR TITLE
Add default commission preference for withdrawals

### DIFF
--- a/saques.html
+++ b/saques.html
@@ -34,8 +34,10 @@
             </h1>
             <div class="flex flex-wrap items-center gap-3">
               <div class="flex items-center gap-2">
-                <span class="text-xs font-medium uppercase tracking-wide text-slate-500"
-                  >De</span>
+                <span
+                  class="text-xs font-medium uppercase tracking-wide text-slate-500"
+                  >De</span
+                >
                 <input
                   type="month"
                   id="filtroMesInicio"
@@ -43,8 +45,10 @@
                 />
               </div>
               <div class="flex items-center gap-2">
-                <span class="text-xs font-medium uppercase tracking-wide text-slate-500"
-                  >Até</span>
+                <span
+                  class="text-xs font-medium uppercase tracking-wide text-slate-500"
+                  >Até</span
+                >
                 <input
                   type="month"
                   id="filtroMesFim"
@@ -115,6 +119,44 @@
                   Registrar
                 </button>
               </form>
+              <div class="mt-4 border-t border-slate-100 pt-4">
+                <div
+                  class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between"
+                >
+                  <div>
+                    <h3 class="text-sm font-semibold text-slate-800">
+                      Comissão padrão
+                    </h3>
+                    <p class="text-xs text-slate-500">
+                      Valor aplicado automaticamente ao registrar novos saques.
+                    </p>
+                  </div>
+                  <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+                    <select
+                      id="percentualPadraoSaque"
+                      class="h-10 rounded-xl border-slate-300 text-sm focus:ring-2 focus:ring-indigo-500"
+                    >
+                      <option value="">Usar cálculo automático</option>
+                      <option value="0">0%</option>
+                      <option value="0.03">3%</option>
+                      <option value="0.04">4%</option>
+                      <option value="0.05">5%</option>
+                    </select>
+                    <button
+                      type="button"
+                      id="btnSalvarPercentualPadrao"
+                      onclick="salvarPercentualPadrao()"
+                      class="h-10 rounded-xl border border-indigo-200 bg-white px-4 text-sm font-medium text-indigo-600 transition hover:bg-indigo-50 disabled:cursor-not-allowed disabled:opacity-70"
+                    >
+                      Salvar padrão
+                    </button>
+                  </div>
+                </div>
+                <p
+                  id="percentualPadraoStatus"
+                  class="mt-2 text-xs text-slate-500"
+                ></p>
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- add a reusable list of valid commission percentages and persist the user's default in Firestore
- expose a new control in the withdrawals page to choose and save the default commission percentage
- automatically apply the saved default percentage when creating new withdrawal entries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fa0758affc832a9633071a79263f44