### PR TITLE
Add team workspace with shared tasks and alerts

### DIFF
--- a/equipes.html
+++ b/equipes.html
@@ -1,1774 +1,1185 @@
 <!DOCTYPE html>
 <html lang="pt-BR">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TeamFlow - Gestão de Equipes</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="css/styles.css?v=20240826">
-    <style>
-        /* Estilos globais e variáveis */
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Equipe - VendedorPro</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-Tz4frX1Pj1kN6H0F5LZFzE8zRAwOB1p5MNDoAuCEi0aKBslZx2drXr/7EQo1gChX2NDVYqoQZnIcqoNCXlbmYw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/styles.css?v=20240826">
+  <style>
+    :root {
+      --brand: #4262ff;
+      --brand-dark: #2f4dde;
+      --brand-soft: rgba(66, 98, 255, 0.1);
+      --text: #1f2937;
+      --text-soft: #6b7280;
+      --border: #e5e7eb;
+      --danger: #ef4444;
+      --success: #059669;
+      --background: #f4f6fb;
+    }
 
-        :root {
-            --primary: #4262ff;
-            --primary-dark: #3351e8;
-            --secondary: #00c875;
-            --error: #dc3545;
-            --error-dark: #c82333;
-            --text: #333;
-            --text-light: #666;
-            --border: #e0e0e0;
-            --card-shadow: 0 2px 8px rgba(0,0,0,0.08);
-            --modal-bg: rgba(0, 0, 0, 0.5);
-            --table-header-bg: #e9ecef;
-        }
+    body {
+      font-family: 'Inter', sans-serif;
+      background: var(--background);
+      color: var(--text);
+      min-height: 100vh;
+    }
 
-        body {
-            background-color: #f5f7fb;
-            color: var(--text);
-            min-height: 100vh;
-        }
+    .team-wrapper {
+      padding: 24px;
+    }
 
-        /* Navegação interna */
-        .team-nav {
-            display: flex;
-            gap: 12px;
-            margin-bottom: 24px;
-        }
+    .team-header h1 {
+      font-size: 28px;
+      font-weight: 700;
+    }
 
-        .nav-link {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            padding: 8px 12px;
-            border-radius: 6px;
-            color: var(--text);
-            text-decoration: none;
-            font-weight: 500;
-            transition: all 0.2s;
-        }
+    .team-header p {
+      margin-top: 6px;
+      color: var(--text-soft);
+      max-width: 680px;
+    }
 
-        .nav-link:hover, .nav-link.active {
-            background-color: rgba(66, 98, 255, 0.1);
-            color: var(--primary);
-        }
+    .team-tabs {
+      margin: 24px 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
 
-        .nav-link i {
-            width: 20px;
-            text-align: center;
-        }
+    .team-tab-button {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 18px;
+      border-radius: 999px;
+      border: 1px solid transparent;
+      background: white;
+      color: var(--text);
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      box-shadow: 0 4px 10px rgba(15, 23, 42, 0.05);
+    }
 
-        /* Main Content e Vistas */
-        .main-content {
-            flex: 1;
-            margin-left: 260px;
-            padding: 24px;
-        }
-        
-        .view {
-            display: none;
-        }
-        .view.active {
-            display: block;
-        }
-        
-        .loading {
-            text-align: center;
-            padding: 48px;
-            font-size: 18px;
-            color: var(--text-light);
-        }
-        
-        #userIdDisplay {
-            margin-top: 16px;
-            font-size: 12px;
-            color: var(--text-light);
-            word-wrap: break-word;
-        }
+    .team-tab-button i {
+      color: var(--brand);
+    }
 
-        .header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 32px;
-        }
+    .team-tab-button:hover {
+      border-color: var(--brand);
+      color: var(--brand);
+    }
 
-        .page-title {
-            font-size: 28px;
-            font-weight: 700;
-        }
+    .team-tab-button.active {
+      background: var(--brand);
+      color: #fff;
+      box-shadow: 0 10px 24px rgba(66, 98, 255, 0.25);
+    }
 
-        .actions {
-            display: flex;
-            gap: 16px;
-        }
+    .team-tab-button.active i {
+      color: #fff;
+    }
 
-        .btn {
-            padding: 10px 20px;
-            border-radius: 6px;
-            font-weight: 500;
-            cursor: pointer;
-            transition: all 0.2s;
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            border: none;
-        }
+    .team-section {
+      display: none;
+    }
 
-        .btn-primary {
-            background: var(--primary);
-            color: white;
-        }
+    .team-section.active {
+      display: block;
+    }
 
-        .btn-primary:hover {
-            background: var(--primary-dark);
-        }
+    .card {
+      background: #fff;
+      border-radius: 16px;
+      padding: 24px;
+      box-shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
+    }
 
-        .btn-outline {
-            background: transparent;
-            border: 1px solid var(--border);
-            color: var(--text);
-        }
+    .section-header {
+      margin-bottom: 18px;
+    }
 
-        .btn-outline:hover {
-            background: var(--secondary);
-        }
-        
-        .btn-green {
-            background: var(--secondary);
-            color: white;
-        }
-        .btn-green:hover {
-            background: #00a861;
-        }
+    .section-header h2 {
+      font-size: 22px;
+      font-weight: 600;
+    }
 
-        .btn-danger {
-            background: var(--error);
-            color: white;
-        }
-        .btn-danger:hover {
-            background: var(--error-dark);
-        }
+    .section-header p {
+      margin-top: 6px;
+      color: var(--text-soft);
+    }
 
-        /* Boards Grid */
-        .boards-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-            gap: 24px;
-            margin-bottom: 48px;
-        }
+    .form-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 18px;
+      margin-top: 16px;
+    }
 
-        .board-card {
-            background: white;
-            border-radius: 12px;
-            overflow: hidden;
-            box-shadow: var(--card-shadow);
-            transition: transform 0.2s, box-shadow 0.2s;
-            position: relative;
-        }
+    .form-group {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
 
-        .board-card-clickable {
-            cursor: pointer;
-        }
+    .form-group label {
+      font-weight: 600;
+      font-size: 14px;
+    }
 
-        .board-card-clickable:hover {
-            transform: translateY(-4px);
-            box-shadow: 0 8px 16px rgba(0,0,0,0.1);
-        }
+    .form-group input,
+    .form-group select,
+    .form-group textarea {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 10px 12px;
+      font-size: 15px;
+      transition: border-color 0.2s ease;
+      background: #fff;
+      min-height: 42px;
+    }
 
-        .board-header {
-            height: 40px;
-            background: var(--primary);
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            padding: 0 16px;
-            color: white;
-            font-weight: 500;
-        }
-        
-        .board-header .board-actions {
-            display: flex;
-            gap: 8px;
-        }
+    .form-group textarea {
+      min-height: 120px;
+      resize: vertical;
+    }
 
-        .board-header .board-actions button {
-            background: none;
-            border: none;
-            color: white;
-            opacity: 0.7;
-            cursor: pointer;
-            transition: opacity 0.2s;
-        }
-        .board-header .board-actions button:hover {
-            opacity: 1;
-        }
+    .form-group input:focus,
+    .form-group select:focus,
+    .form-group textarea:focus {
+      outline: none;
+      border-color: var(--brand);
+      box-shadow: 0 0 0 3px rgba(66, 98, 255, 0.15);
+    }
 
-        .board-content {
-            padding: 16px;
-            cursor: pointer;
-        }
+    .primary-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      padding: 11px 20px;
+      border-radius: 10px;
+      border: none;
+      background: var(--brand);
+      color: #fff;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s ease;
+    }
 
-        .board-title {
-            font-weight: 600;
-            margin-bottom: 8px;
-            font-size: 18px;
-        }
+    .primary-button:hover {
+      background: var(--brand-dark);
+    }
 
-        .board-stats {
-            display: flex;
-            gap: 16px;
-            font-size: 14px;
-            color: var(--text-light);
-        }
+    .primary-button:disabled {
+      opacity: 0.65;
+      cursor: progress;
+    }
 
-        .board-stats div {
-            display: flex;
-            align-items: center;
-            gap: 4px;
-        }
+    .danger-button {
+      background: var(--danger);
+      color: #fff;
+      border: none;
+      padding: 8px 14px;
+      border-radius: 8px;
+      cursor: pointer;
+      transition: background 0.2s ease;
+    }
 
-        .board-members {
-            position: absolute;
-            bottom: 16px;
-            right: 16px;
-            display: flex;
-        }
+    .danger-button:hover {
+      background: #dc2626;
+    }
 
-        .member-avatar {
-            width: 28px;
-            height: 28px;
-            border-radius: 50%;
-            background: var(--primary);
-            color: white;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 12px;
-            font-weight: 600;
-            margin-left: -8px;
-            border: 2px solid white;
-        }
-        
-        .member-avatar-lg {
-            width: 64px;
-            height: 64px;
-            border-radius: 50%;
-            background: var(--primary);
-            color: white;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 24px;
-            font-weight: 600;
-            margin: 0 auto 16px;
-        }
+    .danger-button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
 
-        .member-avatar:first-child {
-            margin-left: 0;
-        }
+    .feedback {
+      margin-top: 12px;
+      font-size: 14px;
+      min-height: 20px;
+    }
 
-        /* Team Section */
-        .section-title {
-            font-size: 20px;
-            font-weight: 600;
-            margin: 32px 0 24px;
-            padding-bottom: 12px;
-            border-bottom: 1px solid var(--border);
-        }
-        .section-title-with-btn {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            padding-bottom: 12px;
-            border-bottom: 1px solid var(--border);
-        }
-        
-        .members-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-            gap: 16px;
-        }
+    .feedback-success {
+      color: var(--success);
+    }
 
-        .member-card {
-            background: white;
-            border-radius: 8px;
-            padding: 20px;
-            box-shadow: var(--card-shadow);
-            text-align: center;
-            position: relative;
-        }
-        .member-card-actions {
-            position: absolute;
-            top: 8px;
-            right: 8px;
-        }
-        .member-card-actions button {
-            background: none;
-            border: none;
-            color: var(--text-light);
-            cursor: pointer;
-            transition: color 0.2s;
-        }
-        .member-card-actions button:hover {
-            color: var(--error);
-        }
+    .feedback-error {
+      color: var(--danger);
+    }
 
-        .member-name {
-            font-weight: 600;
-            margin-bottom: 4px;
-        }
+    .members-grid,
+    .tasks-list,
+    .updates-list {
+      margin-top: 20px;
+      display: grid;
+      gap: 16px;
+    }
 
-        .member-role {
-            color: var(--text-light);
-            font-size: 14px;
-            margin-bottom: 12px;
-        }
+    .members-grid {
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    }
 
-        .member-stats {
-            display: flex;
-            justify-content: center;
-            gap: 16px;
-            font-size: 14px;
-        }
+    .team-card {
+      background: #fff;
+      border-radius: 14px;
+      padding: 18px;
+      box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
 
-        .stat-value {
-            font-weight: 600;
-        }
+    .team-card-header {
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      align-items: flex-start;
+    }
 
-        /* Board View - Tabela */
-        .board-table-container {
-            overflow-x: auto;
-        }
+    .team-card-header h3 {
+      font-size: 18px;
+      font-weight: 600;
+      word-break: break-word;
+    }
 
-        .board-table {
-            width: 100%;
-            border-collapse: collapse;
-            background: white;
-            border-radius: 8px;
-            overflow: hidden;
-            box-shadow: var(--card-shadow);
-        }
-        
-        .board-table thead {
-            background-color: var(--table-header-bg);
-        }
-        
-        .board-table th, .board-table td {
-            padding: 12px 16px;
-            text-align: left;
-            border-bottom: 1px solid var(--border);
-            font-size: 14px;
-        }
-        
-        .board-table th:first-child { min-width: 250px; }
-        .board-table th:nth-child(2) { min-width: 150px; }
-        .board-table th:nth-child(3) { min-width: 120px; }
-        .board-table th:nth-child(4) { min-width: 120px; }
-        .board-table th:nth-child(5) { min-width: 80px; }
-        .board-table th:nth-child(6) { min-width: 100px; }
-        .board-table th:nth-child(7) { min-width: 120px; }
-        .board-table th:nth-child(8) { min-width: 80px; }
-        
-        .board-table tbody tr:last-child td {
-            border-bottom: none;
-        }
+    .team-card-header span {
+      font-size: 14px;
+      color: var(--text-soft);
+    }
 
-        .board-table tbody tr:hover {
-            background-color: var(--secondary);
-        }
-        
-        .editable-cell {
-            padding: 0;
-        }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 4px 10px;
+      border-radius: 999px;
+      font-size: 12px;
+      font-weight: 600;
+      background: var(--brand-soft);
+      color: var(--brand);
+    }
 
