### PR TITLE
Add POSVENDAS profile with limited sidebar access

### DIFF
--- a/configuracao-perfil.html
+++ b/configuracao-perfil.html
@@ -60,6 +60,7 @@
             <option value="Gestor">Gestor</option>
             <option value="Editor">Editor</option>
             <option value="Cliente">Cliente</option>
+            <option value="POSVENDAS">POSVENDAS</option>
           </select>
         </section>
 

--- a/login.js
+++ b/login.js
@@ -118,6 +118,13 @@ const SELLER_ALLOWED_MENU_IDS = [
   'menu-configuracao-perfil',
   'menu-catalogo',
 ];
+const POSVENDAS_ALLOWED_MENU_IDS = [
+  'menu-painel-atualizacoes-gerais',
+  'menu-acompanhamento-diario',
+  'menu-expedicao',
+  'menu-acompanhamento-problemas',
+  'menu-catalogo',
+];
 
 const EXPEDICAO_ALLOWED_SUBMENU_LINKS = {
   menuExpedicao: null,
@@ -335,6 +342,19 @@ async function showUserArea(user) {
       }
     }
 
+    if (perfil === 'posvendas') {
+      const path = window.location.pathname.toLowerCase();
+      if (
+        path.endsWith('/index.html') ||
+        path.endsWith('/login.html') ||
+        path.endsWith('/')
+      ) {
+        window.location.href =
+          'CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=diariamente';
+        return;
+      }
+    }
+
     // 1) aplica restrições de UI
     applyPerfilRestrictions(perfil);
 
@@ -529,6 +549,8 @@ function normalizePerfil(perfil) {
   if (['seller', 'vendedor'].includes(base)) return 'seller';
   if (['expedicao', 'gestor expedicao', 'gestor de expedicao'].includes(base))
     return 'expedicao';
+  if (['posvendas', 'pos-vendas', 'pos vendas'].includes(base))
+    return 'posvendas';
   return base;
 }
 function applyPerfilRestrictions(perfil) {
@@ -592,6 +614,7 @@ function applyPerfilRestrictions(perfil) {
       'menu-desempenho',
     ],
     seller: SELLER_ALLOWED_MENU_IDS,
+    posvendas: POSVENDAS_ALLOWED_MENU_IDS,
     expedicao: EXPEDICAO_ALLOWED_MENU_IDS,
   };
 

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -139,7 +139,7 @@
         <span class="link-text">Configuração de Perfil</span>
       </a>
     </li>
-    <li data-perfil="seller">
+    <li data-perfil="seller,posvendas">
       <a
         href="/catalogo.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
@@ -255,6 +255,29 @@
           />
         </svg>
         <span class="link-text">Painel Atualizações</span>
+      </a>
+    </li>
+    <li data-perfil="posvendas">
+      <a
+        href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=diariamente"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-acompanhamento-diario"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M8.25 7.5l3 3 3-3m-6 9 3-3 3 3M3 5.25C3 4.007 4.007 3 5.25 3h13.5C19.993 3 21 4.007 21 5.25v13.5A2.25 2.25 0 0 1 18.75 21H5.25A2.25 2.25 0 0 1 3 18.75V5.25Z"
+          />
+        </svg>
+        <span class="link-text">Acompanhamento Diário</span>
       </a>
     </li>
     <li>
@@ -407,7 +430,7 @@
         href="/acompanhamento-problemas.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-acompanhamento-problemas"
-        data-perfil="gestor,responsavel financeiro"
+        data-perfil="gestor,responsavel financeiro,posvendas"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -1083,7 +1106,7 @@
           href="/expedicao.html"
           class="sidebar-link flex items-center py-2 px-4 transition-colors"
           id="menu-expedicao"
-          data-perfil="usuario,gestor,expedicao"
+          data-perfil="usuario,gestor,expedicao,posvendas"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary
- add the POSVENDAS profile type and redirect its default landing page to the Acompanhamento Diário view
- constrain sidebar visibility for POSVENDAS and expose the required menu entries only
- allow administrators to assign the POSVENDAS role from the profile configuration page

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fb5a263cd4832aae926eaec40eca15