-        .editable-input, .editable-select {
-            width: 100%;
-            padding: 10px;
-            border: none;
-            background: transparent;
-            font-size: 14px;
-            outline: none;
-        }
+    .badge-danger {
+      background: rgba(239, 68, 68, 0.12);
+      color: var(--danger);
+    }
 
-        .editable-input {
-            border: 1px solid transparent;
-            border-radius: 4px;
-            transition: border-color 0.2s;
-        }
-        
-        .editable-input:focus {
-            border-color: var(--primary);
-            background-color: white;
-        }
-        
-        .status-select {
-            color: white;
-            font-weight: 600;
-            border-radius: 4px;
-            padding: 6px 8px;
-        }
-        .status-select.to-do { background-color: #8c9096; }
-        .status-select.in-progress { background-color: #4262ff; }
-        .status-select.done { background-color: #00c875; }
-        
-        .assignee-cell .assignee-details {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-        }
-        
-        .assignee-cell .assignee-avatar {
-            width: 28px;
-            height: 28px;
-            border-radius: 50%;
-            background: var(--primary);
-            color: white;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 12px;
-            font-weight: 600;
-        }
-        
-        .assignee-cell .assignee-name {
-            font-weight: 500;
-        }
-        
-        .task-actions {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            gap: 8px;
-        }
+    .badge-warning {
+      background: rgba(245, 158, 11, 0.12);
+      color: #d97706;
+    }
 
-        .task-actions button {
-            background: none;
-            border: none;
-            cursor: pointer;
-            color: var(--text-light);
-            transition: color 0.2s;
-        }
-        .task-actions button:hover {
-            color: var(--error);
-        }
-        
-        .file-cell {
-            text-align: center;
-        }
+    .badge-success {
+      background: rgba(16, 185, 129, 0.12);
+      color: #047857;
+    }
 
-        .file-cell a {
-            color: var(--error);
-        }
+    .card-meta {
+      font-size: 13px;
+      color: var(--text-soft);
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
 
-        .file-icon {
-            color: var(--error);
-            font-size: 20px;
-        }
+    .card-meta strong {
+      color: var(--text);
+    }
 
-        .back-button {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            margin-bottom: 24px;
-            color: var(--primary);
-            cursor: pointer;
-            font-weight: 500;
-        }
-        
-        /* Modal customizado */
-        .modal-overlay {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background-color: var(--modal-bg);
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            z-index: 1000;
-            visibility: hidden;
-            opacity: 0;
-            transition: visibility 0s, opacity 0.3s;
-        }
+    .empty-state {
+      text-align: center;
+      padding: 32px;
+      border-radius: 16px;
+      background: white;
+      color: var(--text-soft);
+      box-shadow: 0 18px 45px rgba(15, 23, 42, 0.1);
+    }
 
-        .modal-overlay.visible {
-            visibility: visible;
-            opacity: 1;
-        }
+    .team-loading {
+      margin-bottom: 18px;
+    }
 
-        .modal-content {
-            background: white;
-            padding: 24px;
-            border-radius: 12px;
-            width: 90%;
-            max-width: 400px;
-            box-shadow: var(--card-shadow);
-            position: relative;
-            transform: scale(0.95);
-            transition: transform 0.3s ease-out;
-        }
+    .hidden {
+      display: none !important;
+    }
 
-        .modal-overlay.visible .modal-content {
-            transform: scale(1);
-        }
+    .support-link {
+      color: var(--brand);
+      font-weight: 500;
+      text-decoration: underline;
+      word-break: break-word;
+    }
 
-        .modal-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 16px;
-        }
+    .card-footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
 
-        .modal-title {
-            font-size: 20px;
-            font-weight: 600;
-        }
+    @media (max-width: 768px) {
+      .team-wrapper {
+        padding: 16px;
+      }
 
-        .modal-close {
-            background: none;
-            border: none;
-            font-size: 24px;
-            color: var(--text-light);
-            cursor: pointer;
-        }
+      .card {
+        padding: 18px;
+      }
 
-        .modal-body {
-            line-height: 1.5;
-            color: var(--text);
-        }
-        
-        .form-group {
-            margin-bottom: 16px;
-        }
-        
-        .form-group label {
-            display: block;
-            margin-bottom: 8px;
-            font-weight: 500;
-        }
-        
-        .form-group input, .form-group textarea, .form-group select {
-            width: 100%;
-            padding: 10px;
-            border-radius: 6px;
-            border: 1px solid var(--border);
-            font-size: 16px;
-            background: white;
-        }
-        
-        .form-group textarea {
-            resize: vertical;
-        }
-        
-        .modal-footer {
-            display: flex;
-            justify-content: flex-end;
-            gap: 12px;
-        }
-        
-        .loader {
-            border: 4px solid #f3f3f3;
-            border-radius: 50%;
-            border-top: 4px solid var(--primary);
-            width: 20px;
-            height: 20px;
-            -webkit-animation: spin 2s linear infinite;
-            animation: spin 2s linear infinite;
-            display: none;
-            margin-left: 10px;
-        }
-        .btn-primary .loader, .btn-green .loader, .btn-danger .loader {
-            border-top: 4px solid white;
-        }
-        
-        .btn-primary.loading .loader, .btn-green.loading .loader, .btn-danger.loading .loader {
-            display: inline-block;
-        }
-        .btn-primary.loading span, .btn-green.loading span, .btn-danger.loading span {
-            display: none;
-        }
+      .team-card {
+        padding: 16px;
+      }
 
-        @-webkit-keyframes spin {
-            0% { -webkit-transform: rotate(0deg); }
-            100% { -webkit-transform: rotate(360deg); }
-        }
-        @keyframes spin {
-            0% { transform: rotate(0deg); }
-            100% { transform: rotate(360deg); }
-        }
-
-        /* Responsividade */
-        @media (max-width: 900px) {
-            .team-nav {
-                flex-direction: column;
-            }
-            .main-content {
-                margin-left: 0;
-            }
-            .board-table th, .board-table td {
-                padding: 8px 12px;
-            }
-        }
-
-        @media (max-width: 600px) {
-            .boards-grid {
-                grid-template-columns: 1fr;
-            }
-            .header {
-                flex-direction: column;
-                align-items: flex-start;
-                gap: 16px;
-            }
-            .actions {
-                width: 100%;
-                justify-content: space-between;
-            }
-        }
-    </style>
+      .team-tab-button {
+        width: 100%;
+        justify-content: center;
+      }
+    }
+  </style>
 </head>
 <body>
   <div class="app-container">
     <div id="sidebar-container"></div>
     <div id="navbar-container"></div>
 
-    <!-- Main Content -->
-    <div class="main-content">
-        <div class="team-nav">
-            <a href="#" class="nav-link" data-view-id="dashboardView">
-                <i class="fas fa-home"></i>
-                <span>Dashboard</span>
-            </a>
-            <a href="#" class="nav-link active" data-view-id="myBoardsView">
-                <i class="fas fa-tasks"></i>
-                <span>Meus Quadros</span>
-            </a>
-            <a href="#" class="nav-link" data-view-id="teamView">
-                <i class="fas fa-users"></i>
-                <span>Equipes</span>
-            </a>
-        </div>
-        <div id="userIdDisplay"></div>
+    <main class="main-content team-wrapper">
+      <div id="teamLoading" class="card team-loading">
+        <p><i class="fas fa-circle-notch fa-spin"></i> Carregando informações da equipe...</p>
+      </div>
 
-        <!-- Dashboard View (agora como uma visão geral) -->
-        <div id="dashboardView" class="view">
-            <div class="header">
-                <h2 class="page-title">Dashboard</h2>
-            </div>
-            <p>Bem-vindo ao TeamFlow! Use o menu lateral para navegar entre os seus quadros e a sua equipe.</p>
-        </div>
-        
-        <!-- Meus Quadros View -->
-        <div id="myBoardsView" class="view active">
-            <div class="header">
-                <h2 class="page-title">Meus Quadros</h2>
-                <div class="actions">
-                    <button class="btn btn-outline">
-                        <i class="fas fa-filter"></i>
-                        Filtros
-                    </button>
-                    <button class="btn btn-primary" id="newBoardBtn">
-                        <i class="fas fa-plus"></i>
-                        Novo Quadro
-                    </button>
-                </div>
-            </div>
-            <div id="boardsGrid" class="boards-grid">
-                <div class="loading">Carregando quadros...</div>
-            </div>
-        </div>
+      <header class="team-header">
+        <h1>Gestão da Equipe</h1>
+        <p>Cadastre os integrantes, organize tarefas compartilhadas e mantenha todos atualizados em um único lugar acessível a qualquer perfil.</p>
+      </header>
 
-        <!-- Equipes View -->
-        <div id="teamView" class="view">
-            <div class="header">
-                <h2 class="page-title">Minha Equipe</h2>
-                <div class="actions">
-                    <button class="btn btn-green" id="addMemberBtn">
-                        <i class="fas fa-user-plus"></i>
-                        Adicionar Membro
-                    </button>
-                </div>
+      <nav class="team-tabs" aria-label="Navegação das seções da equipe">
+        <button class="team-tab-button active" data-view="membersView" type="button">
+          <i class="fas fa-envelope"></i>
+          Cadastro de E-mails
+        </button>
+        <button class="team-tab-button" data-view="tasksView" type="button">
+          <i class="fas fa-list-check"></i>
+          Tarefas da Equipe
+        </button>
+        <button class="team-tab-button" data-view="updatesView" type="button">
+          <i class="fas fa-bullhorn"></i>
+          Atualizações e Alertas
+        </button>
+      </nav>
+
+      <section id="membersView" class="team-section active" aria-labelledby="membersTab">
+        <div class="card">
+          <div class="section-header">
+            <h2>Cadastro da equipe</h2>
+            <p>Registre os e-mails e cargos dos integrantes. Os membros cadastrados terão acesso automático às tarefas e alertas desta equipe.</p>
+          </div>
+          <form id="teamMemberForm" autocomplete="off">
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="memberEmail">E-mail do integrante *</label>
+                <input type="email" id="memberEmail" name="memberEmail" placeholder="nome@empresa.com" required>
+              </div>
+              <div class="form-group">
+                <label for="memberRole">Cargo *</label>
+                <input type="text" id="memberRole" name="memberRole" placeholder="Ex: Analista de Expedição" required>
+              </div>
+              <div class="form-group">
+                <label for="memberName">Nome (opcional)</label>
+                <input type="text" id="memberName" name="memberName" placeholder="Nome completo">
+              </div>
             </div>
-            <div id="membersGrid" class="members-grid">
-                <div class="loading">Carregando membros da equipe...</div>
-            </div>
+            <div class="feedback" id="membersFeedback" aria-live="polite"></div>
+            <button class="primary-button" id="memberSubmitBtn" type="submit">
+              <i class="fas fa-user-plus"></i>
+              Adicionar integrante
+            </button>
+          </form>
         </div>
 
-        <!-- Board View (para um quadro específico) -->
-        <div id="boardView" class="view">
-            <div class="back-button" data-view-id="myBoardsView">
-                <i class="fas fa-arrow-left"></i>
-                Voltar para Meus Quadros
-            </div>
-            
-            <div class="header">
-                <h2 class="page-title" id="currentBoardTitle"></h2>
-                <div class="actions">
-                    <button class="btn btn-outline" id="filterTasksBtn">
-                        <i class="fas fa-filter"></i>
-                        Filtros
-                    </button>
-                    <button class="btn btn-outline">
-                        <i class="fas fa-search"></i>
-                        Buscar
-                    </button>
-                    <button class="btn btn-primary" id="newTaskBtn">
-                        <i class="fas fa-plus"></i>
-                        Nova Tarefa
-                    </button>
-                </div>
-            </div>
-
-            <div id="boardTableContainer" class="board-table-container">
-                <!-- A tabela de tarefas será renderizada aqui -->
-            </div>
+        <div id="teamMembersList" class="members-grid" aria-live="polite">
+          <div class="empty-state">Nenhum integrante cadastrado até o momento.</div>
         </div>
-    </div>
+      </section>
 
-    <!-- Modals (sem alterações) -->
-    <!-- Modal para criar um novo quadro -->
-    <div id="newBoardModal" class="modal-overlay">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title" id="newBoardModalTitle">Criar Novo Quadro</h3>
-                <button class="modal-close" id="closeNewBoardModalBtn">&times;</button>
+      <section id="tasksView" class="team-section" aria-labelledby="tasksTab">
+        <div class="card">
+          <div class="section-header">
+            <h2>Registrar tarefa da equipe</h2>
+            <p>Informe os detalhes da tarefa, defina prioridade e associe um responsável. Todas as pessoas cadastradas verão automaticamente essas tarefas.</p>
+          </div>
+          <form id="teamTaskForm" autocomplete="off">
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="taskTitle">Tarefa *</label>
+                <input type="text" id="taskTitle" name="taskTitle" placeholder="Ex: Conferir estoque do dia" required>
+              </div>
+              <div class="form-group">
+                <label for="taskDate">Data</label>
+                <input type="date" id="taskDate" name="taskDate">
+              </div>
+              <div class="form-group">
+                <label for="taskTime">Horário</label>
+                <input type="time" id="taskTime" name="taskTime">
+              </div>
+              <div class="form-group">
+                <label for="taskPriority">Prioridade</label>
+                <select id="taskPriority" name="taskPriority">
+                  <option value="">Selecione</option>
+                  <option value="Alta">Alta</option>
+                  <option value="Média">Média</option>
+                  <option value="Baixa">Baixa</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label for="taskResponsible">Responsável</label>
+                <select id="taskResponsible" name="taskResponsible">
+                  <option value="">Selecione um responsável</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label for="taskSupport">Material de apoio</label>
+                <input type="text" id="taskSupport" name="taskSupport" placeholder="Link ou observação rápida">
+              </div>
             </div>
-            <div class="modal-body">
-                <form id="boardForm">
-                    <input type="hidden" id="boardIdInput">
-                    <div class="form-group">
-                        <label for="boardTitle">Título do Quadro</label>
-                        <input type="text" id="boardTitle" name="title" required placeholder="Ex: Planejamento de Lançamento">
-                    </div>
-                    <div class="form-group">
-                        <label for="boardColor">Cor do Quadro</label>
-                        <input type="color" id="boardColor" name="color" value="#4262ff">
-                    </div>
-                    <div class="form-group">
-                        <label for="boardResponsible">Responsável</label>
-                        <select id="boardResponsible" name="responsible"></select>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-outline" id="cancelBoardModalBtn">Cancelar</button>
-                        <button type="submit" class="btn btn-primary" id="saveBoardBtn">
-                            <span><i class="fas fa-plus"></i> Criar Quadro</span>
-                            <div class="loader"></div>
-                        </button>
-                    </div>
-                </form>
+            <div class="form-group">
+              <label for="taskTips">Dicas e observações</label>
+              <textarea id="taskTips" name="taskTips" placeholder="Inclua instruções adicionais para ajudar na execução da tarefa"></textarea>
             </div>
+            <div class="feedback" id="tasksFeedback" aria-live="polite"></div>
+            <button class="primary-button" id="taskSubmitBtn" type="submit">
+              <i class="fas fa-plus"></i>
+              Registrar tarefa
+            </button>
+          </form>
         </div>
-    </div>
-    
-    <!-- Modal para criar uma nova tarefa -->
-    <div id="newTaskModal" class="modal-overlay">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title">Criar Nova Tarefa</h3>
-                <button class="modal-close" id="closeNewTaskModalBtn">&times;</button>
-            </div>
-            <div class="modal-body">
-                <form id="newTaskForm">
-                    <div class="form-group">
-                        <label for="taskTitle">Título da Tarefa</label>
-                        <input type="text" id="taskTitle" name="title" required placeholder="Ex: Desenvolver a tela de login">
-                    </div>
-                    <div class="form-group">
-                        <label for="taskDescription">Descrição</label>
-                        <textarea id="taskDescription" name="description" rows="4" placeholder="Detalhes sobre a tarefa..."></textarea>
-                    </div>
-                    <div class="form-group">
-                        <label for="taskAssignee">Atribuir a</label>
-                        <select id="taskAssignee" class="assignee-select" required>
-                             <!-- Opções serão preenchidas dinamicamente -->
-                        </select>
-                    </div>
-                    <!-- NOVO: Campo de Data no formulário -->
-                    <div class="form-group">
-                        <label for="taskDate">Data Limite</label>
-                        <input type="date" id="taskDate" name="date">
-                    </div>
-                    <!-- NOVO: Campo de Quantidade no formulário -->
-                    <div class="form-group">
-                        <label for="taskQuantity">Quantidade</label>
-                        <input type="number" id="taskQuantity" name="quantity" value="1" min="1" placeholder="Ex: 5">
-                    </div>
-                    <!-- NOVO: Campo de Arquivo PDF -->
-                    <div class="form-group">
-                        <label for="taskFile">Arquivo (PDF)</label>
-                        <input type="file" id="taskFile" accept="application/pdf">
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-outline" id="cancelNewTaskModalBtn">Cancelar</button>
-                        <button type="submit" class="btn btn-primary" id="saveTaskBtn">
-                            <span><i class="fas fa-plus"></i> Criar Tarefa</span>
-                            <div class="loader"></div>
-                        </button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
 
-    <!-- Modal de filtros -->
-    <div id="filterModal" class="modal-overlay">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title">Filtrar Tarefas</h3>
-                <button class="modal-close" id="closeFilterModalBtn">&times;</button>
-            </div>
-            <div class="modal-body">
-                <form id="filterForm">
-                    <div class="form-group">
-                        <label for="statusFilter">Status</label>
-                        <select id="statusFilter">
-                            <option value="">Todos</option>
-                            <option value="A Fazer">A Fazer</option>
-                            <option value="Em Progresso">Em Progresso</option>
-                            <option value="Concluído">Concluído</option>
-                        </select>
-                    </div>
-                    <div class="form-group">
-                        <label for="assigneeFilter">Responsável</label>
-                        <select id="assigneeFilter">
-                            <option value="">Todos</option>
-                        </select>
-                    </div>
-                    <div class="form-group">
-                        <label>Intervalo de datas</label>
-                        <div style="display:flex;gap:8px;">
-                            <input type="date" id="startDateFilter">
-                            <input type="date" id="endDateFilter">
-                        </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-outline" id="cancelFilterBtn">Cancelar</button>
-                        <button type="submit" class="btn btn-primary" id="applyFilterBtn">Aplicar</button>
-                    </div>
-                </form>
-            </div>
+        <div id="teamTasksList" class="tasks-list" aria-live="polite">
+          <div class="empty-state">Nenhuma tarefa registrada ainda.</div>
         </div>
-    </div>
+      </section>
 
-    <!-- Modal para adicionar um novo membro -->
-    <div id="newMemberModal" class="modal-overlay">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title">Adicionar Membro</h3>
-                <button class="modal-close" id="closeNewMemberModalBtn">&times;</button>
+      <section id="updatesView" class="team-section" aria-labelledby="updatesTab">
+        <div class="card">
+          <div class="section-header">
+            <h2>Atualizações e alertas</h2>
+            <p>Compartilhe comunicados importantes, alertas e novidades para que toda a equipe fique alinhada.</p>
+          </div>
+          <form id="teamUpdateForm" autocomplete="off">
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="updateTitle">Título</label>
+                <input type="text" id="updateTitle" name="updateTitle" placeholder="Ex: Novo procedimento de embalagem">
+              </div>
             </div>
-            <div class="modal-body">
-                <form id="newMemberForm">
-                    <div class="form-group">
-                        <label for="memberName">Nome Completo</label>
-                        <input type="text" id="memberName" name="name" required placeholder="Ex: Ana Mendes">
-                    </div>
-                    <div class="form-group">
-                        <label for="memberRole">Cargo</label>
-                        <input type="text" id="memberRole" name="role" required placeholder="Ex: Desenvolvedor Front-end">
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-outline" id="cancelNewMemberModalBtn">Cancelar</button>
-                        <button type="submit" class="btn btn-green" id="saveMemberBtn">
-                            <span><i class="fas fa-user-plus"></i> Adicionar</span>
-                            <div class="loader"></div>
-                        </button>
-                    </div>
-                </form>
+            <div class="form-group">
+              <label for="updateMessage">Atualização ou alerta *</label>
+              <textarea id="updateMessage" name="updateMessage" placeholder="Descreva claramente a atualização ou alerta para a equipe" required></textarea>
             </div>
+            <div class="feedback" id="updatesFeedback" aria-live="polite"></div>
+            <button class="primary-button" id="updateSubmitBtn" type="submit">
+              <i class="fas fa-paper-plane"></i>
+              Publicar atualização
+            </button>
+          </form>
         </div>
-    </div>
 
-    <!-- Modal de Confirmação (Genérico) -->
-    <div id="confirmationModal" class="modal-overlay">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title">Confirmação</h3>
-                <button class="modal-close" id="closeConfirmationModalBtn">&times;</button>
-            </div>
-            <div class="modal-body">
-                <p id="confirmationMessage">Tem certeza que deseja excluir este item?</p>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-outline" id="cancelConfirmationBtn">Cancelar</button>
-                <button type="button" class="btn btn-danger" id="confirmDeletionBtn">
-                    <span>Excluir</span>
-                    <div class="loader"></div>
-                </button>
-            </div>
+        <div id="teamUpdatesList" class="updates-list" aria-live="polite">
+          <div class="empty-state">Nenhuma atualização registrada.</div>
         </div>
-    </div>
+      </section>
+    </main>
 
-    <!-- Script para Firebase e funcionalidades da UI -->
     <script>window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';</script>
     <script src="shared.js"></script>
     <script type="module" src="firebase-config.js"></script>
-
     <script type="module">
-        
-        // Importa as funções necessárias do Firebase
-        import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
-        import { getAuth, signInWithCustomToken, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
-        import { getFirestore, collection, addDoc, onSnapshot, query, where, updateDoc, doc, deleteDoc, getDocs, setDoc } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
-        import { getStorage, ref, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
-        import { firebaseConfig as defaultFirebaseConfig } from './firebase-config.js';
+      import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js';
+      import { getAuth, onAuthStateChanged, signInWithCustomToken } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js';
+      import {
+        getFirestore,
+        collection,
+        addDoc,
+        onSnapshot,
+        query,
+        where,
+        doc,
+        deleteDoc,
+        updateDoc,
+        getDocs,
+        serverTimestamp,
+        Timestamp
+      } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js';
+      import { firebaseConfig as defaultFirebaseConfig } from './firebase-config.js';
 
-        // Variáveis globais fornecidas pelo ambiente
-        const appId = typeof __app_id !== 'undefined' ? __app_id : 'equipes';
-                const firebaseConfig = window.firebaseConfig || JSON.parse(typeof __firebase_config !== 'undefined' ? __firebase_config : '{}');
+      const tabButtons = document.querySelectorAll('.team-tab-button');
+      const sections = {
+        membersView: document.getElementById('membersView'),
+        tasksView: document.getElementById('tasksView'),
+        updatesView: document.getElementById('updatesView')
+      };
 
-        const initialAuthToken = typeof __initial_auth_token !== 'undefined' ? __initial_auth_token : null;
+      tabButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          tabButtons.forEach((btn) => btn.classList.remove('active'));
+          Object.values(sections).forEach((section) => section.classList.remove('active'));
+          button.classList.add('active');
+          const viewId = button.dataset.view;
+          if (sections[viewId]) {
+            sections[viewId].classList.add('active');
+          }
+        });
+      });
 
-        // Elementos do DOM das Vistas
-        const dashboardView = document.getElementById('dashboardView');
-        const myBoardsView = document.getElementById('myBoardsView');
-        const teamView = document.getElementById('teamView');
-        const boardView = document.getElementById('boardView');
-        const navLinks = document.querySelectorAll('.nav-link');
-        const backButtons = document.querySelectorAll('.back-button');
+      const memberForm = document.getElementById('teamMemberForm');
+      const membersFeedback = document.getElementById('membersFeedback');
+      const memberSubmitBtn = document.getElementById('memberSubmitBtn');
+      const membersList = document.getElementById('teamMembersList');
 
-        // Elementos do DOM do Dashboard
-        const boardsGrid = document.getElementById('boardsGrid');
-        const newBoardBtn = document.getElementById('newBoardBtn');
-        const newBoardModal = document.getElementById('newBoardModal');
-        const boardForm = document.getElementById('boardForm');
-        const boardTitleInput = document.getElementById('boardTitle');
-        const boardColorInput = document.getElementById('boardColor');
-        const boardResponsibleSelect = document.getElementById('boardResponsible');
-        const boardIdInput = document.getElementById('boardIdInput');
-        const newBoardModalTitle = document.getElementById('newBoardModalTitle');
-        const closeNewBoardModalBtn = document.getElementById('closeNewBoardModalBtn');
-        const cancelBoardModalBtn = document.getElementById('cancelBoardModalBtn');
-        const saveBoardBtn = document.getElementById('saveBoardBtn');
-        const userIdDisplay = document.getElementById('userIdDisplay');
+      const taskForm = document.getElementById('teamTaskForm');
+      const tasksFeedback = document.getElementById('tasksFeedback');
+      const taskSubmitBtn = document.getElementById('taskSubmitBtn');
+      const tasksList = document.getElementById('teamTasksList');
+      const taskResponsibleSelect = document.getElementById('taskResponsible');
 
-        // Elementos do DOM de Equipes
-        const membersGrid = document.getElementById('membersGrid');
-        const addMemberBtn = document.getElementById('addMemberBtn');
-        
-        // Elementos do DOM do Board View
-        const currentBoardTitle = document.getElementById('currentBoardTitle');
-        const boardTableContainer = document.getElementById('boardTableContainer');
-        const newTaskBtn = document.getElementById('newTaskBtn');
-        const newTaskModal = document.getElementById('newTaskModal');
-        const newTaskForm = document.getElementById('newTaskForm');
-        const closeNewTaskModalBtn = document.getElementById('closeNewTaskModalBtn');
-        const cancelNewTaskModalBtn = document.getElementById('cancelNewTaskModalBtn');
-        const saveTaskBtn = document.getElementById('saveTaskBtn');
-        const taskAssigneeSelect = document.getElementById('taskAssignee');
+      const updatesForm = document.getElementById('teamUpdateForm');
+      const updatesFeedback = document.getElementById('updatesFeedback');
+      const updateSubmitBtn = document.getElementById('updateSubmitBtn');
+      const updatesList = document.getElementById('teamUpdatesList');
 
-        // Elementos do DOM de filtros
-        const filterTasksBtn = document.getElementById('filterTasksBtn');
-        const filterModal = document.getElementById('filterModal');
-        const filterForm = document.getElementById('filterForm');
-        const closeFilterModalBtn = document.getElementById('closeFilterModalBtn');
-        const statusFilterSelect = document.getElementById('statusFilter');
-        const assigneeFilterSelect = document.getElementById('assigneeFilter');
-        const startDateFilterInput = document.getElementById('startDateFilter');
-        const endDateFilterInput = document.getElementById('endDateFilter');
-        const cancelFilterBtn = document.getElementById('cancelFilterBtn');
-        
-        // Novos inputs do modal de tarefa
-        const taskTitleInput = document.getElementById('taskTitle');
-        const taskDescriptionInput = document.getElementById('taskDescription');
-        const taskDateInput = document.getElementById('taskDate');
-        const taskQuantityInput = document.getElementById('taskQuantity');
-        const taskFileInput = document.getElementById('taskFile');
-        
-        // Elementos do DOM do Modal de Membros
-        const newMemberModal = document.getElementById('newMemberModal');
-        const newMemberForm = document.getElementById('newMemberForm');
-        const closeNewMemberModalBtn = document.getElementById('closeNewMemberModalBtn');
-        const cancelNewMemberModalBtn = document.getElementById('cancelNewMemberModalBtn');
-        const saveMemberBtn = document.getElementById('saveMemberBtn');
+      const teamLoading = document.getElementById('teamLoading');
 
-        // Elementos do DOM do Modal de Confirmação
-        const confirmationModal = document.getElementById('confirmationModal');
-        const confirmationMessage = document.getElementById('confirmationMessage');
-        const closeConfirmationModalBtn = document.getElementById('closeConfirmationModalBtn');
-        const cancelConfirmationBtn = document.getElementById('cancelConfirmationBtn');
-        const confirmDeletionBtn = document.getElementById('confirmDeletionBtn');
-        
-        let app, db, auth, storage;
-        let userId = null;
-        let isAuthReady = false;
-        let currentBoardId = null;
-        let members = []; // Array para armazenar os membros da equipe
-        let membersMap = {}; // Objeto para facilitar a busca de membros por ID
-        let tasksCache = []; // Cache das tarefas do quadro atual
-        let currentFilters = { status: '', assigneeId: '', startDate: null, endDate: null };
-        let originalBoardResponsibleId = null;
-        
-        const defaultColumns = ['A Fazer', 'Em Andamento', 'Concluído'];
-        const statusColors = {
-            'A Fazer': '#8c9096',
-            'Em Andamento': '#4262ff',
-            'Concluído': '#00c875'
-        };
+      let app;
+      let auth;
+      let db;
+      let currentUser = null;
+      let currentUserEmail = '';
+      let ownedMembers = [];
+      let ownedMembersUnsub = null;
+      let tasksUnsub = null;
+      let updatesUnsub = null;
+      let lastSharingSignature = '';
 
-        // Variáveis para a deleção
-        let itemToDelete = null;
-        let itemTypeToDelete = null;
-        let itemOwnerToDelete = null;
-        let itemResponsibleToDelete = null;
-
-        // Função para mostrar um modal
-        function showModal(modal) {
-            modal.classList.add('visible');
+      const rawConfig = (() => {
+        if (window.firebaseConfig) return window.firebaseConfig;
+        if (typeof __firebase_config !== 'undefined') {
+          try {
+            return JSON.parse(__firebase_config);
+          } catch (error) {
+            console.error('Não foi possível interpretar __firebase_config:', error);
+          }
         }
+        return null;
+      })();
+      const firebaseConfig = rawConfig && rawConfig.projectId ? rawConfig : defaultFirebaseConfig;
+      const initialAuthToken = typeof __initial_auth_token !== 'undefined' ? __initial_auth_token : null;
 
-        // Função para esconder um modal
-        function hideModal(modal) {
-            modal.classList.remove('visible');
+      function showFeedback(element, message, type = 'success') {
+        if (!element) return;
+        element.textContent = message;
+        element.classList.remove('feedback-success', 'feedback-error');
+        if (message) {
+          element.classList.add(type === 'error' ? 'feedback-error' : 'feedback-success');
         }
-
-        // Função principal para alternar entre as views
-        function showView(viewId) {
-            // Esconde todas as views
-            const views = document.querySelectorAll('.view');
-            views.forEach(view => view.classList.remove('active'));
-
-            // Mostra a view solicitada
-            const targetView = document.getElementById(viewId);
-            if (targetView) {
-                targetView.classList.add('active');
+        if (message) {
+          setTimeout(() => {
+            if (element.textContent === message) {
+              element.textContent = '';
+              element.classList.remove('feedback-success', 'feedback-error');
             }
+          }, 6000);
+        }
+      }
 
-            // Remove a classe 'active' de todos os links de navegação
-            navLinks.forEach(link => link.classList.remove('active'));
+      function formatDateTime(task) {
+        if (task.scheduledAt && typeof task.scheduledAt.toDate === 'function') {
+          const dateObj = task.scheduledAt.toDate();
+          const datePart = dateObj.toLocaleDateString('pt-BR');
+          const timePart = dateObj.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
+          return `${datePart} às ${timePart}`;
+        }
+        if (task.date || task.time) {
+          const datePart = task.date ? task.date.split('-').reverse().join('/') : 'Data não definida';
+          const timePart = task.time ? task.time : '';
+          return timePart ? `${datePart} às ${timePart}` : datePart;
+        }
+        return 'Sem data definida';
+      }
 
-            // Adiciona a classe 'active' ao link de navegação da view atual
-            const activeNavLink = document.querySelector(`.nav-link[data-view-id="${viewId}"]`);
-            if (activeNavLink) {
-                activeNavLink.classList.add('active');
-            }
-            
-            // Se for a boardView, iniciamos o listener das tarefas
-            if (viewId === 'boardView' && currentBoardId) {
-                setupTasksListener(currentBoardId);
-            }
-        }
-        
-        // Função para abrir a visão de um quadro específico
-        function showBoardView(boardId, boardTitle) {
-            currentBoardId = boardId;
-            currentBoardTitle.innerText = boardTitle;
-            showView('boardView');
-        }
-        
-        // Função para gerar iniciais de um nome
-        function getInitials(name) {
-            if (!name) return '??';
-            const nameParts = name.split(' ');
-            if (nameParts.length > 1) {
-                return (nameParts[0][0] + nameParts[1][0]).toUpperCase();
-            }
-            return nameParts[0][0].toUpperCase();
-        }
-        
-        // Preenche o dropdown de atribuição de tarefas com os membros da equipe
-        function populateAssigneeSelect() {
-            // Limpa e preenche o select no modal de nova tarefa
-            taskAssigneeSelect.innerHTML = '<option value="">Não atribuído</option>';
-            assigneeFilterSelect.innerHTML = '<option value="">Todos</option>';
-            members.forEach(member => {
-                const option = document.createElement('option');
-                option.value = member.id;
-                option.textContent = member.name;
-                taskAssigneeSelect.appendChild(option);
+      function priorityBadgeClass(priority) {
+        if (priority === 'Alta') return 'badge badge-danger';
+        if (priority === 'Média') return 'badge badge-warning';
+        if (priority === 'Baixa') return 'badge badge-success';
+        return 'badge';
+      }
 
-                const filterOption = document.createElement('option');
-                filterOption.value = member.id;
-                filterOption.textContent = member.name;
-                assigneeFilterSelect.appendChild(filterOption);
-            });
+      function getCurrentTeamEmails() {
+        const emails = new Set();
+        if (currentUserEmail) emails.add(currentUserEmail);
+        ownedMembers.forEach((member) => {
+          if (member.memberEmail) {
+            emails.add(member.memberEmail.toLowerCase());
+          }
+        });
+        return emails;
+      }
+
+      function updateResponsibleOptions() {
+        const select = taskResponsibleSelect;
+        if (!select) return;
+
+        const previousValue = select.value;
+        select.innerHTML = '<option value="">Selecione um responsável</option>';
+
+        if (currentUserEmail) {
+          const option = document.createElement('option');
+          option.value = currentUserEmail;
+          option.textContent = `${currentUser?.email || currentUserEmail} (Você)`;
+          option.dataset.role = 'Gestor';
+          select.appendChild(option);
         }
 
-        // Preenche o dropdown de responsável do quadro
-        function populateBoardResponsibleSelect() {
-            if (!boardResponsibleSelect) return;
-            boardResponsibleSelect.innerHTML = '';
-            const meOption = document.createElement('option');
-            meOption.value = userId || '';
-            meOption.textContent = 'Você';
-            boardResponsibleSelect.appendChild(meOption);
-            members.forEach(member => {
-                const option = document.createElement('option');
-                option.value = member.id;
-                option.textContent = member.name;
-                boardResponsibleSelect.appendChild(option);
-            });
-            if (originalBoardResponsibleId) {
-                boardResponsibleSelect.value = originalBoardResponsibleId;
-            }
+        ownedMembers
+          .slice()
+          .sort((a, b) => (a.memberEmail || '').localeCompare(b.memberEmail || ''))
+          .forEach((member) => {
+            const option = document.createElement('option');
+            option.value = (member.memberEmail || '').toLowerCase();
+            const labelName = member.memberName ? ` • ${member.memberName}` : '';
+            option.textContent = `${member.memberEmail}${labelName}`;
+            option.dataset.role = member.role || '';
+            select.appendChild(option);
+          });
+
+        if (previousValue && [...select.options].some((opt) => opt.value === previousValue)) {
+          select.value = previousValue;
         }
-        
-        // Inicializa o Firebase e ouve o estado de autenticação
-        async function initializeFirebase() {
-            // Evita inicializar o Firebase sem as configurações mínimas necessárias.
-            if (!firebaseConfig || !firebaseConfig.projectId) {
-                console.error("Configuração do Firebase ausente ou incompleta.");
-                boardsGrid.innerHTML = '<div class="loading">Configuração do Firebase ausente.</div>';
-                membersGrid.innerHTML = '<div class="loading">Configuração do Firebase ausente.</div>';
-                showView('dashboardView');
+      }
+
+      function renderOwnedMembers() {
+        if (!membersList) return;
+        membersList.innerHTML = '';
+
+        if (ownedMembers.length === 0) {
+          membersList.innerHTML = '<div class="empty-state">Nenhum integrante cadastrado até o momento.</div>';
+          return;
+        }
+
+        const sortedMembers = ownedMembers.slice().sort((a, b) => (a.memberEmail || '').localeCompare(b.memberEmail || ''));
+
+        sortedMembers.forEach((member) => {
+          const card = document.createElement('article');
+          card.className = 'team-card';
+
+          const createdAtText = member.createdAt && typeof member.createdAt.toDate === 'function'
+            ? member.createdAt.toDate().toLocaleString('pt-BR')
+            : 'Pendente de sincronização';
+
+          card.innerHTML = `
+            <div class="team-card-header">
+              <div>
+                <h3>${member.memberEmail || 'E-mail não informado'}</h3>
+                <span>${member.memberName || ''}</span>
+              </div>
+              <span class="badge">${member.role || 'Cargo não informado'}</span>
+            </div>
+            <div class="card-meta">
+              <div><strong>Adicionado em:</strong> ${createdAtText}</div>
+            </div>
+            <div class="card-footer">
+              <span class="card-meta"><strong>Responsável pelo cadastro:</strong> ${currentUser?.email || ''}</span>
+              <button class="danger-button" data-member-id="${member.id}" type="button">
+                <i class="fas fa-user-minus"></i> Remover
+              </button>
+            </div>
+          `;
+
+          const removeButton = card.querySelector('button[data-member-id]');
+          if (removeButton) {
+            removeButton.addEventListener('click', async () => {
+              if (!confirm('Deseja remover este integrante da equipe? As permissões vinculadas às tarefas e alertas serão atualizadas.')) {
                 return;
-            }
-
-            try {
-                app = initializeApp(firebaseConfig);
-                db = getFirestore(app);
-                auth = getAuth(app);
-                storage = getStorage(app);
-
-                if (initialAuthToken) {
-                    await signInWithCustomToken(auth, initialAuthToken);
-                }
-                
-                onAuthStateChanged(auth, (user) => {
-                     if (!user) {
-                        window.location.href = 'index.html?login=1';
-                        return;
-                    }
-
-                    userId = user.uid;
-                    isAuthReady = true;
-                    originalBoardResponsibleId = userId;
-                    userIdDisplay.innerText = `UID do Usuário: ${userId}`;
-                    console.log('User authenticated with UID:', userId);
-
-                    setupBoardsListener();
-                    setupMembersListener();
-                    showView('myBoardsView'); // Mostra a lista de quadros por padrão
-                });
-
-            } catch (e) {
-                console.error("Erro ao inicializar Firebase ou autenticar: ", e);
-                boardsGrid.innerHTML = '<div class="loading">Erro ao carregar os dados. Tente novamente.</div>';
-                showView('dashboardView');
-            }
-        }
-        
-        // Listener em tempo real para os quadros do usuário
-        function setupBoardsListener() {
-            if (!isAuthReady || !userId) return;
-
-            const boardsCollectionRef = collection(db, `artifacts/${appId}/users/${userId}/boards`);
-            
-            onSnapshot(boardsCollectionRef, (snapshot) => {
-                const boards = [];
-                snapshot.forEach(doc => {
-                    boards.push({ id: doc.id, ...doc.data() });
-                });
-                renderBoards(boards);
-                console.log('Quadros atualizados:', boards);
-            }, (error) => {
-                console.error('Erro ao buscar quadros em tempo real:', error);
-                boardsGrid.innerHTML = '<div class="loading">Erro ao carregar os quadros.</div>';
+              }
+              try {
+                removeButton.disabled = true;
+                await deleteDoc(doc(db, 'teamMembers', member.id));
+                showFeedback(membersFeedback, 'Integrante removido com sucesso.', 'success');
+                await syncOwnerSharing();
+              } catch (error) {
+                console.error('Erro ao remover integrante:', error);
+                showFeedback(membersFeedback, 'Não foi possível remover o integrante.', 'error');
+              } finally {
+                removeButton.disabled = false;
+              }
             });
-        }
-        
-        // Listener em tempo real para os membros da equipe
-        function setupMembersListener() {
-            if (!isAuthReady || !userId) return;
+          }
 
-            const membersCollectionRef = collection(db, `artifacts/${appId}/users/${userId}/members`);
-            
-            onSnapshot(membersCollectionRef, (snapshot) => {
-                members = [];
-                membersMap = {};
-                snapshot.forEach(doc => {
-                    const member = { id: doc.id, ...doc.data() };
-                    members.push(member);
-                    membersMap[member.id] = member;
-                });
-                renderMembers(members);
-                populateAssigneeSelect(); // Atualiza o select do modal de tarefas
-                populateBoardResponsibleSelect(); // Atualiza o select de responsável do quadro
-                console.log('Membros da equipe atualizados:', members);
-            }, (error) => {
-                console.error('Erro ao buscar membros em tempo real:', error);
-                membersGrid.innerHTML = '<div class="loading">Erro ao carregar os membros.</div>';
-            });
-        }
-        
-        // Listener em tempo real para as tarefas de um quadro específico
-        function setupTasksListener(boardId) {
-            if (!isAuthReady || !userId || !boardId) return;
-            
-            const tasksCollectionRef = collection(db, `artifacts/${appId}/users/${userId}/tasks`);
-            const q = query(tasksCollectionRef, where("boardId", "==", boardId));
-            
-            onSnapshot(q, (snapshot) => {
-                tasksCache = [];
-                snapshot.forEach(doc => {
-                    tasksCache.push({ id: doc.id, ...doc.data() });
-                });
-                renderTasks(tasksCache);
-                console.log('Tarefas atualizadas para o quadro', boardId, ':', tasksCache);
-            }, (error) => {
-                console.error('Erro ao buscar tarefas em tempo real:', error);
-            });
-        }
-        
-        // Função para renderizar os quadros dinamicamente
-        function renderBoards(boards) {
-            boardsGrid.innerHTML = '';
-            if (boards.length === 0) {
-                boardsGrid.innerHTML = '<div class="loading">Nenhum quadro encontrado. Crie um novo!</div>';
-                return;
-            }
-            
-            boards.forEach(board => {
-                const boardCard = document.createElement('div');
-                boardCard.classList.add('board-card');
-                
-                const boardHeader = document.createElement('div');
-                boardHeader.classList.add('board-header');
-                boardHeader.style.backgroundColor = board.color;
-
-                const boardTitleIcon = document.createElement('div');
-                boardTitleIcon.innerHTML = `<i class="fas fa-briefcase"></i> ${board.title}`;
-                
-                const boardActions = document.createElement('div');
-                boardActions.classList.add('board-actions');
-
-                const editButton = document.createElement('button');
-                editButton.innerHTML = `<i class="fas fa-edit"></i>`;
-                editButton.onclick = (e) => {
-                    e.stopPropagation();
-                    openEditBoardModal(board);
-                };
-
-                const deleteButton = document.createElement('button');
-                deleteButton.innerHTML = `<i class="fas fa-trash-alt"></i>`;
-                deleteButton.onclick = (e) => {
-                    e.stopPropagation(); // Previne a navegação para o board
-                    showConfirmationModal(board.id, 'board', `Tem certeza que deseja excluir o quadro "${board.title}"? Esta ação é irreversível.`, board.ownerId, board.responsibleId);
-                };
-                
-                boardActions.appendChild(editButton);
-                boardActions.appendChild(deleteButton);
-                
-                boardHeader.appendChild(boardTitleIcon);
-                boardHeader.appendChild(boardActions);
-                
-                const boardContent = document.createElement('div');
-                boardContent.classList.add('board-content');
-                boardContent.onclick = () => showBoardView(board.id, board.title);
-                boardContent.innerHTML = `
-                    <div class="board-title">${board.description || 'Nenhuma descrição'}</div>
-                    <div class="board-stats">
-                        <div><i class="fas fa-tasks"></i> 0 tarefas</div>
-                        <div><i class="fas fa-check-circle"></i> 0 concluídas</div>
-                    </div>
-                    <div class="board-members">
-                        <div class="member-avatar">AM</div>
-                        <div class="member-avatar">+1</div>
-                    </div>
-                `;
-
-                boardCard.appendChild(boardHeader);
-                boardCard.appendChild(boardContent);
-                
-                boardsGrid.appendChild(boardCard);
-            });
-        }
-        
-        // Abre o modal de edição de quadro
-        function openEditBoardModal(board) {
-            newBoardModalTitle.innerText = 'Editar Quadro';
-            boardIdInput.value = board.id;
-            boardTitleInput.value = board.title;
-            boardColorInput.value = board.color;
-            boardResponsibleSelect.value = board.responsibleId || userId;
-            originalBoardResponsibleId = board.responsibleId || userId;
-            saveBoardBtn.querySelector('span').innerHTML = '<i class="fas fa-save"></i> Salvar';
-            showModal(newBoardModal);
-        }
-        
-        // Função para renderizar os membros da equipe dinamicamente
-        function renderMembers(teamMembers) {
-            membersGrid.innerHTML = '';
-            if (teamMembers.length === 0) {
-                membersGrid.innerHTML = '<div class="loading">Nenhum membro na equipe. Adicione um!</div>';
-                return;
-            }
-            
-            teamMembers.forEach(member => {
-                const memberCard = document.createElement('div');
-                memberCard.classList.add('member-card');
-                
-                memberCard.innerHTML = `
-                    <div class="member-avatar-lg">${getInitials(member.name)}</div>
-                    <div class="member-name">${member.name}</div>
-                    <div class="member-role">${member.role}</div>
-                    <div class="member-stats">
-                        <div>
-                            <div class="stat-value">0</div>
-                            <div>Projetos</div>
-                        </div>
-                        <div>
-                            <div class="stat-value">0</div>
-                            <div>Tarefas</div>
-                        </div>
-                    </div>
-                    <div class="member-card-actions">
-                        <button class="delete-member-btn" data-member-id="${member.id}">
-                            <i class="fas fa-trash-alt"></i>
-                        </button>
-                    </div>
-                `;
-                membersGrid.appendChild(memberCard);
-            });
-            
-            document.querySelectorAll('.delete-member-btn').forEach(btn => {
-                btn.addEventListener('click', (e) => {
-                    const memberId = e.currentTarget.dataset.memberId;
-                    const member = members.find(m => m.id === memberId);
-                    if (member) {
-                        showConfirmationModal(memberId, 'member', `Tem certeza que deseja excluir o membro "${member.name}"? Esta ação é irreversível.`);
-                    }
-                });
-            });
-        }
-
-        function applyTaskFilters(tasks) {
-            return tasks.filter(task => {
-                if (currentFilters.status && task.status !== currentFilters.status) return false;
-                if (currentFilters.assigneeId && task.assigneeId !== currentFilters.assigneeId) return false;
-                const taskDate = task.date && task.date.seconds ? new Date(task.date.seconds * 1000) : null;
-                if (currentFilters.startDate && (!taskDate || taskDate < currentFilters.startDate)) return false;
-                if (currentFilters.endDate && (!taskDate || taskDate > currentFilters.endDate)) return false;
-                return true;
-            });
-        }
-
-        // Função para renderizar as tarefas dinamicamente em uma tabela
-        function renderTasks(tasks) {
-            tasks = applyTaskFilters(tasks);
-            boardTableContainer.innerHTML = '';
-            
-            const table = document.createElement('table');
-            table.classList.add('board-table');
-            table.innerHTML = `
-                <thead>
-                    <tr>
-                        <th>Título</th>
-                        <th>Responsável</th>
-                        <th>Status</th>
-                        <th>Data</th>
-                        <th>Arquivos</th>
-                        <th>Quantidade</th>
-                        <th>Última atualização</th>
-                        <th>Ações</th>
-                    </tr>
-                </thead>
-                <tbody></tbody>
-            `;
-            const tableBody = table.querySelector('tbody');
-            
-            if (tasks.length === 0) {
-                tableBody.innerHTML = `<tr><td colspan="8" class="loading">Nenhuma tarefa encontrada.</td></tr>`;
-            } else {
-                tasks.forEach(task => {
-                    const assignee = membersMap[task.assigneeId];
-                    const assigneeName = assignee ? assignee.name : 'Não Atribuído';
-                    const assigneeInitials = assignee ? getInitials(assignee.name) : '??';
-                    const date = task.date && task.date.seconds ? new Date(task.date.seconds * 1000).toLocaleDateString() : 'N/A';
-                    const lastUpdated = task.lastUpdated && task.lastUpdated.seconds ? new Date(task.lastUpdated.seconds * 1000).toLocaleDateString() : 'N/A';
-                    
-                    const row = document.createElement('tr');
-                    
-                    // Célula do Título
-                    const titleCell = document.createElement('td');
-                    titleCell.innerHTML = `
-                        <input type="text" class="editable-input" value="${task.title || ''}" data-task-id="${task.id}" data-field="title">
-                    `;
-                    row.appendChild(titleCell);
-                    
-                    // Célula do Responsável
-                    const assigneeCell = document.createElement('td');
-                    const assigneeSelect = document.createElement('select');
-                    assigneeSelect.classList.add('editable-select');
-                    assigneeSelect.dataset.taskId = task.id;
-                    assigneeSelect.dataset.field = 'assigneeId';
-                    assigneeSelect.innerHTML = '<option value="">Não Atribuído</option>';
-                    members.forEach(member => {
-                        const option = document.createElement('option');
-                        option.value = member.id;
-                        option.textContent = member.name;
-                        if (task.assigneeId === member.id) {
-                            option.selected = true;
-                        }
-                        assigneeSelect.appendChild(option);
-                    });
-                    assigneeSelect.addEventListener('change', async (e) => {
-                        await updateTaskField(task.id, 'assigneeId', e.target.value);
-                    });
-                    assigneeCell.appendChild(assigneeSelect);
-                    row.appendChild(assigneeCell);
-
-                    // Célula do Status
-                    const statusCell = document.createElement('td');
-                    const statusSelect = document.createElement('select');
-                    statusSelect.classList.add('editable-select', 'status-select');
-                    statusSelect.classList.add((task.status || 'A Fazer').toLowerCase().replace(' ', '-'));
-                    statusSelect.dataset.taskId = task.id;
-                    statusSelect.dataset.field = 'status';
-                    defaultColumns.forEach(status => {
-                        const option = document.createElement('option');
-                        option.value = status;
-                        option.textContent = status;
-                        if (task.status === status) {
-                            option.selected = true;
-                        }
-                        statusSelect.appendChild(option);
-                    });
-                    statusSelect.style.backgroundColor = statusColors[task.status || 'A Fazer'] || '#ccc';
-                    statusSelect.addEventListener('change', async (e) => {
-                        await updateTaskField(task.id, 'status', e.target.value);
-                        e.target.style.backgroundColor = statusColors[e.target.value] || '#ccc';
-                    });
-                    statusCell.appendChild(statusSelect);
-                    row.appendChild(statusCell);
-                    
-                    // Célula da Data
-                    const dateCell = document.createElement('td');
-                    dateCell.innerHTML = `<input type="date" class="editable-input" value="${task.date && task.date.seconds ? new Date(task.date.seconds * 1000).toISOString().split('T')[0] : ''}" data-task-id="${task.id}" data-field="date">`;
-                    dateCell.querySelector('input').addEventListener('change', async (e) => {
-                        await updateTaskField(task.id, 'date', new Date(e.target.value));
-                    });
-                    row.appendChild(dateCell);
-                    
-                    // Célula de Arquivos
-                    const filesCell = document.createElement('td');
-                    filesCell.classList.add('file-cell');
-                    if (task.fileURL) {
-                        filesCell.innerHTML = `<a href="${task.fileURL}" target="_blank"><i class="fas fa-file-pdf file-icon"></i></a>`;
-                    } else {
-                        filesCell.textContent = '—';
-                    }
-                    row.appendChild(filesCell);
-
-                    // Célula da Quantidade
-                    const quantityCell = document.createElement('td');
-                    quantityCell.innerHTML = `<input type="number" class="editable-input" value="${task.quantity || ''}" data-task-id="${task.id}" data-field="quantity" min="1">`;
-                    row.appendChild(quantityCell);
-                    
-                    // Célula da Última atualização
-                    const lastUpdatedCell = document.createElement('td');
-                    lastUpdatedCell.textContent = lastUpdated;
-                    row.appendChild(lastUpdatedCell);
-                    
-                    // Célula de Ações
-                    const actionsCell = document.createElement('td');
-                    actionsCell.classList.add('task-actions');
-                    const deleteButton = document.createElement('button');
-                    deleteButton.innerHTML = `<i class="fas fa-trash-alt"></i>`;
-                    deleteButton.onclick = (e) => {
-                        showConfirmationModal(task.id, 'task', `Tem certeza que deseja excluir a tarefa "${task.title}"?`);
-                    };
-                    actionsCell.appendChild(deleteButton);
-                    row.appendChild(actionsCell);
-                    
-                    tableBody.appendChild(row);
-                });
-            }
-            
-            boardTableContainer.appendChild(table);
-
-            // Adiciona event listeners para os inputs editáveis
-            document.querySelectorAll('.editable-input').forEach(input => {
-                input.addEventListener('change', async (e) => {
-                    const taskId = e.target.dataset.taskId;
-                    const field = e.target.dataset.field;
-                    const value = e.target.value;
-                    await updateTaskField(taskId, field, value);
-                });
-            });
-        }
-        
-        async function updateTaskField(taskId, field, value) {
-            if (!isAuthReady || !userId) return;
-            try {
-                const taskRef = doc(db, `artifacts/${appId}/users/${userId}/tasks`, taskId);
-                // Prepara os dados para atualização, incluindo a data da última atualização
-                const updateData = { [field]: value, lastUpdated: new Date() };
-
-                await updateDoc(taskRef, updateData);
-                console.log(`Campo ${field} da tarefa ${taskId} atualizado para: ${value}`);
-            } catch (error) {
-                console.error("Erro ao atualizar o campo da tarefa:", error);
-            }
-        }
-
-        // Modal de confirmação genérico
-        function showConfirmationModal(id, type, message, ownerId = null, responsibleId = null) {
-            itemToDelete = id;
-            itemTypeToDelete = type;
-            itemOwnerToDelete = ownerId;
-            itemResponsibleToDelete = responsibleId;
-            confirmationMessage.textContent = message;
-            showModal(confirmationModal);
-        }
-
-        // Deleção de item
-        async function deleteItem() {
-            if (!itemToDelete || !itemTypeToDelete) return;
-
-            confirmDeletionBtn.classList.add('loading');
-            
-            try {
-                if (itemTypeToDelete === 'board') {
-                    const usersToClean = new Set([userId]);
-                    if (itemOwnerToDelete) usersToClean.add(itemOwnerToDelete);
-                    if (itemResponsibleToDelete) usersToClean.add(itemResponsibleToDelete);
-
-                    for (const uid of usersToClean) {
-                        const tasksRef = collection(db, `artifacts/${appId}/users/${uid}/tasks`);
-                        const q = query(tasksRef, where("boardId", "==", itemToDelete));
-                        const querySnapshot = await getDocs(q);
-                        const deletions = [];
-                        querySnapshot.forEach(docSnap => {
-                            deletions.push(deleteDoc(docSnap.ref));
-                        });
-                        await Promise.all(deletions);
-                        await deleteDoc(doc(db, `artifacts/${appId}/users/${uid}/boards`, itemToDelete));
-                    }
-                    console.log(`Quadro ${itemToDelete} e suas tarefas associadas foram deletados.`);
-                    showView('myBoardsView'); // Retorna à vista de quadros
-                } else if (itemTypeToDelete === 'task') {
-                    await deleteDoc(doc(db, `artifacts/${appId}/users/${userId}/tasks`, itemToDelete));
-                    console.log(`Tarefa ${itemToDelete} deletada.`);
-                } else if (itemTypeToDelete === 'member') {
-                    // TODO: Adicionar lógica para remover atribuição de tarefas antes de deletar o membro
-                    await deleteDoc(doc(db, `artifacts/${appId}/users/${userId}/members`, itemToDelete));
-                    console.log(`Membro ${itemToDelete} deletado.`);
-                }
-            } catch (error) {
-                console.error(`Erro ao deletar o item ${itemToDelete} do tipo ${itemTypeToDelete}:`, error);
-            } finally {
-                confirmDeletionBtn.classList.remove('loading');
-                hideModal(confirmationModal);
-                itemToDelete = null;
-                itemTypeToDelete = null;
-                itemOwnerToDelete = null;
-                itemResponsibleToDelete = null;
-            }
-        }
-        
-        // Lida com o envio do formulário para criar ou editar um novo quadro
-        boardForm.addEventListener('submit', async (e) => {
-            e.preventDefault();
-
-            saveBoardBtn.classList.add('loading');
-
-            let boardId = boardIdInput.value;
-            const title = boardTitleInput.value;
-            const color = boardColorInput.value;
-            const responsibleId = boardResponsibleSelect.value || userId;
-
-            if (!title) {
-                console.error('O título do quadro é obrigatório.');
-                saveBoardBtn.classList.remove('loading');
-                return;
-            }
-
-            try {
-                if (!boardId) {
-                    boardId = doc(collection(db, `artifacts/${appId}/users/${userId}/boards`)).id;
-                }
-
-                const boardData = {
-                    title: title,
-                    description: `Quadro de equipe para ${title}`,
-                    color: color,
-                    ownerId: userId,
-                    responsibleId: responsibleId,
-                };
-                if (!boardIdInput.value) {
-                    boardData.createdAt = new Date();
-                }
-
-                const boardRefCreator = doc(db, `artifacts/${appId}/users/${userId}/boards`, boardId);
-                await setDoc(boardRefCreator, boardData, { merge: true });
-
-                if (responsibleId !== userId) {
-                    const boardRefResp = doc(db, `artifacts/${appId}/users/${responsibleId}/boards`, boardId);
-                    await setDoc(boardRefResp, boardData, { merge: true });
-                }
-
-                if (boardIdInput.value && originalBoardResponsibleId && originalBoardResponsibleId !== responsibleId && originalBoardResponsibleId !== userId) {
-                    await deleteDoc(doc(db, `artifacts/${appId}/users/${originalBoardResponsibleId}/boards`, boardId));
-                }
-
-                hideModal(newBoardModal);
-                boardForm.reset();
-                boardResponsibleSelect.value = userId;
-                originalBoardResponsibleId = userId;
-            } catch (e) {
-                console.error('Erro ao salvar o quadro: ', e);
-            } finally {
-                saveBoardBtn.classList.remove('loading');
-                saveBoardBtn.querySelector('span').innerHTML = '<i class="fas fa-plus"></i> Criar Quadro';
-            }
+          membersList.appendChild(card);
         });
-        
-        // Lida com o envio do formulário para criar uma nova tarefa (LÓGICA ATUALIZADA)
-        newTaskForm.addEventListener('submit', async (e) => {
-            e.preventDefault();
-            
-            saveTaskBtn.classList.add('loading');
+      }
 
-            const title = taskTitleInput.value;
-            const description = taskDescriptionInput.value;
-            const assigneeId = taskAssigneeSelect.value;
-            const date = taskDateInput.value;
-            const quantity = taskQuantityInput.value;
-            const file = taskFileInput.files[0];
-            
-            if (!title) {
-                console.error('O título da tarefa é obrigatório.');
-                saveTaskBtn.classList.remove('loading');
-                return;
+      function renderTasks(tasks) {
+        if (!tasksList) return;
+        tasksList.innerHTML = '';
+
+        if (tasks.length === 0) {
+          tasksList.innerHTML = '<div class="empty-state">Nenhuma tarefa registrada ainda.</div>';
+          return;
+        }
+
+        const sortedTasks = tasks.slice().sort((a, b) => {
+          const getTime = (item) => {
+            if (item.scheduledAt && typeof item.scheduledAt.toDate === 'function') {
+              return item.scheduledAt.toDate().getTime();
             }
-            
-            const newTaskData = {
-                title: title,
-                description: description,
-                status: 'A Fazer',
-                boardId: currentBoardId,
-                assigneeId: assigneeId,
-                date: date ? new Date(date) : null, // Salva a data, se houver
-                quantity: quantity ? parseInt(quantity) : 1, // Salva a quantidade
-                lastUpdated: new Date(),
-                fileName: file ? file.name : null,
-                fileURL: null,
-            };
-
-            try {
-                const tasksCollectionRef = collection(db, `artifacts/${appId}/users/${userId}/tasks`);
-                const docRef = await addDoc(tasksCollectionRef, newTaskData);
-
-                if (file) {
-                    const storageRef = ref(storage, `tasks/${userId}/${docRef.id}/${file.name}`);
-                    await uploadBytes(storageRef, file);
-                    const downloadURL = await getDownloadURL(storageRef);
-                    await updateDoc(docRef, { fileURL: downloadURL });
-                }
-
-                console.log('Nova tarefa adicionada com sucesso:', newTaskData);
-                hideModal(newTaskModal);
-                newTaskForm.reset();
-            } catch (e) {
-                console.error('Erro ao adicionar a tarefa: ', e);
-            } finally {
-                saveTaskBtn.classList.remove('loading');
+            if (item.createdAt && typeof item.createdAt.toDate === 'function') {
+              return item.createdAt.toDate().getTime();
             }
-        });
-        
-        // Lida com o envio do formulário para adicionar um novo membro
-        newMemberForm.addEventListener('submit', async (e) => {
-            e.preventDefault();
-            
-            saveMemberBtn.classList.add('loading');
-            
-            const name = newMemberForm.elements['memberName'].value;
-            const role = newMemberForm.elements['memberRole'].value;
-            
-            if (!name || !role) {
-                console.error('Nome e cargo do membro são obrigatórios.');
-                saveMemberBtn.classList.remove('loading');
-                return;
-            }
-            
-            const newMemberData = {
-                name: name,
-                role: role,
-            };
-            
-            try {
-                const membersCollectionRef = collection(db, `artifacts/${appId}/users/${userId}/members`);
-                await addDoc(membersCollectionRef, newMemberData);
-                
-                console.log('Novo membro adicionado com sucesso:', newMemberData);
-                hideModal(newMemberModal);
-                newMemberForm.reset();
-            } catch (e) {
-                console.error('Erro ao adicionar o membro: ', e);
-            } finally {
-                saveMemberBtn.classList.remove('loading');
-            }
-        });
-        
-        // Event listeners para os botões dos modais
-        newBoardBtn.addEventListener('click', () => {
-            newBoardModalTitle.innerText = 'Criar Novo Quadro';
-            boardIdInput.value = '';
-            boardForm.reset();
-            boardResponsibleSelect.value = userId;
-            originalBoardResponsibleId = userId;
-            saveBoardBtn.querySelector('span').innerHTML = '<i class="fas fa-plus"></i> Criar Quadro';
-            showModal(newBoardModal);
-        });
-        closeNewBoardModalBtn.addEventListener('click', () => hideModal(newBoardModal));
-        cancelBoardModalBtn.addEventListener('click', () => hideModal(newBoardModal));
-
-        newTaskBtn.addEventListener('click', () => showModal(newTaskModal));
-        closeNewTaskModalBtn.addEventListener('click', () => hideModal(newTaskModal));
-        cancelNewTaskModalBtn.addEventListener('click', () => hideModal(newTaskModal));
-
-        filterTasksBtn.addEventListener('click', () => showModal(filterModal));
-        closeFilterModalBtn.addEventListener('click', () => hideModal(filterModal));
-        cancelFilterBtn.addEventListener('click', () => hideModal(filterModal));
-        filterForm.addEventListener('submit', (e) => {
-            e.preventDefault();
-            currentFilters.status = statusFilterSelect.value;
-            currentFilters.assigneeId = assigneeFilterSelect.value;
-            currentFilters.startDate = startDateFilterInput.value ? new Date(startDateFilterInput.value) : null;
-            currentFilters.endDate = endDateFilterInput.value ? new Date(endDateFilterInput.value) : null;
-            renderTasks(tasksCache);
-            hideModal(filterModal);
+            return 0;
+          };
+          return getTime(a) - getTime(b);
         });
 
-        addMemberBtn.addEventListener('click', () => showModal(newMemberModal));
-        closeNewMemberModalBtn.addEventListener('click', () => hideModal(newMemberModal));
-        cancelNewMemberModalBtn.addEventListener('click', () => hideModal(newMemberModal));
-        
-        confirmDeletionBtn.addEventListener('click', deleteItem);
-        closeConfirmationModalBtn.addEventListener('click', () => hideModal(confirmationModal));
-        cancelConfirmationBtn.addEventListener('click', () => hideModal(confirmationModal));
+        sortedTasks.forEach((task) => {
+          const isOwner = task.ownerUid === (currentUser?.uid || '');
+          const card = document.createElement('article');
+          card.className = 'team-card';
 
-        // Adiciona os event listeners para os links de navegação e botões de voltar
-        navLinks.forEach(link => {
-            link.addEventListener('click', (e) => {
-                e.preventDefault();
-                const viewId = link.getAttribute('data-view-id');
-                if (viewId) {
-                    showView(viewId);
+          const createdAtText = task.createdAt && typeof task.createdAt.toDate === 'function'
+            ? task.createdAt.toDate().toLocaleString('pt-BR')
+            : 'Pendente de sincronização';
+
+          const priority = task.priority || '';
+          const priorityClass = priorityBadgeClass(priority);
+          const priorityLabel = priority ? `<span class="${priorityClass}">${priority}</span>` : '';
+
+          let supportHtml = '';
+          if (task.supportMaterial) {
+            const support = task.supportMaterial.trim();
+            const isLink = /^https?:\/\//i.test(support);
+            supportHtml = isLink
+              ? `<a href="${support}" class="support-link" target="_blank" rel="noopener noreferrer">${support}</a>`
+              : `<span>${support}</span>`;
+          }
+
+          card.innerHTML = `
+            <div class="team-card-header">
+              <div>
+                <h3>${task.title || 'Tarefa sem título'}</h3>
+                <span>${formatDateTime(task)}</span>
+              </div>
+              ${priorityLabel}
+            </div>
+            <div class="card-meta">
+              <div><strong>Responsável:</strong> ${task.responsibleEmail ? task.responsibleEmail : 'Não definido'}</div>
+              ${task.responsibleRole ? `<div><strong>Cargo:</strong> ${task.responsibleRole}</div>` : ''}
+              <div><strong>Registrada por:</strong> ${task.ownerEmail || 'Usuário não identificado'}</div>
+              <div><strong>Registrada em:</strong> ${createdAtText}</div>
+            </div>
+            ${task.tips ? `<div><strong>Dicas:</strong><br>${task.tips.replace(/\n/g, '<br>')}</div>` : ''}
+            ${supportHtml ? `<div><strong>Material de apoio:</strong><br>${supportHtml}</div>` : ''}
+            ${isOwner ? `
+              <div class="card-footer">
+                <span class="card-meta">Compartilhada com ${task.allowedEmails?.length || 0} integrante(s).</span>
+                <button class="danger-button" data-task-id="${task.id}" type="button">
+                  <i class="fas fa-trash"></i> Excluir tarefa
+                </button>
+              </div>
+            ` : ''}
+          `;
+
+          if (isOwner) {
+            const deleteBtn = card.querySelector('button[data-task-id]');
+            if (deleteBtn) {
+              deleteBtn.addEventListener('click', async () => {
+                if (!confirm('Deseja excluir esta tarefa?')) return;
+                try {
+                  deleteBtn.disabled = true;
+                  await deleteDoc(doc(db, 'teamTasks', task.id));
+                  showFeedback(tasksFeedback, 'Tarefa excluída com sucesso.', 'success');
+                } catch (error) {
+                  console.error('Erro ao excluir tarefa:', error);
+                  showFeedback(tasksFeedback, 'Não foi possível excluir a tarefa.', 'error');
+                } finally {
+                  deleteBtn.disabled = false;
                 }
-            });
+              });
+            }
+          }
+
+          tasksList.appendChild(card);
+        });
+      }
+
+      function renderUpdates(updates) {
+        if (!updatesList) return;
+        updatesList.innerHTML = '';
+
+        if (updates.length === 0) {
+          updatesList.innerHTML = '<div class="empty-state">Nenhuma atualização registrada.</div>';
+          return;
+        }
+
+        const sortedUpdates = updates.slice().sort((a, b) => {
+          const aTime = a.createdAt && typeof a.createdAt.toDate === 'function' ? a.createdAt.toDate().getTime() : 0;
+          const bTime = b.createdAt && typeof b.createdAt.toDate === 'function' ? b.createdAt.toDate().getTime() : 0;
+          return bTime - aTime;
         });
 
-        backButtons.forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const viewId = btn.getAttribute('data-view-id');
-                if (viewId) {
-                    showView(viewId);
+        sortedUpdates.forEach((update) => {
+          const isOwner = update.ownerUid === (currentUser?.uid || '');
+          const createdAtText = update.createdAt && typeof update.createdAt.toDate === 'function'
+            ? update.createdAt.toDate().toLocaleString('pt-BR')
+            : 'Pendente de sincronização';
+
+          const card = document.createElement('article');
+          card.className = 'team-card';
+          card.innerHTML = `
+            <div class="team-card-header">
+              <div>
+                <h3>${update.title || 'Atualização'}</h3>
+                <span>${createdAtText}</span>
+              </div>
+            </div>
+            <div>${(update.message || '').replace(/\n/g, '<br>')}</div>
+            <div class="card-meta">
+              <div><strong>Publicado por:</strong> ${update.ownerEmail || 'Usuário não identificado'}</div>
+              <div><strong>Visível para:</strong> ${update.allowedEmails?.length || 0} integrante(s)</div>
+            </div>
+            ${isOwner ? `
+              <div class="card-footer">
+                <span class="card-meta"></span>
+                <button class="danger-button" data-update-id="${update.id}" type="button">
+                  <i class="fas fa-trash"></i> Remover alerta
+                </button>
+              </div>
+            ` : ''}
+          `;
+
+          if (isOwner) {
+            const deleteBtn = card.querySelector('button[data-update-id]');
+            if (deleteBtn) {
+              deleteBtn.addEventListener('click', async () => {
+                if (!confirm('Deseja excluir esta atualização/alerta?')) return;
+                try {
+                  deleteBtn.disabled = true;
+                  await deleteDoc(doc(db, 'teamUpdates', update.id));
+                  showFeedback(updatesFeedback, 'Atualização removida com sucesso.', 'success');
+                } catch (error) {
+                  console.error('Erro ao remover atualização:', error);
+                  showFeedback(updatesFeedback, 'Não foi possível remover a atualização.', 'error');
+                } finally {
+                  deleteBtn.disabled = false;
                 }
-            });
+              });
+            }
+          }
+
+          updatesList.appendChild(card);
+        });
+      }
+
+      function areSetsEqual(existing, target) {
+        if (existing.length !== target.length) return false;
+        const existingSet = new Set(existing.map((value) => value.toLowerCase()));
+        return target.every((value) => existingSet.has(value));
+      }
+
+      async function syncOwnerSharing() {
+        if (!currentUser) return;
+        const baseEmails = [...getCurrentTeamEmails()];
+
+        const tasksRef = collection(db, 'teamTasks');
+        const tasksSnapshot = await getDocs(query(tasksRef, where('ownerUid', '==', currentUser.uid)));
+        const updatesRef = collection(db, 'teamUpdates');
+        const updatesSnapshot = await getDocs(query(updatesRef, where('ownerUid', '==', currentUser.uid)));
+
+        const updatesToRun = [];
+
+        tasksSnapshot.forEach((docSnap) => {
+          const data = docSnap.data();
+          const allowed = new Set(baseEmails);
+          if (data.responsibleEmailLower) {
+            allowed.add(data.responsibleEmailLower);
+          }
+          const target = [...allowed];
+          const current = Array.isArray(data.allowedEmails) ? data.allowedEmails : [];
+          if (!areSetsEqual(current, target)) {
+            updatesToRun.push(updateDoc(docSnap.ref, { allowedEmails: target }));
+          }
         });
 
-        // Inicia a aplicação Firebase
-        initializeFirebase();
+        updatesSnapshot.forEach((docSnap) => {
+          const data = docSnap.data();
+          const target = [...baseEmails];
+          const current = Array.isArray(data.allowedEmails) ? data.allowedEmails : [];
+          if (!areSetsEqual(current, target)) {
+            updatesToRun.push(updateDoc(docSnap.ref, { allowedEmails: target }));
+          }
+        });
+
+        if (updatesToRun.length > 0) {
+          try {
+            await Promise.all(updatesToRun);
+          } catch (error) {
+            console.error('Erro ao sincronizar compartilhamento:', error);
+          }
+        }
+      }
+
+      function watchOwnedMembers() {
+        if (!db || !currentUser) return;
+        if (ownedMembersUnsub) ownedMembersUnsub();
+        const membersRef = collection(db, 'teamMembers');
+        const membersQuery = query(membersRef, where('ownerUid', '==', currentUser.uid));
+        ownedMembersUnsub = onSnapshot(
+          membersQuery,
+          (snapshot) => {
+            ownedMembers = snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+            renderOwnedMembers();
+            updateResponsibleOptions();
+            const signature = JSON.stringify([...getCurrentTeamEmails()].sort());
+            if (signature !== lastSharingSignature) {
+              lastSharingSignature = signature;
+              syncOwnerSharing();
+            }
+          },
+          (error) => {
+            console.error('Erro ao carregar integrantes:', error);
+            showFeedback(membersFeedback, 'Erro ao carregar integrantes da equipe.', 'error');
+          }
+        );
+      }
+
+      function watchTasks() {
+        if (!db || !currentUserEmail) return;
+        if (tasksUnsub) tasksUnsub();
+        const tasksRef = collection(db, 'teamTasks');
+        const tasksQuery = query(tasksRef, where('allowedEmails', 'array-contains', currentUserEmail));
+        tasksUnsub = onSnapshot(
+          tasksQuery,
+          (snapshot) => {
+            const tasks = snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+            renderTasks(tasks);
+          },
+          (error) => {
+            console.error('Erro ao carregar tarefas:', error);
+            showFeedback(tasksFeedback, 'Erro ao carregar as tarefas da equipe.', 'error');
+          }
+        );
+      }
+
+      function watchUpdates() {
+        if (!db || !currentUserEmail) return;
+        if (updatesUnsub) updatesUnsub();
+        const updatesRef = collection(db, 'teamUpdates');
+        const updatesQuery = query(updatesRef, where('allowedEmails', 'array-contains', currentUserEmail));
+        updatesUnsub = onSnapshot(
+          updatesQuery,
+          (snapshot) => {
+            const updates = snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+            renderUpdates(updates);
+          },
+          (error) => {
+            console.error('Erro ao carregar atualizações:', error);
+            showFeedback(updatesFeedback, 'Erro ao carregar atualizações.', 'error');
+          }
+        );
+      }
+
+      memberForm?.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!currentUser) {
+          showFeedback(membersFeedback, 'Faça login para cadastrar integrantes.', 'error');
+          return;
+        }
+        const emailInput = document.getElementById('memberEmail');
+        const roleInput = document.getElementById('memberRole');
+        const nameInput = document.getElementById('memberName');
+
+        const emailValue = (emailInput.value || '').trim().toLowerCase();
+        const roleValue = (roleInput.value || '').trim();
+        const nameValue = (nameInput.value || '').trim();
+
+        if (!emailValue || !roleValue) {
+          showFeedback(membersFeedback, 'Preencha o e-mail e o cargo do integrante.', 'error');
+          return;
+        }
+
+        if (emailValue === currentUserEmail) {
+          showFeedback(membersFeedback, 'Não é necessário cadastrar o seu próprio e-mail.', 'error');
+          return;
+        }
+
+        if (ownedMembers.some((member) => (member.memberEmail || '').toLowerCase() === emailValue)) {
+          showFeedback(membersFeedback, 'Este e-mail já está cadastrado na equipe.', 'error');
+          return;
+        }
+
+        try {
+          memberSubmitBtn.disabled = true;
+          await addDoc(collection(db, 'teamMembers'), {
+            ownerUid: currentUser.uid,
+            ownerEmail: currentUser.email || '',
+            memberEmail: emailValue,
+            memberName: nameValue,
+            role: roleValue,
+            createdAt: serverTimestamp()
+          });
+          memberForm.reset();
+          showFeedback(membersFeedback, 'Integrante cadastrado com sucesso!', 'success');
+          await syncOwnerSharing();
+        } catch (error) {
+          console.error('Erro ao cadastrar integrante:', error);
+          showFeedback(membersFeedback, 'Não foi possível cadastrar o integrante.', 'error');
+        } finally {
+          memberSubmitBtn.disabled = false;
+        }
+      });
+
+      taskForm?.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!currentUser) {
+          showFeedback(tasksFeedback, 'Faça login para registrar tarefas.', 'error');
+          return;
+        }
+
+        const title = (document.getElementById('taskTitle').value || '').trim();
+        const date = (document.getElementById('taskDate').value || '').trim();
+        const time = (document.getElementById('taskTime').value || '').trim();
+        const priority = (document.getElementById('taskPriority').value || '').trim();
+        const tips = (document.getElementById('taskTips').value || '').trim();
+        const supportMaterial = (document.getElementById('taskSupport').value || '').trim();
+        const responsibleSelect = taskResponsibleSelect;
+        const responsibleEmail = responsibleSelect?.value ? responsibleSelect.value.toLowerCase() : '';
+        const responsibleRole = responsibleSelect?.selectedOptions?.[0]?.dataset?.role || '';
+
+        if (!title) {
+          showFeedback(tasksFeedback, 'Informe uma tarefa para registrar.', 'error');
+          return;
+        }
+
+        let scheduledAt = null;
+        if (date) {
+          const isoDate = time ? `${date}T${time}` : `${date}T00:00`;
+          const parsed = new Date(isoDate);
+          if (!isNaN(parsed.getTime())) {
+            scheduledAt = Timestamp.fromDate(parsed);
+          }
+        }
+
+        const allowedEmails = new Set(getCurrentTeamEmails());
+        if (responsibleEmail) {
+          allowedEmails.add(responsibleEmail);
+        }
+
+        try {
+          taskSubmitBtn.disabled = true;
+          await addDoc(collection(db, 'teamTasks'), {
+            ownerUid: currentUser.uid,
+            ownerEmail: currentUser.email || '',
+            title,
+            date,
+            time,
+            priority,
+            tips,
+            supportMaterial,
+            responsibleEmail: responsibleEmail || '',
+            responsibleEmailLower: responsibleEmail || '',
+            responsibleRole: responsibleRole || '',
+            scheduledAt,
+            createdAt: serverTimestamp(),
+            allowedEmails: Array.from(allowedEmails)
+          });
+          taskForm.reset();
+          updateResponsibleOptions();
+          showFeedback(tasksFeedback, 'Tarefa registrada com sucesso!', 'success');
+        } catch (error) {
+          console.error('Erro ao registrar tarefa:', error);
+          showFeedback(tasksFeedback, 'Não foi possível registrar a tarefa.', 'error');
+        } finally {
+          taskSubmitBtn.disabled = false;
+        }
+      });
+
+      updatesForm?.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!currentUser) {
+          showFeedback(updatesFeedback, 'Faça login para publicar alertas.', 'error');
+          return;
+        }
+
+        const title = (document.getElementById('updateTitle').value || '').trim();
+        const message = (document.getElementById('updateMessage').value || '').trim();
+
+        if (!message) {
+          showFeedback(updatesFeedback, 'Descreva a atualização ou alerta antes de publicar.', 'error');
+          return;
+        }
+
+        const allowedEmails = Array.from(getCurrentTeamEmails());
+
+        try {
+          updateSubmitBtn.disabled = true;
+          await addDoc(collection(db, 'teamUpdates'), {
+            ownerUid: currentUser.uid,
+            ownerEmail: currentUser.email || '',
+            title,
+            message,
+            createdAt: serverTimestamp(),
+            allowedEmails
+          });
+          updatesForm.reset();
+          showFeedback(updatesFeedback, 'Atualização publicada com sucesso!', 'success');
+        } catch (error) {
+          console.error('Erro ao publicar atualização:', error);
+          showFeedback(updatesFeedback, 'Não foi possível publicar a atualização.', 'error');
+        } finally {
+          updateSubmitBtn.disabled = false;
+        }
+      });
+
+      async function initializeFirebase() {
+        if (!firebaseConfig || !firebaseConfig.projectId) {
+          teamLoading.innerHTML = '<strong>Configuração do Firebase não encontrada.</strong>';
+          return;
+        }
+
+        try {
+          app = initializeApp(firebaseConfig);
+          auth = getAuth(app);
+          db = getFirestore(app);
+
+          if (initialAuthToken) {
+            await signInWithCustomToken(auth, initialAuthToken);
+          }
+
+          onAuthStateChanged(auth, (user) => {
+            if (!user) {
+              window.location.href = 'index.html?login=1';
+              return;
+            }
+            currentUser = user;
+            currentUserEmail = (user.email || '').toLowerCase();
+            teamLoading?.classList.add('hidden');
+            watchOwnedMembers();
+            watchTasks();
+            watchUpdates();
+            updateResponsibleOptions();
+          });
+        } catch (error) {
+          console.error('Erro ao inicializar Firebase:', error);
+          teamLoading.innerHTML = '<strong>Não foi possível inicializar os serviços da equipe.</strong>';
+        }
+      }
+
+      initializeFirebase();
     </script>
   </div>
 </body>

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -508,7 +508,6 @@
         href="/equipes.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-equipes"
-        data-perfil="gestor"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -524,7 +523,7 @@
             d="M15 19.128c.833.242 1.714.372 2.625.372 1.479 0 2.878-.342 4.122-.952v-.173c0-2.278-1.847-4.125-4.125-4.125-1.418 0-2.669.716-3.411 1.806M15 19.128V19.125c0-3.52-2.854-6.375-6.375-6.375S2.25 15.605 2.25 19.125v.009A11.953 11.953 0 0 0 12 21c2.678 0 5.218-.585 7.499-1.632M12.75 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM20.25 8.625a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z"
           />
         </svg>
-        <span class="link-text">Equipes</span>
+        <span class="link-text">Equipe</span>
       </a>
     </li>
     <li>


### PR DESCRIPTION
## Summary
- replace the old Equipes experience with a single Equipe hub featuring subpáginas for cadastro, tarefas e alertas
- persist team emails/cargos, tarefas and updates in Firestore with automatic sharing for todos os e-mails cadastrados
- allow every perfil to acessar a nova aba Equipe a partir do menu lateral

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fb5f8a3e68832a83625737fe489000