### PR TITLE
Add shared equipe hub with member, task, and alert pages

### DIFF
--- a/equipes.html
+++ b/equipes.html
@@ -1,1775 +1,1341 @@
 <!DOCTYPE html>
 <html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TeamFlow - Gestão de Equipes</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="css/styles.css?v=20240826">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Central da Equipe</title>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
+      integrity="sha512-pJHtvj8T9n5cMMX0SqnX+ANXoy2cuglRez2oJ6TP2PzefDs2fzGEylh4G6dkprdFM5lTyTX0b6KT1XH0Yv45dQ=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="css/styles.css?v=20240826" />
     <style>
-        /* Estilos globais e variáveis */
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+      :root {
+        color-scheme: light dark;
+      }
 
-        :root {
-            --primary: #4262ff;
-            --primary-dark: #3351e8;
-            --secondary: #00c875;
-            --error: #dc3545;
-            --error-dark: #c82333;
-            --text: #333;
-            --text-light: #666;
-            --border: #e0e0e0;
-            --card-shadow: 0 2px 8px rgba(0,0,0,0.08);
-            --modal-bg: rgba(0, 0, 0, 0.5);
-            --table-header-bg: #e9ecef;
-        }
+      body {
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: var(--color-background, #f5f7fb);
+        color: var(--color-text, #1f2937);
+      }
 
-        body {
-            background-color: #f5f7fb;
-            color: var(--text);
-            min-height: 100vh;
-        }
+      .page-wrapper {
+        min-height: 100vh;
+        display: flex;
+      }
 
-        /* Navegação interna */
-        .team-nav {
-            display: flex;
-            gap: 12px;
-            margin-bottom: 24px;
-        }
+      .main-content {
+        flex: 1;
+        padding: 32px 24px 48px;
+        max-width: 1200px;
+        margin: 0 auto;
+      }
 
-        .nav-link {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            padding: 8px 12px;
-            border-radius: 6px;
-            color: var(--text);
-            text-decoration: none;
-            font-weight: 500;
-            transition: all 0.2s;
-        }
+      .page-header {
+        margin-bottom: 24px;
+      }
 
-        .nav-link:hover, .nav-link.active {
-            background-color: rgba(66, 98, 255, 0.1);
-            color: var(--primary);
-        }
+      .page-header h1 {
+        font-size: clamp(1.8rem, 2vw + 1rem, 2.5rem);
+        font-weight: 700;
+        margin-bottom: 8px;
+      }
 
-        .nav-link i {
-            width: 20px;
-            text-align: center;
-        }
+      .page-header p {
+        color: var(--text-light, #4b5563);
+        max-width: 780px;
+      }
 
-        /* Main Content e Vistas */
+      .tab-nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-bottom: 24px;
+      }
+
+      .tab-nav button {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        border: 1px solid var(--border-color, #d1d5db);
+        background: var(--tab-bg, #fff);
+        color: inherit;
+        padding: 10px 18px;
+        border-radius: 12px;
+        cursor: pointer;
+        font-weight: 600;
+        transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+      }
+
+      .tab-nav button i {
+        color: var(--primary, #4262ff);
+      }
+
+      .tab-nav button.active {
+        background: var(--primary, #4262ff);
+        color: #fff;
+        border-color: transparent;
+      }
+
+      .tab-nav button.active i {
+        color: inherit;
+      }
+
+      .tab-view {
+        display: none;
+        gap: 24px;
+        flex-direction: column;
+      }
+
+      .tab-view.active {
+        display: flex;
+      }
+
+      .card {
+        background: var(--card-bg, #ffffff);
+        border-radius: 16px;
+        padding: 24px;
+        box-shadow: 0 18px 32px -24px rgba(15, 23, 42, 0.45);
+        border: 1px solid color-mix(in srgb, var(--primary, #4262ff) 10%, transparent);
+      }
+
+      .text-sm {
+        font-size: 0.95rem;
+      }
+
+      .card h2,
+      .card h3 {
+        font-weight: 700;
+        margin-bottom: 12px;
+      }
+
+      form {
+        display: grid;
+        gap: 16px;
+      }
+
+      label {
+        font-weight: 600;
+        display: flex;
+        gap: 6px;
+        align-items: center;
+      }
+
+      label span.required {
+        color: #dc2626;
+        font-weight: 700;
+      }
+
+      input[type='text'],
+      input[type='email'],
+      input[type='date'],
+      input[type='time'],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px 12px;
+        border-radius: 10px;
+        border: 1px solid var(--border-color, #d1d5db);
+        background: var(--input-bg, #fff);
+        color: inherit;
+        transition: border 0.2s ease, box-shadow 0.2s ease;
+        font-size: 0.98rem;
+      }
+
+      textarea {
+        min-height: 96px;
+        resize: vertical;
+      }
+
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--primary, #4262ff);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary, #4262ff) 25%, transparent);
+      }
+
+      .actions-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        justify-content: flex-end;
+      }
+
+      button[type='submit'],
+      .secondary-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        padding: 10px 18px;
+        border-radius: 12px;
+        border: none;
+        cursor: pointer;
+        font-weight: 600;
+        transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+      }
+
+      button[type='submit'] {
+        background: linear-gradient(135deg, var(--primary, #4262ff), #6b8bff);
+        color: #fff;
+      }
+
+      button[type='submit']:hover:not([disabled]) {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 24px -18px rgba(66, 98, 255, 0.8);
+      }
+
+      button[disabled] {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+
+      .secondary-button {
+        background: color-mix(in srgb, var(--primary, #4262ff) 10%, transparent);
+        color: var(--primary, #4262ff);
+        border: 1px solid color-mix(in srgb, var(--primary, #4262ff) 40%, transparent);
+      }
+
+      .status-message {
+        padding: 12px 16px;
+        border-radius: 12px;
+        font-weight: 500;
+        display: none;
+      }
+
+      .status-message.show {
+        display: block;
+      }
+
+      .status-success {
+        background: color-mix(in srgb, #10b981 12%, transparent);
+        color: #047857;
+        border: 1px solid color-mix(in srgb, #10b981 50%, transparent);
+      }
+
+      .status-error {
+        background: color-mix(in srgb, #ef4444 12%, transparent);
+        color: #b91c1c;
+        border: 1px solid color-mix(in srgb, #ef4444 50%, transparent);
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        overflow: hidden;
+        border-radius: 14px;
+      }
+
+      table thead {
+        background: color-mix(in srgb, var(--primary, #4262ff) 8%, transparent);
+        text-align: left;
+      }
+
+      table th,
+      table td {
+        padding: 12px 14px;
+        border-bottom: 1px solid color-mix(in srgb, var(--primary, #4262ff) 12%, transparent);
+      }
+
+      table tbody tr:last-child td {
+        border-bottom: none;
+      }
+
+      .empty-state {
+        padding: 24px;
+        text-align: center;
+        border-radius: 14px;
+        border: 1px dashed color-mix(in srgb, var(--primary, #4262ff) 35%, transparent);
+        background: color-mix(in srgb, var(--primary, #4262ff) 4%, transparent);
+        font-weight: 500;
+        color: var(--text-light, #4b5563);
+      }
+
+      .stack {
+        display: grid;
+        gap: 16px;
+      }
+
+      .task-card,
+      .update-card {
+        border: 1px solid color-mix(in srgb, var(--primary, #4262ff) 16%, transparent);
+        border-radius: 16px;
+        padding: 18px;
+        background: color-mix(in srgb, var(--card-bg, #ffffff) 92%, transparent);
+        display: grid;
+        gap: 12px;
+      }
+
+      .task-card header,
+      .update-card header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 12px;
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 10px;
+        border-radius: 999px;
+        font-size: 0.8rem;
+        font-weight: 600;
+        background: color-mix(in srgb, var(--primary, #4262ff) 12%, transparent);
+        color: var(--primary, #4262ff);
+      }
+
+      .badge.high {
+        background: color-mix(in srgb, #ef4444 16%, transparent);
+        color: #b91c1c;
+      }
+
+      .badge.medium {
+        background: color-mix(in srgb, #f59e0b 16%, transparent);
+        color: #b45309;
+      }
+
+      .badge.low {
+        background: color-mix(in srgb, #10b981 16%, transparent);
+        color: #047857;
+      }
+
+      .tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 8px;
+        background: color-mix(in srgb, var(--primary, #4262ff) 6%, transparent);
+        border-radius: 999px;
+        font-size: 0.75rem;
+      }
+
+      .card-footer {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+        color: var(--text-light, #4b5563);
+        font-size: 0.9rem;
+      }
+
+      .card-footer button {
+        background: transparent;
+        color: inherit;
+        border: none;
+        cursor: pointer;
+        font-weight: 600;
+        padding: 0;
+      }
+
+      .card-footer button:hover {
+        color: #ef4444;
+      }
+
+      @media (max-width: 960px) {
         .main-content {
-            flex: 1;
-            margin-left: 260px;
-            padding: 24px;
-        }
-        
-        .view {
-            display: none;
-        }
-        .view.active {
-            display: block;
-        }
-        
-        .loading {
-            text-align: center;
-            padding: 48px;
-            font-size: 18px;
-            color: var(--text-light);
-        }
-        
-        #userIdDisplay {
-            margin-top: 16px;
-            font-size: 12px;
-            color: var(--text-light);
-            word-wrap: break-word;
+          padding: 24px 16px 40px;
         }
 
-        .header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 32px;
+        .card {
+          padding: 20px;
+        }
+      }
+
+      @media (max-width: 640px) {
+        .tab-nav button {
+          flex: 1 1 100%;
         }
 
-        .page-title {
-            font-size: 28px;
-            font-weight: 700;
+        table thead {
+          display: none;
         }
 
-        .actions {
-            display: flex;
-            gap: 16px;
+        table tr {
+          display: grid;
+          gap: 12px;
+          padding: 16px;
+          border: 1px solid color-mix(in srgb, var(--primary, #4262ff) 15%, transparent);
+          border-radius: 14px;
+          margin-bottom: 16px;
         }
 
-        .btn {
-            padding: 10px 20px;
-            border-radius: 6px;
-            font-weight: 500;
-            cursor: pointer;
-            transition: all 0.2s;
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            border: none;
+        table td {
+          border: none;
+          padding: 0;
         }
 
-        .btn-primary {
-            background: var(--primary);
-            color: white;
-        }
-
-        .btn-primary:hover {
-            background: var(--primary-dark);
-        }
-
-        .btn-outline {
-            background: transparent;
-            border: 1px solid var(--border);
-            color: var(--text);
-        }
-
-        .btn-outline:hover {
-            background: var(--secondary);
-        }
-        
-        .btn-green {
-            background: var(--secondary);
-            color: white;
-        }
-        .btn-green:hover {
-            background: #00a861;
-        }
-
-        .btn-danger {
-            background: var(--error);
-            color: white;
-        }
-        .btn-danger:hover {
-            background: var(--error-dark);
-        }
-
-        /* Boards Grid */
-        .boards-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-            gap: 24px;
-            margin-bottom: 48px;
-        }
-
-        .board-card {
-            background: white;
-            border-radius: 12px;
-            overflow: hidden;
-            box-shadow: var(--card-shadow);
-            transition: transform 0.2s, box-shadow 0.2s;
-            position: relative;
-        }
-
-        .board-card-clickable {
-            cursor: pointer;
-        }
-
-        .board-card-clickable:hover {
-            transform: translateY(-4px);
-            box-shadow: 0 8px 16px rgba(0,0,0,0.1);
-        }
-
-        .board-header {
-            height: 40px;
-            background: var(--primary);
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            padding: 0 16px;
-            color: white;
-            font-weight: 500;
-        }
-        
-        .board-header .board-actions {
-            display: flex;
-            gap: 8px;
-        }
-
-        .board-header .board-actions button {
-            background: none;
-            border: none;
-            color: white;
-            opacity: 0.7;
-            cursor: pointer;
-            transition: opacity 0.2s;
-        }
-        .board-header .board-actions button:hover {
-            opacity: 1;
-        }
-
-        .board-content {
-            padding: 16px;
-            cursor: pointer;
-        }
-
-        .board-title {
-            font-weight: 600;
-            margin-bottom: 8px;
-            font-size: 18px;
-        }
-
-        .board-stats {
-            display: flex;
-            gap: 16px;
-            font-size: 14px;
-            color: var(--text-light);
-        }
-
-        .board-stats div {
-            display: flex;
-            align-items: center;
-            gap: 4px;
-        }
-
-        .board-members {
-            position: absolute;
-            bottom: 16px;
-            right: 16px;
-            display: flex;
-        }
-
-        .member-avatar {
-            width: 28px;
-            height: 28px;
-            border-radius: 50%;
-            background: var(--primary);
-            color: white;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 12px;
-            font-weight: 600;
-            margin-left: -8px;
-            border: 2px solid white;
-        }
-        
-        .member-avatar-lg {
-            width: 64px;
-            height: 64px;
-            border-radius: 50%;
-            background: var(--primary);
-            color: white;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 24px;
-            font-weight: 600;
-            margin: 0 auto 16px;
-        }
-
-        .member-avatar:first-child {
-            margin-left: 0;
-        }
-
-        /* Team Section */
-        .section-title {
-            font-size: 20px;
-            font-weight: 600;
-            margin: 32px 0 24px;
-            padding-bottom: 12px;
-            border-bottom: 1px solid var(--border);
-        }
-        .section-title-with-btn {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            padding-bottom: 12px;
-            border-bottom: 1px solid var(--border);
-        }
-        
-        .members-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-            gap: 16px;
-        }
-
-        .member-card {
-            background: white;
-            border-radius: 8px;
-            padding: 20px;
-            box-shadow: var(--card-shadow);
-            text-align: center;
-            position: relative;
-        }
-        .member-card-actions {
-            position: absolute;
-            top: 8px;
-            right: 8px;
-        }
-        .member-card-actions button {
-            background: none;
-            border: none;
-            color: var(--text-light);
-            cursor: pointer;
-            transition: color 0.2s;
-        }
-        .member-card-actions button:hover {
-            color: var(--error);
-        }
-
-        .member-name {
-            font-weight: 600;
-            margin-bottom: 4px;
-        }
-
-        .member-role {
-            color: var(--text-light);
-            font-size: 14px;
-            margin-bottom: 12px;
-        }
-
-        .member-stats {
-            display: flex;
-            justify-content: center;
-            gap: 16px;
-            font-size: 14px;
-        }
-
-        .stat-value {
-            font-weight: 600;
-        }
-
-        /* Board View - Tabela */
-        .board-table-container {
-            overflow-x: auto;
-        }
-
-        .board-table {
-            width: 100%;
-            border-collapse: collapse;
-            background: white;
-            border-radius: 8px;
-            overflow: hidden;
-            box-shadow: var(--card-shadow);
-        }
-        
-        .board-table thead {
-            background-color: var(--table-header-bg);
-        }
-        
-        .board-table th, .board-table td {
-            padding: 12px 16px;
-            text-align: left;
-            border-bottom: 1px solid var(--border);
-            font-size: 14px;
-        }
-        
-        .board-table th:first-child { min-width: 250px; }
-        .board-table th:nth-child(2) { min-width: 150px; }
-        .board-table th:nth-child(3) { min-width: 120px; }
-        .board-table th:nth-child(4) { min-width: 120px; }
-        .board-table th:nth-child(5) { min-width: 80px; }
-        .board-table th:nth-child(6) { min-width: 100px; }
-        .board-table th:nth-child(7) { min-width: 120px; }
-        .board-table th:nth-child(8) { min-width: 80px; }
-        
-        .board-table tbody tr:last-child td {
-            border-bottom: none;
-        }
-
-        .board-table tbody tr:hover {
-            background-color: var(--secondary);
-        }
-        
-        .editable-cell {
-            padding: 0;
-        }
-
-        .editable-input, .editable-select {
-            width: 100%;
-            padding: 10px;
-            border: none;
-            background: transparent;
-            font-size: 14px;
-            outline: none;
-        }
-
-        .editable-input {
-            border: 1px solid transparent;
-            border-radius: 4px;
-            transition: border-color 0.2s;
-        }
-        
-        .editable-input:focus {
-            border-color: var(--primary);
-            background-color: white;
-        }
-        
-        .status-select {
-            color: white;
-            font-weight: 600;
-            border-radius: 4px;
-            padding: 6px 8px;
-        }
-        .status-select.to-do { background-color: #8c9096; }
-        .status-select.in-progress { background-color: #4262ff; }
-        .status-select.done { background-color: #00c875; }
-        
-        .assignee-cell .assignee-details {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-        }
-        
-        .assignee-cell .assignee-avatar {
-            width: 28px;
-            height: 28px;
-            border-radius: 50%;
-            background: var(--primary);
-            color: white;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 12px;
-            font-weight: 600;
-        }
-        
-        .assignee-cell .assignee-name {
-            font-weight: 500;
-        }
-        
-        .task-actions {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            gap: 8px;
-        }
-
-        .task-actions button {
-            background: none;
-            border: none;
-            cursor: pointer;
-            color: var(--text-light);
-            transition: color 0.2s;
-        }
-        .task-actions button:hover {
-            color: var(--error);
-        }
-        
-        .file-cell {
-            text-align: center;
-        }
-
-        .file-cell a {
-            color: var(--error);
-        }
-
-        .file-icon {
-            color: var(--error);
-            font-size: 20px;
-        }
-
-        .back-button {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            margin-bottom: 24px;
-            color: var(--primary);
-            cursor: pointer;
-            font-weight: 500;
-        }
-        
-        /* Modal customizado */
-        .modal-overlay {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background-color: var(--modal-bg);
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            z-index: 1000;
-            visibility: hidden;
-            opacity: 0;
-            transition: visibility 0s, opacity 0.3s;
-        }
-
-        .modal-overlay.visible {
-            visibility: visible;
-            opacity: 1;
-        }
-
-        .modal-content {
-            background: white;
-            padding: 24px;
-            border-radius: 12px;
-            width: 90%;
-            max-width: 400px;
-            box-shadow: var(--card-shadow);
-            position: relative;
-            transform: scale(0.95);
-            transition: transform 0.3s ease-out;
-        }
-
-        .modal-overlay.visible .modal-content {
-            transform: scale(1);
-        }
-
-        .modal-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 16px;
-        }
-
-        .modal-title {
-            font-size: 20px;
-            font-weight: 600;
-        }
-
-        .modal-close {
-            background: none;
-            border: none;
-            font-size: 24px;
-            color: var(--text-light);
-            cursor: pointer;
-        }
-
-        .modal-body {
-            line-height: 1.5;
-            color: var(--text);
-        }
-        
-        .form-group {
-            margin-bottom: 16px;
-        }
-        
-        .form-group label {
-            display: block;
-            margin-bottom: 8px;
-            font-weight: 500;
-        }
-        
-        .form-group input, .form-group textarea, .form-group select {
-            width: 100%;
-            padding: 10px;
-            border-radius: 6px;
-            border: 1px solid var(--border);
-            font-size: 16px;
-            background: white;
-        }
-        
-        .form-group textarea {
-            resize: vertical;
-        }
-        
-        .modal-footer {
-            display: flex;
-            justify-content: flex-end;
-            gap: 12px;
-        }
-        
-        .loader {
-            border: 4px solid #f3f3f3;
-            border-radius: 50%;
-            border-top: 4px solid var(--primary);
-            width: 20px;
-            height: 20px;
-            -webkit-animation: spin 2s linear infinite;
-            animation: spin 2s linear infinite;
-            display: none;
-            margin-left: 10px;
-        }
-        .btn-primary .loader, .btn-green .loader, .btn-danger .loader {
-            border-top: 4px solid white;
-        }
-        
-        .btn-primary.loading .loader, .btn-green.loading .loader, .btn-danger.loading .loader {
-            display: inline-block;
-        }
-        .btn-primary.loading span, .btn-green.loading span, .btn-danger.loading span {
-            display: none;
-        }
-
-        @-webkit-keyframes spin {
-            0% { -webkit-transform: rotate(0deg); }
-            100% { -webkit-transform: rotate(360deg); }
-        }
-        @keyframes spin {
-            0% { transform: rotate(0deg); }
-            100% { transform: rotate(360deg); }
-        }
-
-        /* Responsividade */
-        @media (max-width: 900px) {
-            .team-nav {
-                flex-direction: column;
-            }
-            .main-content {
-                margin-left: 0;
-            }
-            .board-table th, .board-table td {
-                padding: 8px 12px;
-            }
-        }
-
-        @media (max-width: 600px) {
-            .boards-grid {
-                grid-template-columns: 1fr;
-            }
-            .header {
-                flex-direction: column;
-                align-items: flex-start;
-                gap: 16px;
-            }
-            .actions {
-                width: 100%;
-                justify-content: space-between;
-            }
-        }
+        table td::before {
+          content: attr(data-label);
+          display: block;
+          font-weight: 600;
+          margin-bottom: 4px;
+          color: var(--text-light, #4b5563);
+        }
+      }
     </style>
-</head>
-<body>
-  <div class="app-container">
-    <div id="sidebar-container"></div>
-    <div id="navbar-container"></div>
+  </head>
+  <body>
+    <div class="page-wrapper">
+      <div id="sidebar-container"></div>
+      <div class="main-content">
+        <div id="navbar-container"></div>
 
-    <!-- Main Content -->
-    <div class="main-content">
-        <div class="team-nav">
-            <a href="#" class="nav-link" data-view-id="dashboardView">
-                <i class="fas fa-home"></i>
-                <span>Dashboard</span>
-            </a>
-            <a href="#" class="nav-link active" data-view-id="myBoardsView">
-                <i class="fas fa-tasks"></i>
-                <span>Meus Quadros</span>
-            </a>
-            <a href="#" class="nav-link" data-view-id="teamView">
-                <i class="fas fa-users"></i>
-                <span>Equipes</span>
-            </a>
-        </div>
-        <div id="userIdDisplay"></div>
-
-        <!-- Dashboard View (agora como uma visão geral) -->
-        <div id="dashboardView" class="view">
-            <div class="header">
-                <h2 class="page-title">Dashboard</h2>
-            </div>
-            <p>Bem-vindo ao TeamFlow! Use o menu lateral para navegar entre os seus quadros e a sua equipe.</p>
-        </div>
-        
-        <!-- Meus Quadros View -->
-        <div id="myBoardsView" class="view active">
-            <div class="header">
-                <h2 class="page-title">Meus Quadros</h2>
-                <div class="actions">
-                    <button class="btn btn-outline">
-                        <i class="fas fa-filter"></i>
-                        Filtros
-                    </button>
-                    <button class="btn btn-primary" id="newBoardBtn">
-                        <i class="fas fa-plus"></i>
-                        Novo Quadro
-                    </button>
-                </div>
-            </div>
-            <div id="boardsGrid" class="boards-grid">
-                <div class="loading">Carregando quadros...</div>
-            </div>
+        <div class="page-header">
+          <h1>Central da Equipe</h1>
+          <p>
+            Organize sua equipe, compartilhe tarefas e mantenha todos informados com atualizações e alertas em um só lugar.
+          </p>
         </div>
 
-        <!-- Equipes View -->
-        <div id="teamView" class="view">
-            <div class="header">
-                <h2 class="page-title">Minha Equipe</h2>
-                <div class="actions">
-                    <button class="btn btn-green" id="addMemberBtn">
-                        <i class="fas fa-user-plus"></i>
-                        Adicionar Membro
-                    </button>
-                </div>
-            </div>
-            <div id="membersGrid" class="members-grid">
-                <div class="loading">Carregando membros da equipe...</div>
-            </div>
-        </div>
+        <nav class="tab-nav" aria-label="Subpáginas da equipe">
+          <button type="button" class="active" data-tab="members">
+            <i class="fas fa-user-group" aria-hidden="true"></i>
+            Cadastro da equipe
+          </button>
+          <button type="button" data-tab="tasks">
+            <i class="fas fa-list-check" aria-hidden="true"></i>
+            Tarefas da equipe
+          </button>
+          <button type="button" data-tab="updates">
+            <i class="fas fa-bell" aria-hidden="true"></i>
+            Atualizações e alertas
+          </button>
+        </nav>
 
-        <!-- Board View (para um quadro específico) -->
-        <div id="boardView" class="view">
-            <div class="back-button" data-view-id="myBoardsView">
-                <i class="fas fa-arrow-left"></i>
-                Voltar para Meus Quadros
-            </div>
-            
-            <div class="header">
-                <h2 class="page-title" id="currentBoardTitle"></h2>
-                <div class="actions">
-                    <button class="btn btn-outline" id="filterTasksBtn">
-                        <i class="fas fa-filter"></i>
-                        Filtros
-                    </button>
-                    <button class="btn btn-outline">
-                        <i class="fas fa-search"></i>
-                        Buscar
-                    </button>
-                    <button class="btn btn-primary" id="newTaskBtn">
-                        <i class="fas fa-plus"></i>
-                        Nova Tarefa
-                    </button>
-                </div>
-            </div>
-
-            <div id="boardTableContainer" class="board-table-container">
-                <!-- A tabela de tarefas será renderizada aqui -->
-            </div>
-        </div>
-    </div>
-
-    <!-- Modals (sem alterações) -->
-    <!-- Modal para criar um novo quadro -->
-    <div id="newBoardModal" class="modal-overlay">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title" id="newBoardModalTitle">Criar Novo Quadro</h3>
-                <button class="modal-close" id="closeNewBoardModalBtn">&times;</button>
-            </div>
-            <div class="modal-body">
-                <form id="boardForm">
-                    <input type="hidden" id="boardIdInput">
-                    <div class="form-group">
-                        <label for="boardTitle">Título do Quadro</label>
-                        <input type="text" id="boardTitle" name="title" required placeholder="Ex: Planejamento de Lançamento">
-                    </div>
-                    <div class="form-group">
-                        <label for="boardColor">Cor do Quadro</label>
-                        <input type="color" id="boardColor" name="color" value="#4262ff">
-                    </div>
-                    <div class="form-group">
-                        <label for="boardResponsible">Responsável</label>
-                        <select id="boardResponsible" name="responsible"></select>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-outline" id="cancelBoardModalBtn">Cancelar</button>
-                        <button type="submit" class="btn btn-primary" id="saveBoardBtn">
-                            <span><i class="fas fa-plus"></i> Criar Quadro</span>
-                            <div class="loader"></div>
-                        </button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
-    
-    <!-- Modal para criar uma nova tarefa -->
-    <div id="newTaskModal" class="modal-overlay">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title">Criar Nova Tarefa</h3>
-                <button class="modal-close" id="closeNewTaskModalBtn">&times;</button>
-            </div>
-            <div class="modal-body">
-                <form id="newTaskForm">
-                    <div class="form-group">
-                        <label for="taskTitle">Título da Tarefa</label>
-                        <input type="text" id="taskTitle" name="title" required placeholder="Ex: Desenvolver a tela de login">
-                    </div>
-                    <div class="form-group">
-                        <label for="taskDescription">Descrição</label>
-                        <textarea id="taskDescription" name="description" rows="4" placeholder="Detalhes sobre a tarefa..."></textarea>
-                    </div>
-                    <div class="form-group">
-                        <label for="taskAssignee">Atribuir a</label>
-                        <select id="taskAssignee" class="assignee-select" required>
-                             <!-- Opções serão preenchidas dinamicamente -->
-                        </select>
-                    </div>
-                    <!-- NOVO: Campo de Data no formulário -->
-                    <div class="form-group">
-                        <label for="taskDate">Data Limite</label>
-                        <input type="date" id="taskDate" name="date">
-                    </div>
-                    <!-- NOVO: Campo de Quantidade no formulário -->
-                    <div class="form-group">
-                        <label for="taskQuantity">Quantidade</label>
-                        <input type="number" id="taskQuantity" name="quantity" value="1" min="1" placeholder="Ex: 5">
-                    </div>
-                    <!-- NOVO: Campo de Arquivo PDF -->
-                    <div class="form-group">
-                        <label for="taskFile">Arquivo (PDF)</label>
-                        <input type="file" id="taskFile" accept="application/pdf">
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-outline" id="cancelNewTaskModalBtn">Cancelar</button>
-                        <button type="submit" class="btn btn-primary" id="saveTaskBtn">
-                            <span><i class="fas fa-plus"></i> Criar Tarefa</span>
-                            <div class="loader"></div>
-                        </button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
-
-    <!-- Modal de filtros -->
-    <div id="filterModal" class="modal-overlay">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title">Filtrar Tarefas</h3>
-                <button class="modal-close" id="closeFilterModalBtn">&times;</button>
-            </div>
-            <div class="modal-body">
-                <form id="filterForm">
-                    <div class="form-group">
-                        <label for="statusFilter">Status</label>
-                        <select id="statusFilter">
-                            <option value="">Todos</option>
-                            <option value="A Fazer">A Fazer</option>
-                            <option value="Em Progresso">Em Progresso</option>
-                            <option value="Concluído">Concluído</option>
-                        </select>
-                    </div>
-                    <div class="form-group">
-                        <label for="assigneeFilter">Responsável</label>
-                        <select id="assigneeFilter">
-                            <option value="">Todos</option>
-                        </select>
-                    </div>
-                    <div class="form-group">
-                        <label>Intervalo de datas</label>
-                        <div style="display:flex;gap:8px;">
-                            <input type="date" id="startDateFilter">
-                            <input type="date" id="endDateFilter">
-                        </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-outline" id="cancelFilterBtn">Cancelar</button>
-                        <button type="submit" class="btn btn-primary" id="applyFilterBtn">Aplicar</button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
-
-    <!-- Modal para adicionar um novo membro -->
-    <div id="newMemberModal" class="modal-overlay">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title">Adicionar Membro</h3>
-                <button class="modal-close" id="closeNewMemberModalBtn">&times;</button>
-            </div>
-            <div class="modal-body">
-                <form id="newMemberForm">
-                    <div class="form-group">
-                        <label for="memberName">Nome Completo</label>
-                        <input type="text" id="memberName" name="name" required placeholder="Ex: Ana Mendes">
-                    </div>
-                    <div class="form-group">
-                        <label for="memberRole">Cargo</label>
-                        <input type="text" id="memberRole" name="role" required placeholder="Ex: Desenvolvedor Front-end">
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-outline" id="cancelNewMemberModalBtn">Cancelar</button>
-                        <button type="submit" class="btn btn-green" id="saveMemberBtn">
-                            <span><i class="fas fa-user-plus"></i> Adicionar</span>
-                            <div class="loader"></div>
-                        </button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
-
-    <!-- Modal de Confirmação (Genérico) -->
-    <div id="confirmationModal" class="modal-overlay">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title">Confirmação</h3>
-                <button class="modal-close" id="closeConfirmationModalBtn">&times;</button>
-            </div>
-            <div class="modal-body">
-                <p id="confirmationMessage">Tem certeza que deseja excluir este item?</p>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-outline" id="cancelConfirmationBtn">Cancelar</button>
-                <button type="button" class="btn btn-danger" id="confirmDeletionBtn">
-                    <span>Excluir</span>
-                    <div class="loader"></div>
+        <section id="members" class="tab-view active" aria-labelledby="Cadastro da equipe">
+          <div class="card">
+            <h2>Registrar integrante</h2>
+            <p class="text-sm" style="color: var(--text-light, #4b5563); margin-bottom: 12px;">
+              Cadastre os e-mails e cargos da sua equipe para liberar o acesso automático às tarefas e alertas.
+            </p>
+            <div id="memberStatus" class="status-message" role="status" aria-live="polite"></div>
+            <form id="memberForm">
+              <div>
+                <label for="memberName">
+                  Nome completo
+                </label>
+                <input id="memberName" name="memberName" type="text" placeholder="Ex.: Ana Mendes" autocomplete="name" />
+              </div>
+              <div>
+                <label for="memberEmail">
+                  E-mail da equipe <span class="required" aria-hidden="true">*</span>
+                </label>
+                <input
+                  id="memberEmail"
+                  name="memberEmail"
+                  type="email"
+                  placeholder="nome@suaempresa.com"
+                  autocomplete="email"
+                  required
+                />
+              </div>
+              <div>
+                <label for="memberRole">
+                  Cargo ou função <span class="required" aria-hidden="true">*</span>
+                </label>
+                <input
+                  id="memberRole"
+                  name="memberRole"
+                  type="text"
+                  placeholder="Ex.: Analista de Atendimento"
+                  required
+                />
+              </div>
+              <div class="actions-row">
+                <button type="submit" id="memberSubmitBtn">
+                  <i class="fas fa-user-plus" aria-hidden="true"></i>
+                  Adicionar integrante
                 </button>
+              </div>
+            </form>
+          </div>
+
+          <div class="card">
+            <h2>Minha equipe</h2>
+            <div class="stack" id="myMembersContainer">
+              <div class="empty-state">Cadastre integrantes para montar a sua equipe.</div>
             </div>
-        </div>
+          </div>
+
+          <div class="card" id="sharedTeamsCard" hidden>
+            <h2>Equipes em que participo</h2>
+            <p class="text-sm" style="color: var(--text-light, #4b5563);">
+              Estes são os times que adicionaram seu e-mail. Você tem acesso às tarefas e alertas publicados por eles.
+            </p>
+            <div class="stack" id="sharedTeamsContainer"></div>
+          </div>
+        </section>
+
+        <section id="tasks" class="tab-view" aria-labelledby="Tarefas da equipe">
+          <div class="card">
+            <h2>Registrar tarefa</h2>
+            <p class="text-sm" style="color: var(--text-light, #4b5563); margin-bottom: 12px;">
+              Defina tarefas com data, horário, prioridade e materiais de apoio. Os integrantes cadastrados verão tudo automaticamente.
+            </p>
+            <div id="taskStatus" class="status-message" role="status" aria-live="polite"></div>
+            <form id="taskForm">
+              <div>
+                <label for="taskTitle">
+                  Tarefa <span class="required" aria-hidden="true">*</span>
+                </label>
+                <input id="taskTitle" name="taskTitle" type="text" placeholder="Ex.: Realizar inventário diário" required />
+              </div>
+              <div class="stack" style="grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));">
+                <div>
+                  <label for="taskDate">
+                    Data <span class="required" aria-hidden="true">*</span>
+                  </label>
+                  <input id="taskDate" name="taskDate" type="date" required />
+                </div>
+                <div>
+                  <label for="taskTime">
+                    Horário <span class="required" aria-hidden="true">*</span>
+                  </label>
+                  <input id="taskTime" name="taskTime" type="time" required />
+                </div>
+                <div>
+                  <label for="taskPriority">
+                    Prioridade <span class="required" aria-hidden="true">*</span>
+                  </label>
+                  <select id="taskPriority" name="taskPriority" required>
+                    <option value="alta">Alta</option>
+                    <option value="media">Média</option>
+                    <option value="baixa">Baixa</option>
+                  </select>
+                </div>
+              </div>
+              <div>
+                <label for="taskTips">Dicas e orientações</label>
+                <textarea id="taskTips" name="taskTips" placeholder="Compartilhe detalhes, lembretes ou checklists importantes."></textarea>
+              </div>
+              <div>
+                <label for="taskSupport">Material de apoio</label>
+                <textarea
+                  id="taskSupport"
+                  name="taskSupport"
+                  placeholder="Links, anotações ou referências úteis."
+                ></textarea>
+              </div>
+              <div>
+                <label for="taskResponsible">
+                  Usuário responsável <span class="required" aria-hidden="true">*</span>
+                </label>
+                <select id="taskResponsible" name="taskResponsible" required>
+                  <option value="" disabled selected>Cadastre a equipe para selecionar um responsável</option>
+                </select>
+              </div>
+              <div class="actions-row">
+                <button type="submit" id="taskSubmitBtn">
+                  <i class="fas fa-plus" aria-hidden="true"></i>
+                  Salvar tarefa
+                </button>
+              </div>
+            </form>
+          </div>
+
+          <div class="card">
+            <h2>Tarefas compartilhadas</h2>
+            <div id="tasksContainer" class="stack">
+              <div class="empty-state">As tarefas cadastradas aqui aparecerão para toda a equipe.</div>
+            </div>
+          </div>
+        </section>
+
+        <section id="updates" class="tab-view" aria-labelledby="Atualizações e alertas">
+          <div class="card">
+            <h2>Publicar atualização ou alerta</h2>
+            <p class="text-sm" style="color: var(--text-light, #4b5563); margin-bottom: 12px;">
+              Use esta área para comunicar mudanças importantes, avisos urgentes ou novidades da equipe.
+            </p>
+            <div id="updateStatus" class="status-message" role="status" aria-live="polite"></div>
+            <form id="updateForm">
+              <div>
+                <label for="updateTitle">Título</label>
+                <input id="updateTitle" name="updateTitle" type="text" placeholder="Ex.: Mudanças no processo de expedição" />
+              </div>
+              <div>
+                <label for="updateMessage">
+                  Mensagem <span class="required" aria-hidden="true">*</span>
+                </label>
+                <textarea
+                  id="updateMessage"
+                  name="updateMessage"
+                  placeholder="Descreva a atualização ou alerta."
+                  required
+                ></textarea>
+              </div>
+              <div class="actions-row">
+                <button type="submit" id="updateSubmitBtn">
+                  <i class="fas fa-paper-plane" aria-hidden="true"></i>
+                  Compartilhar comunicado
+                </button>
+              </div>
+            </form>
+          </div>
+
+          <div class="card">
+            <h2>Atualizações recentes</h2>
+            <div id="updatesContainer" class="stack">
+              <div class="empty-state">Nenhuma atualização registrada até o momento.</div>
+            </div>
+          </div>
+        </section>
+      </div>
     </div>
 
-    <!-- Script para Firebase e funcionalidades da UI -->
     <script>window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';</script>
     <script src="shared.js"></script>
     <script type="module" src="firebase-config.js"></script>
-
     <script type="module">
-        
-        // Importa as funções necessárias do Firebase
-        import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
-        import { getAuth, signInWithCustomToken, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
-        import { getFirestore, collection, addDoc, onSnapshot, query, where, updateDoc, doc, deleteDoc, getDocs, setDoc } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
-        import { getStorage, ref, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
-        import { firebaseConfig as defaultFirebaseConfig } from './firebase-config.js';
+      import {
+        initializeApp,
+        getApps,
+        getApp
+      } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js';
+      import {
+        getAuth,
+        signInWithCustomToken,
+        onAuthStateChanged
+      } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js';
+      import {
+        getFirestore,
+        collection,
+        collectionGroup,
+        addDoc,
+        deleteDoc,
+        doc,
+        getDocs,
+        onSnapshot,
+        orderBy,
+        query,
+        serverTimestamp,
+        where
+      } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js';
 
-        // Variáveis globais fornecidas pelo ambiente
-        const appId = typeof __app_id !== 'undefined' ? __app_id : 'equipes';
-                const firebaseConfig = window.firebaseConfig || JSON.parse(typeof __firebase_config !== 'undefined' ? __firebase_config : '{}');
+      const appId = typeof __app_id !== 'undefined' ? __app_id : 'equipes';
+      const firebaseConfig = window.firebaseConfig ||
+        (typeof __firebase_config !== 'undefined' ? JSON.parse(__firebase_config) : null) ||
+        (window.defaultFirebaseConfig || null);
+      const initialAuthToken = typeof __initial_auth_token !== 'undefined' ? __initial_auth_token : null;
 
-        const initialAuthToken = typeof __initial_auth_token !== 'undefined' ? __initial_auth_token : null;
+      const tabButtons = document.querySelectorAll('.tab-nav button');
+      const tabViews = document.querySelectorAll('.tab-view');
+      tabButtons.forEach((btn) => {
+        btn.addEventListener('click', () => {
+          const target = btn.dataset.tab;
+          tabButtons.forEach((b) => b.classList.toggle('active', b === btn));
+          tabViews.forEach((view) => view.classList.toggle('active', view.id === target));
+        });
+      });
 
-        // Elementos do DOM das Vistas
-        const dashboardView = document.getElementById('dashboardView');
-        const myBoardsView = document.getElementById('myBoardsView');
-        const teamView = document.getElementById('teamView');
-        const boardView = document.getElementById('boardView');
-        const navLinks = document.querySelectorAll('.nav-link');
-        const backButtons = document.querySelectorAll('.back-button');
+      const memberForm = document.getElementById('memberForm');
+      const memberStatus = document.getElementById('memberStatus');
+      const memberSubmitBtn = document.getElementById('memberSubmitBtn');
+      const myMembersContainer = document.getElementById('myMembersContainer');
+      const sharedTeamsCard = document.getElementById('sharedTeamsCard');
+      const sharedTeamsContainer = document.getElementById('sharedTeamsContainer');
 
-        // Elementos do DOM do Dashboard
-        const boardsGrid = document.getElementById('boardsGrid');
-        const newBoardBtn = document.getElementById('newBoardBtn');
-        const newBoardModal = document.getElementById('newBoardModal');
-        const boardForm = document.getElementById('boardForm');
-        const boardTitleInput = document.getElementById('boardTitle');
-        const boardColorInput = document.getElementById('boardColor');
-        const boardResponsibleSelect = document.getElementById('boardResponsible');
-        const boardIdInput = document.getElementById('boardIdInput');
-        const newBoardModalTitle = document.getElementById('newBoardModalTitle');
-        const closeNewBoardModalBtn = document.getElementById('closeNewBoardModalBtn');
-        const cancelBoardModalBtn = document.getElementById('cancelBoardModalBtn');
-        const saveBoardBtn = document.getElementById('saveBoardBtn');
-        const userIdDisplay = document.getElementById('userIdDisplay');
+      const taskForm = document.getElementById('taskForm');
+      const taskStatus = document.getElementById('taskStatus');
+      const taskSubmitBtn = document.getElementById('taskSubmitBtn');
+      const taskResponsibleSelect = document.getElementById('taskResponsible');
+      const tasksContainer = document.getElementById('tasksContainer');
 
-        // Elementos do DOM de Equipes
-        const membersGrid = document.getElementById('membersGrid');
-        const addMemberBtn = document.getElementById('addMemberBtn');
-        
-        // Elementos do DOM do Board View
-        const currentBoardTitle = document.getElementById('currentBoardTitle');
-        const boardTableContainer = document.getElementById('boardTableContainer');
-        const newTaskBtn = document.getElementById('newTaskBtn');
-        const newTaskModal = document.getElementById('newTaskModal');
-        const newTaskForm = document.getElementById('newTaskForm');
-        const closeNewTaskModalBtn = document.getElementById('closeNewTaskModalBtn');
-        const cancelNewTaskModalBtn = document.getElementById('cancelNewTaskModalBtn');
-        const saveTaskBtn = document.getElementById('saveTaskBtn');
-        const taskAssigneeSelect = document.getElementById('taskAssignee');
+      const updateForm = document.getElementById('updateForm');
+      const updateStatus = document.getElementById('updateStatus');
+      const updateSubmitBtn = document.getElementById('updateSubmitBtn');
+      const updatesContainer = document.getElementById('updatesContainer');
 
-        // Elementos do DOM de filtros
-        const filterTasksBtn = document.getElementById('filterTasksBtn');
-        const filterModal = document.getElementById('filterModal');
-        const filterForm = document.getElementById('filterForm');
-        const closeFilterModalBtn = document.getElementById('closeFilterModalBtn');
-        const statusFilterSelect = document.getElementById('statusFilter');
-        const assigneeFilterSelect = document.getElementById('assigneeFilter');
-        const startDateFilterInput = document.getElementById('startDateFilter');
-        const endDateFilterInput = document.getElementById('endDateFilter');
-        const cancelFilterBtn = document.getElementById('cancelFilterBtn');
-        
-        // Novos inputs do modal de tarefa
-        const taskTitleInput = document.getElementById('taskTitle');
-        const taskDescriptionInput = document.getElementById('taskDescription');
-        const taskDateInput = document.getElementById('taskDate');
-        const taskQuantityInput = document.getElementById('taskQuantity');
-        const taskFileInput = document.getElementById('taskFile');
-        
-        // Elementos do DOM do Modal de Membros
-        const newMemberModal = document.getElementById('newMemberModal');
-        const newMemberForm = document.getElementById('newMemberForm');
-        const closeNewMemberModalBtn = document.getElementById('closeNewMemberModalBtn');
-        const cancelNewMemberModalBtn = document.getElementById('cancelNewMemberModalBtn');
-        const saveMemberBtn = document.getElementById('saveMemberBtn');
+      let app;
+      let db;
+      let auth;
+      let currentUser = null;
+      let currentEmail = '';
+      let trackedOwners = new Set();
 
-        // Elementos do DOM do Modal de Confirmação
-        const confirmationModal = document.getElementById('confirmationModal');
-        const confirmationMessage = document.getElementById('confirmationMessage');
-        const closeConfirmationModalBtn = document.getElementById('closeConfirmationModalBtn');
-        const cancelConfirmationBtn = document.getElementById('cancelConfirmationBtn');
-        const confirmDeletionBtn = document.getElementById('confirmDeletionBtn');
-        
-        let app, db, auth, storage;
-        let userId = null;
-        let isAuthReady = false;
-        let currentBoardId = null;
-        let members = []; // Array para armazenar os membros da equipe
-        let membersMap = {}; // Objeto para facilitar a busca de membros por ID
-        let tasksCache = []; // Cache das tarefas do quadro atual
-        let currentFilters = { status: '', assigneeId: '', startDate: null, endDate: null };
-        let originalBoardResponsibleId = null;
-        
-        const defaultColumns = ['A Fazer', 'Em Andamento', 'Concluído'];
-        const statusColors = {
-            'A Fazer': '#8c9096',
-            'Em Andamento': '#4262ff',
-            'Concluído': '#00c875'
-        };
+      const ownerInfo = new Map();
+      const membersByOwner = new Map();
+      const tasksByOwner = new Map();
+      const updatesByOwner = new Map();
 
-        // Variáveis para a deleção
-        let itemToDelete = null;
-        let itemTypeToDelete = null;
-        let itemOwnerToDelete = null;
-        let itemResponsibleToDelete = null;
+      const memberUnsubs = new Map();
+      const taskUnsubs = new Map();
+      const updateUnsubs = new Map();
 
-        // Função para mostrar um modal
-        function showModal(modal) {
-            modal.classList.add('visible');
+      function showStatus(element, message, type = 'success') {
+        if (!element) return;
+        element.textContent = message || '';
+        element.classList.remove('status-success', 'status-error', 'show');
+        if (!message) return;
+        element.classList.add(type === 'error' ? 'status-error' : 'status-success', 'show');
+      }
+
+      function setButtonLoading(button, loading) {
+        if (!button) return;
+        button.disabled = loading;
+      }
+
+      function formatDate(date) {
+        if (!date) return 'Sem data definida';
+        return new Intl.DateTimeFormat('pt-BR', {
+          day: '2-digit',
+          month: '2-digit',
+          year: 'numeric'
+        }).format(date);
+      }
+
+      function formatTime(timeString) {
+        if (!timeString) return '';
+        try {
+          const [hour, minute] = timeString.split(':');
+          return `${hour.padStart(2, '0')}:${minute.padStart(2, '0')}`;
+        } catch (e) {
+          return timeString;
+        }
+      }
+
+      function resolveOwnerLabel(ownerUid) {
+        const meta = ownerInfo.get(ownerUid) || {};
+        if (ownerUid === currentUser?.uid) {
+          return 'Minha equipe';
+        }
+        if (meta.label) return meta.label;
+        if (meta.email) return `Equipe de ${meta.email}`;
+        return 'Equipe compartilhada';
+      }
+
+      function resolveMemberName(ownerUid, email) {
+        if (!email) return 'Não atribuído';
+        const normalized = email.toLowerCase();
+        const members = membersByOwner.get(ownerUid) || [];
+        const match = members.find((member) => (member.emailLower || '').toLowerCase() === normalized);
+        if (match) {
+          return match.name || match.email || email;
+        }
+        if (ownerUid === currentUser?.uid && currentUser?.email && currentUser.email.toLowerCase() === normalized) {
+          return 'Você';
+        }
+        return email;
+      }
+
+      function renderMyMembers() {
+        const myMembers = membersByOwner.get(currentUser?.uid) || [];
+        if (!myMembers.length) {
+          myMembersContainer.innerHTML = '<div class="empty-state">Cadastre integrantes para montar a sua equipe.</div>';
+          return;
         }
 
-        // Função para esconder um modal
-        function hideModal(modal) {
-            modal.classList.remove('visible');
-        }
-
-        // Função principal para alternar entre as views
-        function showView(viewId) {
-            // Esconde todas as views
-            const views = document.querySelectorAll('.view');
-            views.forEach(view => view.classList.remove('active'));
-
-            // Mostra a view solicitada
-            const targetView = document.getElementById(viewId);
-            if (targetView) {
-                targetView.classList.add('active');
-            }
-
-            // Remove a classe 'active' de todos os links de navegação
-            navLinks.forEach(link => link.classList.remove('active'));
-
-            // Adiciona a classe 'active' ao link de navegação da view atual
-            const activeNavLink = document.querySelector(`.nav-link[data-view-id="${viewId}"]`);
-            if (activeNavLink) {
-                activeNavLink.classList.add('active');
-            }
-            
-            // Se for a boardView, iniciamos o listener das tarefas
-            if (viewId === 'boardView' && currentBoardId) {
-                setupTasksListener(currentBoardId);
-            }
-        }
-        
-        // Função para abrir a visão de um quadro específico
-        function showBoardView(boardId, boardTitle) {
-            currentBoardId = boardId;
-            currentBoardTitle.innerText = boardTitle;
-            showView('boardView');
-        }
-        
-        // Função para gerar iniciais de um nome
-        function getInitials(name) {
-            if (!name) return '??';
-            const nameParts = name.split(' ');
-            if (nameParts.length > 1) {
-                return (nameParts[0][0] + nameParts[1][0]).toUpperCase();
-            }
-            return nameParts[0][0].toUpperCase();
-        }
-        
-        // Preenche o dropdown de atribuição de tarefas com os membros da equipe
-        function populateAssigneeSelect() {
-            // Limpa e preenche o select no modal de nova tarefa
-            taskAssigneeSelect.innerHTML = '<option value="">Não atribuído</option>';
-            assigneeFilterSelect.innerHTML = '<option value="">Todos</option>';
-            members.forEach(member => {
-                const option = document.createElement('option');
-                option.value = member.id;
-                option.textContent = member.name;
-                taskAssigneeSelect.appendChild(option);
-
-                const filterOption = document.createElement('option');
-                filterOption.value = member.id;
-                filterOption.textContent = member.name;
-                assigneeFilterSelect.appendChild(filterOption);
-            });
-        }
-
-        // Preenche o dropdown de responsável do quadro
-        function populateBoardResponsibleSelect() {
-            if (!boardResponsibleSelect) return;
-            boardResponsibleSelect.innerHTML = '';
-            const meOption = document.createElement('option');
-            meOption.value = userId || '';
-            meOption.textContent = 'Você';
-            boardResponsibleSelect.appendChild(meOption);
-            members.forEach(member => {
-                const option = document.createElement('option');
-                option.value = member.id;
-                option.textContent = member.name;
-                boardResponsibleSelect.appendChild(option);
-            });
-            if (originalBoardResponsibleId) {
-                boardResponsibleSelect.value = originalBoardResponsibleId;
-            }
-        }
-        
-        // Inicializa o Firebase e ouve o estado de autenticação
-        async function initializeFirebase() {
-            // Evita inicializar o Firebase sem as configurações mínimas necessárias.
-            if (!firebaseConfig || !firebaseConfig.projectId) {
-                console.error("Configuração do Firebase ausente ou incompleta.");
-                boardsGrid.innerHTML = '<div class="loading">Configuração do Firebase ausente.</div>';
-                membersGrid.innerHTML = '<div class="loading">Configuração do Firebase ausente.</div>';
-                showView('dashboardView');
-                return;
-            }
-
-            try {
-                app = initializeApp(firebaseConfig);
-                db = getFirestore(app);
-                auth = getAuth(app);
-                storage = getStorage(app);
-
-                if (initialAuthToken) {
-                    await signInWithCustomToken(auth, initialAuthToken);
-                }
-                
-                onAuthStateChanged(auth, (user) => {
-                     if (!user) {
-                        window.location.href = 'index.html?login=1';
-                        return;
-                    }
-
-                    userId = user.uid;
-                    isAuthReady = true;
-                    originalBoardResponsibleId = userId;
-                    userIdDisplay.innerText = `UID do Usuário: ${userId}`;
-                    console.log('User authenticated with UID:', userId);
-
-                    setupBoardsListener();
-                    setupMembersListener();
-                    showView('myBoardsView'); // Mostra a lista de quadros por padrão
-                });
-
-            } catch (e) {
-                console.error("Erro ao inicializar Firebase ou autenticar: ", e);
-                boardsGrid.innerHTML = '<div class="loading">Erro ao carregar os dados. Tente novamente.</div>';
-                showView('dashboardView');
-            }
-        }
-        
-        // Listener em tempo real para os quadros do usuário
-        function setupBoardsListener() {
-            if (!isAuthReady || !userId) return;
-
-            const boardsCollectionRef = collection(db, `artifacts/${appId}/users/${userId}/boards`);
-            
-            onSnapshot(boardsCollectionRef, (snapshot) => {
-                const boards = [];
-                snapshot.forEach(doc => {
-                    boards.push({ id: doc.id, ...doc.data() });
-                });
-                renderBoards(boards);
-                console.log('Quadros atualizados:', boards);
-            }, (error) => {
-                console.error('Erro ao buscar quadros em tempo real:', error);
-                boardsGrid.innerHTML = '<div class="loading">Erro ao carregar os quadros.</div>';
-            });
-        }
-        
-        // Listener em tempo real para os membros da equipe
-        function setupMembersListener() {
-            if (!isAuthReady || !userId) return;
-
-            const membersCollectionRef = collection(db, `artifacts/${appId}/users/${userId}/members`);
-            
-            onSnapshot(membersCollectionRef, (snapshot) => {
-                members = [];
-                membersMap = {};
-                snapshot.forEach(doc => {
-                    const member = { id: doc.id, ...doc.data() };
-                    members.push(member);
-                    membersMap[member.id] = member;
-                });
-                renderMembers(members);
-                populateAssigneeSelect(); // Atualiza o select do modal de tarefas
-                populateBoardResponsibleSelect(); // Atualiza o select de responsável do quadro
-                console.log('Membros da equipe atualizados:', members);
-            }, (error) => {
-                console.error('Erro ao buscar membros em tempo real:', error);
-                membersGrid.innerHTML = '<div class="loading">Erro ao carregar os membros.</div>';
-            });
-        }
-        
-        // Listener em tempo real para as tarefas de um quadro específico
-        function setupTasksListener(boardId) {
-            if (!isAuthReady || !userId || !boardId) return;
-            
-            const tasksCollectionRef = collection(db, `artifacts/${appId}/users/${userId}/tasks`);
-            const q = query(tasksCollectionRef, where("boardId", "==", boardId));
-            
-            onSnapshot(q, (snapshot) => {
-                tasksCache = [];
-                snapshot.forEach(doc => {
-                    tasksCache.push({ id: doc.id, ...doc.data() });
-                });
-                renderTasks(tasksCache);
-                console.log('Tarefas atualizadas para o quadro', boardId, ':', tasksCache);
-            }, (error) => {
-                console.error('Erro ao buscar tarefas em tempo real:', error);
-            });
-        }
-        
-        // Função para renderizar os quadros dinamicamente
-        function renderBoards(boards) {
-            boardsGrid.innerHTML = '';
-            if (boards.length === 0) {
-                boardsGrid.innerHTML = '<div class="loading">Nenhum quadro encontrado. Crie um novo!</div>';
-                return;
-            }
-            
-            boards.forEach(board => {
-                const boardCard = document.createElement('div');
-                boardCard.classList.add('board-card');
-                
-                const boardHeader = document.createElement('div');
-                boardHeader.classList.add('board-header');
-                boardHeader.style.backgroundColor = board.color;
-
-                const boardTitleIcon = document.createElement('div');
-                boardTitleIcon.innerHTML = `<i class="fas fa-briefcase"></i> ${board.title}`;
-                
-                const boardActions = document.createElement('div');
-                boardActions.classList.add('board-actions');
-
-                const editButton = document.createElement('button');
-                editButton.innerHTML = `<i class="fas fa-edit"></i>`;
-                editButton.onclick = (e) => {
-                    e.stopPropagation();
-                    openEditBoardModal(board);
-                };
-
-                const deleteButton = document.createElement('button');
-                deleteButton.innerHTML = `<i class="fas fa-trash-alt"></i>`;
-                deleteButton.onclick = (e) => {
-                    e.stopPropagation(); // Previne a navegação para o board
-                    showConfirmationModal(board.id, 'board', `Tem certeza que deseja excluir o quadro "${board.title}"? Esta ação é irreversível.`, board.ownerId, board.responsibleId);
-                };
-                
-                boardActions.appendChild(editButton);
-                boardActions.appendChild(deleteButton);
-                
-                boardHeader.appendChild(boardTitleIcon);
-                boardHeader.appendChild(boardActions);
-                
-                const boardContent = document.createElement('div');
-                boardContent.classList.add('board-content');
-                boardContent.onclick = () => showBoardView(board.id, board.title);
-                boardContent.innerHTML = `
-                    <div class="board-title">${board.description || 'Nenhuma descrição'}</div>
-                    <div class="board-stats">
-                        <div><i class="fas fa-tasks"></i> 0 tarefas</div>
-                        <div><i class="fas fa-check-circle"></i> 0 concluídas</div>
-                    </div>
-                    <div class="board-members">
-                        <div class="member-avatar">AM</div>
-                        <div class="member-avatar">+1</div>
-                    </div>
-                `;
-
-                boardCard.appendChild(boardHeader);
-                boardCard.appendChild(boardContent);
-                
-                boardsGrid.appendChild(boardCard);
-            });
-        }
-        
-        // Abre o modal de edição de quadro
-        function openEditBoardModal(board) {
-            newBoardModalTitle.innerText = 'Editar Quadro';
-            boardIdInput.value = board.id;
-            boardTitleInput.value = board.title;
-            boardColorInput.value = board.color;
-            boardResponsibleSelect.value = board.responsibleId || userId;
-            originalBoardResponsibleId = board.responsibleId || userId;
-            saveBoardBtn.querySelector('span').innerHTML = '<i class="fas fa-save"></i> Salvar';
-            showModal(newBoardModal);
-        }
-        
-        // Função para renderizar os membros da equipe dinamicamente
-        function renderMembers(teamMembers) {
-            membersGrid.innerHTML = '';
-            if (teamMembers.length === 0) {
-                membersGrid.innerHTML = '<div class="loading">Nenhum membro na equipe. Adicione um!</div>';
-                return;
-            }
-            
-            teamMembers.forEach(member => {
-                const memberCard = document.createElement('div');
-                memberCard.classList.add('member-card');
-                
-                memberCard.innerHTML = `
-                    <div class="member-avatar-lg">${getInitials(member.name)}</div>
-                    <div class="member-name">${member.name}</div>
-                    <div class="member-role">${member.role}</div>
-                    <div class="member-stats">
-                        <div>
-                            <div class="stat-value">0</div>
-                            <div>Projetos</div>
-                        </div>
-                        <div>
-                            <div class="stat-value">0</div>
-                            <div>Tarefas</div>
-                        </div>
-                    </div>
-                    <div class="member-card-actions">
-                        <button class="delete-member-btn" data-member-id="${member.id}">
-                            <i class="fas fa-trash-alt"></i>
-                        </button>
-                    </div>
-                `;
-                membersGrid.appendChild(memberCard);
-            });
-            
-            document.querySelectorAll('.delete-member-btn').forEach(btn => {
-                btn.addEventListener('click', (e) => {
-                    const memberId = e.currentTarget.dataset.memberId;
-                    const member = members.find(m => m.id === memberId);
-                    if (member) {
-                        showConfirmationModal(memberId, 'member', `Tem certeza que deseja excluir o membro "${member.name}"? Esta ação é irreversível.`);
-                    }
-                });
-            });
-        }
-
-        function applyTaskFilters(tasks) {
-            return tasks.filter(task => {
-                if (currentFilters.status && task.status !== currentFilters.status) return false;
-                if (currentFilters.assigneeId && task.assigneeId !== currentFilters.assigneeId) return false;
-                const taskDate = task.date && task.date.seconds ? new Date(task.date.seconds * 1000) : null;
-                if (currentFilters.startDate && (!taskDate || taskDate < currentFilters.startDate)) return false;
-                if (currentFilters.endDate && (!taskDate || taskDate > currentFilters.endDate)) return false;
-                return true;
-            });
-        }
-
-        // Função para renderizar as tarefas dinamicamente em uma tabela
-        function renderTasks(tasks) {
-            tasks = applyTaskFilters(tasks);
-            boardTableContainer.innerHTML = '';
-            
-            const table = document.createElement('table');
-            table.classList.add('board-table');
-            table.innerHTML = `
-                <thead>
-                    <tr>
-                        <th>Título</th>
-                        <th>Responsável</th>
-                        <th>Status</th>
-                        <th>Data</th>
-                        <th>Arquivos</th>
-                        <th>Quantidade</th>
-                        <th>Última atualização</th>
-                        <th>Ações</th>
-                    </tr>
-                </thead>
-                <tbody></tbody>
+        const rows = myMembers
+          .sort((a, b) => (a.name || a.email || '').localeCompare(b.name || b.email || ''))
+          .map((member) => {
+            const email = member.email || '—';
+            const role = member.role || '—';
+            const name = member.name || member.email || '—';
+            return `
+              <div class="task-card" data-member-id="${member.id}">
+                <header>
+                  <div>
+                    <strong>${name}</strong>
+                    <div style="color: var(--text-light, #4b5563); font-size: 0.9rem;">${email}</div>
+                  </div>
+                  <span class="badge"><i class="fas fa-briefcase"></i>${role}</span>
+                </header>
+                <div class="card-footer">
+                  <span>Adicionado em ${member.createdAt ? formatDate(member.createdAt) : '—'}</span>
+                  <button type="button" data-action="delete-member" data-id="${member.id}">
+                    <i class="fas fa-trash" aria-hidden="true"></i> Remover
+                  </button>
+                </div>
+              </div>
             `;
-            const tableBody = table.querySelector('tbody');
-            
-            if (tasks.length === 0) {
-                tableBody.innerHTML = `<tr><td colspan="8" class="loading">Nenhuma tarefa encontrada.</td></tr>`;
-            } else {
-                tasks.forEach(task => {
-                    const assignee = membersMap[task.assigneeId];
-                    const assigneeName = assignee ? assignee.name : 'Não Atribuído';
-                    const assigneeInitials = assignee ? getInitials(assignee.name) : '??';
-                    const date = task.date && task.date.seconds ? new Date(task.date.seconds * 1000).toLocaleDateString() : 'N/A';
-                    const lastUpdated = task.lastUpdated && task.lastUpdated.seconds ? new Date(task.lastUpdated.seconds * 1000).toLocaleDateString() : 'N/A';
-                    
-                    const row = document.createElement('tr');
-                    
-                    // Célula do Título
-                    const titleCell = document.createElement('td');
-                    titleCell.innerHTML = `
-                        <input type="text" class="editable-input" value="${task.title || ''}" data-task-id="${task.id}" data-field="title">
-                    `;
-                    row.appendChild(titleCell);
-                    
-                    // Célula do Responsável
-                    const assigneeCell = document.createElement('td');
-                    const assigneeSelect = document.createElement('select');
-                    assigneeSelect.classList.add('editable-select');
-                    assigneeSelect.dataset.taskId = task.id;
-                    assigneeSelect.dataset.field = 'assigneeId';
-                    assigneeSelect.innerHTML = '<option value="">Não Atribuído</option>';
-                    members.forEach(member => {
-                        const option = document.createElement('option');
-                        option.value = member.id;
-                        option.textContent = member.name;
-                        if (task.assigneeId === member.id) {
-                            option.selected = true;
-                        }
-                        assigneeSelect.appendChild(option);
-                    });
-                    assigneeSelect.addEventListener('change', async (e) => {
-                        await updateTaskField(task.id, 'assigneeId', e.target.value);
-                    });
-                    assigneeCell.appendChild(assigneeSelect);
-                    row.appendChild(assigneeCell);
+          })
+          .join('');
 
-                    // Célula do Status
-                    const statusCell = document.createElement('td');
-                    const statusSelect = document.createElement('select');
-                    statusSelect.classList.add('editable-select', 'status-select');
-                    statusSelect.classList.add((task.status || 'A Fazer').toLowerCase().replace(' ', '-'));
-                    statusSelect.dataset.taskId = task.id;
-                    statusSelect.dataset.field = 'status';
-                    defaultColumns.forEach(status => {
-                        const option = document.createElement('option');
-                        option.value = status;
-                        option.textContent = status;
-                        if (task.status === status) {
-                            option.selected = true;
-                        }
-                        statusSelect.appendChild(option);
-                    });
-                    statusSelect.style.backgroundColor = statusColors[task.status || 'A Fazer'] || '#ccc';
-                    statusSelect.addEventListener('change', async (e) => {
-                        await updateTaskField(task.id, 'status', e.target.value);
-                        e.target.style.backgroundColor = statusColors[e.target.value] || '#ccc';
-                    });
-                    statusCell.appendChild(statusSelect);
-                    row.appendChild(statusCell);
-                    
-                    // Célula da Data
-                    const dateCell = document.createElement('td');
-                    dateCell.innerHTML = `<input type="date" class="editable-input" value="${task.date && task.date.seconds ? new Date(task.date.seconds * 1000).toISOString().split('T')[0] : ''}" data-task-id="${task.id}" data-field="date">`;
-                    dateCell.querySelector('input').addEventListener('change', async (e) => {
-                        await updateTaskField(task.id, 'date', new Date(e.target.value));
-                    });
-                    row.appendChild(dateCell);
-                    
-                    // Célula de Arquivos
-                    const filesCell = document.createElement('td');
-                    filesCell.classList.add('file-cell');
-                    if (task.fileURL) {
-                        filesCell.innerHTML = `<a href="${task.fileURL}" target="_blank"><i class="fas fa-file-pdf file-icon"></i></a>`;
-                    } else {
-                        filesCell.textContent = '—';
-                    }
-                    row.appendChild(filesCell);
+        myMembersContainer.innerHTML = rows;
+      }
 
-                    // Célula da Quantidade
-                    const quantityCell = document.createElement('td');
-                    quantityCell.innerHTML = `<input type="number" class="editable-input" value="${task.quantity || ''}" data-task-id="${task.id}" data-field="quantity" min="1">`;
-                    row.appendChild(quantityCell);
-                    
-                    // Célula da Última atualização
-                    const lastUpdatedCell = document.createElement('td');
-                    lastUpdatedCell.textContent = lastUpdated;
-                    row.appendChild(lastUpdatedCell);
-                    
-                    // Célula de Ações
-                    const actionsCell = document.createElement('td');
-                    actionsCell.classList.add('task-actions');
-                    const deleteButton = document.createElement('button');
-                    deleteButton.innerHTML = `<i class="fas fa-trash-alt"></i>`;
-                    deleteButton.onclick = (e) => {
-                        showConfirmationModal(task.id, 'task', `Tem certeza que deseja excluir a tarefa "${task.title}"?`);
-                    };
-                    actionsCell.appendChild(deleteButton);
-                    row.appendChild(actionsCell);
-                    
-                    tableBody.appendChild(row);
-                });
-            }
-            
-            boardTableContainer.appendChild(table);
+      function renderSharedTeams() {
+        const owners = Array.from(trackedOwners).filter((ownerUid) => ownerUid !== currentUser?.uid);
+        if (!owners.length) {
+          sharedTeamsCard.hidden = true;
+          sharedTeamsContainer.innerHTML = '';
+          return;
+        }
 
-            // Adiciona event listeners para os inputs editáveis
-            document.querySelectorAll('.editable-input').forEach(input => {
-                input.addEventListener('change', async (e) => {
-                    const taskId = e.target.dataset.taskId;
-                    const field = e.target.dataset.field;
-                    const value = e.target.value;
-                    await updateTaskField(taskId, field, value);
-                });
+        sharedTeamsCard.hidden = false;
+        sharedTeamsContainer.innerHTML = owners
+          .map((ownerUid) => {
+            const members = membersByOwner.get(ownerUid) || [];
+            const meta = ownerInfo.get(ownerUid) || {};
+            const memberList = members
+              .map((member) => {
+                const role = member.role || '—';
+                const email = member.email || '—';
+                const name = member.name || email;
+                return `<li><strong>${name}</strong> — ${role} (${email})</li>`;
+              })
+              .join('');
+
+            return `
+              <div class="task-card">
+                <header>
+                  <div>
+                    <strong>${resolveOwnerLabel(ownerUid)}</strong>
+                    ${meta.email ? `<div class="tag"><i class="fas fa-envelope"></i>${meta.email}</div>` : ''}
+                  </div>
+                </header>
+                <div>
+                  ${memberList ? `<ul class="stack" style="padding-left: 18px;">${memberList}</ul>` : '<div class="empty-state">Nenhum integrante listado.</div>'}
+                </div>
+              </div>
+            `;
+          })
+          .join('');
+      }
+
+      function priorityBadge(priority) {
+        const normalized = (priority || '').toLowerCase();
+        if (normalized === 'alta') return '<span class="badge high"><i class="fas fa-circle-exclamation"></i>Alta</span>';
+        if (normalized === 'media') return '<span class="badge medium"><i class="fas fa-exclamation"></i>Média</span>';
+        return '<span class="badge low"><i class="fas fa-check"></i>Baixa</span>';
+      }
+
+      function renderTasks() {
+        const owners = Array.from(trackedOwners);
+        if (!owners.length) {
+          tasksContainer.innerHTML = '<div class="empty-state">As tarefas cadastradas aqui aparecerão para toda a equipe.</div>';
+          return;
+        }
+
+        const sections = owners
+          .map((ownerUid) => {
+            const tasks = (tasksByOwner.get(ownerUid) || []).slice().sort((a, b) => {
+              const aDate = a.dueDate ? new Date(`${a.dueDate}T${a.dueTime || '00:00'}`) : null;
+              const bDate = b.dueDate ? new Date(`${b.dueDate}T${b.dueTime || '00:00'}`) : null;
+              if (aDate && bDate) return aDate - bDate;
+              if (aDate) return -1;
+              if (bDate) return 1;
+              return (b.createdAt?.getTime?.() || 0) - (a.createdAt?.getTime?.() || 0);
             });
+
+            const cards = tasks
+              .map((task) => {
+                const dueDate = task.dueDate ? new Date(`${task.dueDate}T00:00:00`) : null;
+                const material = task.supportMaterial ? `<div><strong>Material:</strong> ${task.supportMaterial.replace(/\n
+/g, '<br>')}</div>` : '';
+                const tips = task.tips ? `<div><strong>Dicas:</strong> ${task.tips.replace(/\n
+/g, '<br>')}</div>` : '';
+                const responsible = resolveMemberName(ownerUid, task.responsibleEmail);
+
+                return `
+                  <article class="task-card" data-task-id="${task.id}" data-owner="${ownerUid}">
+                    <header>
+                      <div>
+                        <h3 style="margin: 0 0 4px;">${task.title || 'Tarefa sem título'}</h3>
+                        <div class="tag"><i class="fas fa-user"></i>${responsible}</div>
+                      </div>
+                      ${priorityBadge(task.priority)}
+                    </header>
+                    <div class="stack">
+                      <div><strong>Data:</strong> ${task.dueDate ? formatDate(dueDate) : 'Sem data'}</div>
+                      <div><strong>Horário:</strong> ${formatTime(task.dueTime)}</div>
+                      ${tips}
+                      ${material}
+                    </div>
+                    <div class="card-footer">
+                      <span>Registrado por ${task.createdBy || 'Equipe'}${task.createdAt ? ` em ${formatDate(task.createdAt)}` : ''}</span>
+                      ${ownerUid === currentUser?.uid ? `<button type="button" data-action="delete-task" data-id="${task.id}">Excluir</button>` : ''}
+                    </div>
+                  </article>
+                `;
+              })
+              .join('');
+
+            return `
+              <section class="stack">
+                <h3>${resolveOwnerLabel(ownerUid)}</h3>
+                ${cards || '<div class="empty-state">Nenhuma tarefa cadastrada para esta equipe.</div>'}
+              </section>
+            `;
+          })
+          .join('');
+
+        tasksContainer.innerHTML = sections || '<div class="empty-state">As tarefas cadastradas aqui aparecerão para toda a equipe.</div>';
+      }
+
+      function renderUpdates() {
+        const owners = Array.from(trackedOwners);
+        if (!owners.length) {
+          updatesContainer.innerHTML = '<div class="empty-state">Nenhuma atualização registrada até o momento.</div>';
+          return;
         }
-        
-        async function updateTaskField(taskId, field, value) {
-            if (!isAuthReady || !userId) return;
-            try {
-                const taskRef = doc(db, `artifacts/${appId}/users/${userId}/tasks`, taskId);
-                // Prepara os dados para atualização, incluindo a data da última atualização
-                const updateData = { [field]: value, lastUpdated: new Date() };
 
-                await updateDoc(taskRef, updateData);
-                console.log(`Campo ${field} da tarefa ${taskId} atualizado para: ${value}`);
-            } catch (error) {
-                console.error("Erro ao atualizar o campo da tarefa:", error);
-            }
-        }
-
-        // Modal de confirmação genérico
-        function showConfirmationModal(id, type, message, ownerId = null, responsibleId = null) {
-            itemToDelete = id;
-            itemTypeToDelete = type;
-            itemOwnerToDelete = ownerId;
-            itemResponsibleToDelete = responsibleId;
-            confirmationMessage.textContent = message;
-            showModal(confirmationModal);
-        }
-
-        // Deleção de item
-        async function deleteItem() {
-            if (!itemToDelete || !itemTypeToDelete) return;
-
-            confirmDeletionBtn.classList.add('loading');
-            
-            try {
-                if (itemTypeToDelete === 'board') {
-                    const usersToClean = new Set([userId]);
-                    if (itemOwnerToDelete) usersToClean.add(itemOwnerToDelete);
-                    if (itemResponsibleToDelete) usersToClean.add(itemResponsibleToDelete);
-
-                    for (const uid of usersToClean) {
-                        const tasksRef = collection(db, `artifacts/${appId}/users/${uid}/tasks`);
-                        const q = query(tasksRef, where("boardId", "==", itemToDelete));
-                        const querySnapshot = await getDocs(q);
-                        const deletions = [];
-                        querySnapshot.forEach(docSnap => {
-                            deletions.push(deleteDoc(docSnap.ref));
-                        });
-                        await Promise.all(deletions);
-                        await deleteDoc(doc(db, `artifacts/${appId}/users/${uid}/boards`, itemToDelete));
-                    }
-                    console.log(`Quadro ${itemToDelete} e suas tarefas associadas foram deletados.`);
-                    showView('myBoardsView'); // Retorna à vista de quadros
-                } else if (itemTypeToDelete === 'task') {
-                    await deleteDoc(doc(db, `artifacts/${appId}/users/${userId}/tasks`, itemToDelete));
-                    console.log(`Tarefa ${itemToDelete} deletada.`);
-                } else if (itemTypeToDelete === 'member') {
-                    // TODO: Adicionar lógica para remover atribuição de tarefas antes de deletar o membro
-                    await deleteDoc(doc(db, `artifacts/${appId}/users/${userId}/members`, itemToDelete));
-                    console.log(`Membro ${itemToDelete} deletado.`);
-                }
-            } catch (error) {
-                console.error(`Erro ao deletar o item ${itemToDelete} do tipo ${itemTypeToDelete}:`, error);
-            } finally {
-                confirmDeletionBtn.classList.remove('loading');
-                hideModal(confirmationModal);
-                itemToDelete = null;
-                itemTypeToDelete = null;
-                itemOwnerToDelete = null;
-                itemResponsibleToDelete = null;
-            }
-        }
-        
-        // Lida com o envio do formulário para criar ou editar um novo quadro
-        boardForm.addEventListener('submit', async (e) => {
-            e.preventDefault();
-
-            saveBoardBtn.classList.add('loading');
-
-            let boardId = boardIdInput.value;
-            const title = boardTitleInput.value;
-            const color = boardColorInput.value;
-            const responsibleId = boardResponsibleSelect.value || userId;
-
-            if (!title) {
-                console.error('O título do quadro é obrigatório.');
-                saveBoardBtn.classList.remove('loading');
-                return;
-            }
-
-            try {
-                if (!boardId) {
-                    boardId = doc(collection(db, `artifacts/${appId}/users/${userId}/boards`)).id;
-                }
-
-                const boardData = {
-                    title: title,
-                    description: `Quadro de equipe para ${title}`,
-                    color: color,
-                    ownerId: userId,
-                    responsibleId: responsibleId,
-                };
-                if (!boardIdInput.value) {
-                    boardData.createdAt = new Date();
-                }
-
-                const boardRefCreator = doc(db, `artifacts/${appId}/users/${userId}/boards`, boardId);
-                await setDoc(boardRefCreator, boardData, { merge: true });
-
-                if (responsibleId !== userId) {
-                    const boardRefResp = doc(db, `artifacts/${appId}/users/${responsibleId}/boards`, boardId);
-                    await setDoc(boardRefResp, boardData, { merge: true });
-                }
-
-                if (boardIdInput.value && originalBoardResponsibleId && originalBoardResponsibleId !== responsibleId && originalBoardResponsibleId !== userId) {
-                    await deleteDoc(doc(db, `artifacts/${appId}/users/${originalBoardResponsibleId}/boards`, boardId));
-                }
-
-                hideModal(newBoardModal);
-                boardForm.reset();
-                boardResponsibleSelect.value = userId;
-                originalBoardResponsibleId = userId;
-            } catch (e) {
-                console.error('Erro ao salvar o quadro: ', e);
-            } finally {
-                saveBoardBtn.classList.remove('loading');
-                saveBoardBtn.querySelector('span').innerHTML = '<i class="fas fa-plus"></i> Criar Quadro';
-            }
-        });
-        
-        // Lida com o envio do formulário para criar uma nova tarefa (LÓGICA ATUALIZADA)
-        newTaskForm.addEventListener('submit', async (e) => {
-            e.preventDefault();
-            
-            saveTaskBtn.classList.add('loading');
-
-            const title = taskTitleInput.value;
-            const description = taskDescriptionInput.value;
-            const assigneeId = taskAssigneeSelect.value;
-            const date = taskDateInput.value;
-            const quantity = taskQuantityInput.value;
-            const file = taskFileInput.files[0];
-            
-            if (!title) {
-                console.error('O título da tarefa é obrigatório.');
-                saveTaskBtn.classList.remove('loading');
-                return;
-            }
-            
-            const newTaskData = {
-                title: title,
-                description: description,
-                status: 'A Fazer',
-                boardId: currentBoardId,
-                assigneeId: assigneeId,
-                date: date ? new Date(date) : null, // Salva a data, se houver
-                quantity: quantity ? parseInt(quantity) : 1, // Salva a quantidade
-                lastUpdated: new Date(),
-                fileName: file ? file.name : null,
-                fileURL: null,
-            };
-
-            try {
-                const tasksCollectionRef = collection(db, `artifacts/${appId}/users/${userId}/tasks`);
-                const docRef = await addDoc(tasksCollectionRef, newTaskData);
-
-                if (file) {
-                    const storageRef = ref(storage, `tasks/${userId}/${docRef.id}/${file.name}`);
-                    await uploadBytes(storageRef, file);
-                    const downloadURL = await getDownloadURL(storageRef);
-                    await updateDoc(docRef, { fileURL: downloadURL });
-                }
-
-                console.log('Nova tarefa adicionada com sucesso:', newTaskData);
-                hideModal(newTaskModal);
-                newTaskForm.reset();
-            } catch (e) {
-                console.error('Erro ao adicionar a tarefa: ', e);
-            } finally {
-                saveTaskBtn.classList.remove('loading');
-            }
-        });
-        
-        // Lida com o envio do formulário para adicionar um novo membro
-        newMemberForm.addEventListener('submit', async (e) => {
-            e.preventDefault();
-            
-            saveMemberBtn.classList.add('loading');
-            
-            const name = newMemberForm.elements['memberName'].value;
-            const role = newMemberForm.elements['memberRole'].value;
-            
-            if (!name || !role) {
-                console.error('Nome e cargo do membro são obrigatórios.');
-                saveMemberBtn.classList.remove('loading');
-                return;
-            }
-            
-            const newMemberData = {
-                name: name,
-                role: role,
-            };
-            
-            try {
-                const membersCollectionRef = collection(db, `artifacts/${appId}/users/${userId}/members`);
-                await addDoc(membersCollectionRef, newMemberData);
-                
-                console.log('Novo membro adicionado com sucesso:', newMemberData);
-                hideModal(newMemberModal);
-                newMemberForm.reset();
-            } catch (e) {
-                console.error('Erro ao adicionar o membro: ', e);
-            } finally {
-                saveMemberBtn.classList.remove('loading');
-            }
-        });
-        
-        // Event listeners para os botões dos modais
-        newBoardBtn.addEventListener('click', () => {
-            newBoardModalTitle.innerText = 'Criar Novo Quadro';
-            boardIdInput.value = '';
-            boardForm.reset();
-            boardResponsibleSelect.value = userId;
-            originalBoardResponsibleId = userId;
-            saveBoardBtn.querySelector('span').innerHTML = '<i class="fas fa-plus"></i> Criar Quadro';
-            showModal(newBoardModal);
-        });
-        closeNewBoardModalBtn.addEventListener('click', () => hideModal(newBoardModal));
-        cancelBoardModalBtn.addEventListener('click', () => hideModal(newBoardModal));
-
-        newTaskBtn.addEventListener('click', () => showModal(newTaskModal));
-        closeNewTaskModalBtn.addEventListener('click', () => hideModal(newTaskModal));
-        cancelNewTaskModalBtn.addEventListener('click', () => hideModal(newTaskModal));
-
-        filterTasksBtn.addEventListener('click', () => showModal(filterModal));
-        closeFilterModalBtn.addEventListener('click', () => hideModal(filterModal));
-        cancelFilterBtn.addEventListener('click', () => hideModal(filterModal));
-        filterForm.addEventListener('submit', (e) => {
-            e.preventDefault();
-            currentFilters.status = statusFilterSelect.value;
-            currentFilters.assigneeId = assigneeFilterSelect.value;
-            currentFilters.startDate = startDateFilterInput.value ? new Date(startDateFilterInput.value) : null;
-            currentFilters.endDate = endDateFilterInput.value ? new Date(endDateFilterInput.value) : null;
-            renderTasks(tasksCache);
-            hideModal(filterModal);
-        });
-
-        addMemberBtn.addEventListener('click', () => showModal(newMemberModal));
-        closeNewMemberModalBtn.addEventListener('click', () => hideModal(newMemberModal));
-        cancelNewMemberModalBtn.addEventListener('click', () => hideModal(newMemberModal));
-        
-        confirmDeletionBtn.addEventListener('click', deleteItem);
-        closeConfirmationModalBtn.addEventListener('click', () => hideModal(confirmationModal));
-        cancelConfirmationBtn.addEventListener('click', () => hideModal(confirmationModal));
-
-        // Adiciona os event listeners para os links de navegação e botões de voltar
-        navLinks.forEach(link => {
-            link.addEventListener('click', (e) => {
-                e.preventDefault();
-                const viewId = link.getAttribute('data-view-id');
-                if (viewId) {
-                    showView(viewId);
-                }
+        const sections = owners
+          .map((ownerUid) => {
+            const updates = (updatesByOwner.get(ownerUid) || []).slice().sort((a, b) => {
+              const aDate = a.createdAt?.getTime?.() || 0;
+              const bDate = b.createdAt?.getTime?.() || 0;
+              return bDate - aDate;
             });
+
+            const cards = updates
+              .map((update) => {
+                const createdAt = update.createdAt ? formatDate(update.createdAt) : '—';
+                return `
+                  <article class="update-card" data-update-id="${update.id}" data-owner="${ownerUid}">
+                    <header>
+                      <div>
+                        <h3 style="margin: 0 0 4px;">${update.title || 'Atualização'}</h3>
+                        <div class="tag"><i class="fas fa-user"></i>${update.createdBy || 'Equipe'}</div>
+                      </div>
+                    </header>
+                    <div>${(update.message || '').replace(/\n
+/g, '<br>')}</div>
+                    <div class="card-footer">
+                      <span>Publicado em ${createdAt}</span>
+                      ${ownerUid === currentUser?.uid ? `<button type="button" data-action="delete-update" data-id="${update.id}">Excluir</button>` : ''}
+                    </div>
+                  </article>
+                `;
+              })
+              .join('');
+
+            return `
+              <section class="stack">
+                <h3>${resolveOwnerLabel(ownerUid)}</h3>
+                ${cards || '<div class="empty-state">Nenhum comunicado foi compartilhado ainda.</div>'}
+              </section>
+            `;
+          })
+          .join('');
+
+        updatesContainer.innerHTML = sections || '<div class="empty-state">Nenhuma atualização registrada até o momento.</div>';
+      }
+
+      function updateResponsibleOptions() {
+        if (!taskResponsibleSelect) return;
+        const myMembers = membersByOwner.get(currentUser?.uid) || [];
+        const currentUserEmail = currentUser?.email || '';
+        const options = [
+          '<option value="">Selecione um responsável</option>'
+        ];
+
+        const normalizedEmails = new Set();
+        myMembers.forEach((member) => {
+          if (!member.email) return;
+          const normalized = member.email.toLowerCase();
+          if (normalizedEmails.has(normalized)) return;
+          normalizedEmails.add(normalized);
+          const label = `${member.name || member.email} — ${member.role || 'Sem cargo'}`;
+          options.push(`<option value="${member.email}">${label}</option>`);
         });
 
-        backButtons.forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const viewId = btn.getAttribute('data-view-id');
-                if (viewId) {
-                    showView(viewId);
-                }
+        if (currentUserEmail) {
+          const normalized = currentUserEmail.toLowerCase();
+          if (!normalizedEmails.has(normalized)) {
+            options.push(`<option value="${currentUserEmail}">${currentUserEmail} (Você)</option>`);
+          }
+        }
+
+        taskResponsibleSelect.innerHTML = options.join('');
+      }
+
+      function extractOwnerUidFromPath(path) {
+        const segments = path.split('/');
+        const index = segments.indexOf('users');
+        if (index >= 0 && segments.length > index + 1) {
+          return segments[index + 1];
+        }
+        return null;
+      }
+
+      function ensureOwnerMeta(ownerUid, meta = {}) {
+        const currentMeta = ownerInfo.get(ownerUid) || {};
+        ownerInfo.set(ownerUid, { ...currentMeta, ...meta });
+      }
+
+      function subscribeToOwnerCollections(ownerUid) {
+        if (!db) return;
+        if (!memberUnsubs.has(ownerUid)) {
+          const membersRef = collection(db, 'artifacts', appId, 'users', ownerUid, 'members');
+          const membersQuery = query(membersRef, orderBy('createdAt', 'desc'));
+          const unsub = onSnapshot(membersQuery, (snapshot) => {
+            const members = snapshot.docs.map((docSnap) => {
+              const data = docSnap.data();
+              const createdAt = data.createdAt?.toDate?.() || null;
+              if (data.ownerUid && data.ownerEmail) {
+                ensureOwnerMeta(data.ownerUid, { email: data.ownerEmail });
+              }
+              return {
+                id: docSnap.id,
+                name: data.name || '',
+                email: data.email || '',
+                emailLower: (data.emailLower || data.email || '').toLowerCase(),
+                role: data.role || '',
+                createdAt,
+              };
             });
-        });
+            membersByOwner.set(ownerUid, members);
+            if (ownerUid === currentUser?.uid) {
+              updateResponsibleOptions();
+            }
+            renderMyMembers();
+            renderSharedTeams();
+            renderTasks();
+          }, (error) => {
+            console.error('Erro ao acompanhar membros:', error);
+          });
+          memberUnsubs.set(ownerUid, unsub);
+        }
 
-        // Inicia a aplicação Firebase
-        initializeFirebase();
+        if (!taskUnsubs.has(ownerUid)) {
+          const tasksRef = collection(db, 'artifacts', appId, 'users', ownerUid, 'tasks');
+          const tasksQuery = query(tasksRef, orderBy('createdAt', 'desc'));
+          const unsub = onSnapshot(tasksQuery, (snapshot) => {
+            const tasks = snapshot.docs.map((docSnap) => {
+              const data = docSnap.data();
+              const createdAt = data.createdAt?.toDate?.() || null;
+              if (data.ownerUid && data.ownerEmail) {
+                ensureOwnerMeta(data.ownerUid, { email: data.ownerEmail });
+              }
+              return {
+                id: docSnap.id,
+                title: data.title || '',
+                dueDate: data.dueDate || '',
+                dueTime: data.dueTime || '',
+                priority: data.priority || 'baixa',
+                tips: data.tips || '',
+                supportMaterial: data.supportMaterial || '',
+                responsibleEmail: data.responsibleEmail || '',
+                createdBy: data.createdBy || '',
+                createdAt,
+              };
+            });
+            tasksByOwner.set(ownerUid, tasks);
+            renderTasks();
+          }, (error) => {
+            console.error('Erro ao acompanhar tarefas:', error);
+          });
+          taskUnsubs.set(ownerUid, unsub);
+        }
+
+        if (!updateUnsubs.has(ownerUid)) {
+          const updatesRef = collection(db, 'artifacts', appId, 'users', ownerUid, 'updates');
+          const updatesQuery = query(updatesRef, orderBy('createdAt', 'desc'));
+          const unsub = onSnapshot(updatesQuery, (snapshot) => {
+            const updates = snapshot.docs.map((docSnap) => {
+              const data = docSnap.data();
+              const createdAt = data.createdAt?.toDate?.() || null;
+              if (data.ownerUid && data.ownerEmail) {
+                ensureOwnerMeta(data.ownerUid, { email: data.ownerEmail });
+              }
+              return {
+                id: docSnap.id,
+                title: data.title || '',
+                message: data.message || '',
+                createdBy: data.createdBy || '',
+                createdAt,
+              };
+            });
+            updatesByOwner.set(ownerUid, updates);
+            renderUpdates();
+          }, (error) => {
+            console.error('Erro ao acompanhar atualizações:', error);
+          });
+          updateUnsubs.set(ownerUid, unsub);
+        }
+      }
+
+      function unsubscribeFromOwner(ownerUid) {
+        const unsubMembers = memberUnsubs.get(ownerUid);
+        if (unsubMembers) {
+          unsubMembers();
+          memberUnsubs.delete(ownerUid);
+        }
+        const unsubTasks = taskUnsubs.get(ownerUid);
+        if (unsubTasks) {
+          unsubTasks();
+          taskUnsubs.delete(ownerUid);
+        }
+        const unsubUpdates = updateUnsubs.get(ownerUid);
+        if (unsubUpdates) {
+          unsubUpdates();
+          updateUnsubs.delete(ownerUid);
+        }
+        membersByOwner.delete(ownerUid);
+        tasksByOwner.delete(ownerUid);
+        updatesByOwner.delete(ownerUid);
+      }
+
+      function applyOwnerSet(newOwnersSet) {
+        const newOwners = new Set(newOwnersSet);
+        newOwners.forEach((ownerUid) => {
+          if (!trackedOwners.has(ownerUid)) {
+            subscribeToOwnerCollections(ownerUid);
+          }
+        });
+        trackedOwners.forEach((ownerUid) => {
+          if (!newOwners.has(ownerUid)) {
+            unsubscribeFromOwner(ownerUid);
+          }
+        });
+        trackedOwners = newOwners;
+        renderMyMembers();
+        renderSharedTeams();
+        renderTasks();
+        renderUpdates();
+      }
+
+      async function refreshSharedMemberships() {
+        if (!db || !currentEmail) return;
+        try {
+          const membersQuery = query(
+            collectionGroup(db, 'members'),
+            where('emailLower', '==', currentEmail)
+          );
+          const snapshot = await getDocs(membersQuery);
+          const owners = new Set([currentUser.uid]);
+          snapshot.forEach((docSnap) => {
+            const data = docSnap.data();
+            const ownerUid = data.ownerUid || extractOwnerUidFromPath(docSnap.ref.path);
+            if (!ownerUid) return;
+            owners.add(ownerUid);
+            ensureOwnerMeta(ownerUid, {
+              email: data.ownerEmail || undefined,
+              label: data.ownerName ? `Equipe de ${data.ownerName}` : undefined,
+            });
+          });
+          applyOwnerSet(owners);
+        } catch (error) {
+          console.error('Erro ao buscar equipes compartilhadas:', error);
+          showStatus(memberStatus, 'Não foi possível carregar equipes compartilhadas.', 'error');
+        }
+      }
+
+      function initializeAuth() {
+        if (!firebaseConfig || !firebaseConfig.projectId) {
+          showStatus(memberStatus, 'Configuração do Firebase ausente. Contate o suporte.', 'error');
+          return;
+        }
+
+        try {
+          if (!getApps().length) {
+            app = initializeApp(firebaseConfig);
+          } else {
+            app = getApp();
+          }
+          db = getFirestore(app);
+          auth = getAuth(app);
+
+          if (initialAuthToken) {
+            signInWithCustomToken(auth, initialAuthToken).catch((error) => {
+              console.error('Erro ao autenticar com token personalizado:', error);
+            });
+          }
+
+          onAuthStateChanged(auth, (user) => {
+            if (!user) {
+              window.location.href = 'index.html?login=1';
+              return;
+            }
+
+            currentUser = user;
+            currentEmail = (user.email || '').toLowerCase();
+            ensureOwnerMeta(user.uid, {
+              email: user.email || undefined,
+              label: 'Minha equipe'
+            });
+            applyOwnerSet(new Set([user.uid]));
+            refreshSharedMemberships();
+          });
+        } catch (error) {
+          console.error('Erro ao inicializar Firebase:', error);
+          showStatus(memberStatus, 'Não foi possível conectar ao Firebase.', 'error');
+        }
+      }
+
+      memberForm?.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!db || !currentUser) return;
+        const formData = new FormData(memberForm);
+        const name = (formData.get('memberName') || '').toString().trim();
+        const email = (formData.get('memberEmail') || '').toString().trim();
+        const role = (formData.get('memberRole') || '').toString().trim();
+
+        if (!email || !role) {
+          showStatus(memberStatus, 'Informe o e-mail e o cargo do integrante.', 'error');
+          return;
+        }
+
+        const normalizedEmail = email.toLowerCase();
+        const existing = (membersByOwner.get(currentUser.uid) || []).some(
+          (member) => (member.emailLower || '').toLowerCase() === normalizedEmail
+        );
+        if (existing) {
+          showStatus(memberStatus, 'Este e-mail já está cadastrado na equipe.', 'error');
+          return;
+        }
+
+        setButtonLoading(memberSubmitBtn, true);
+        try {
+          await addDoc(collection(db, 'artifacts', appId, 'users', currentUser.uid, 'members'), {
+            name,
+            email,
+            emailLower: normalizedEmail,
+            role,
+            ownerUid: currentUser.uid,
+            ownerEmail: currentUser.email || null,
+            ownerName: currentUser.displayName || null,
+            createdAt: serverTimestamp(),
+          });
+          memberForm.reset();
+          showStatus(memberStatus, 'Integrante cadastrado com sucesso!');
+          updateResponsibleOptions();
+        } catch (error) {
+          console.error('Erro ao adicionar integrante:', error);
+          showStatus(memberStatus, 'Não foi possível cadastrar o integrante.', 'error');
+        } finally {
+          setButtonLoading(memberSubmitBtn, false);
+        }
+      });
+
+      myMembersContainer?.addEventListener('click', async (event) => {
+        const button = event.target.closest('[data-action="delete-member"]');
+        if (!button || !db || !currentUser) return;
+        const memberId = button.dataset.id;
+        if (!memberId) return;
+        if (!confirm('Tem certeza de que deseja remover este integrante?')) return;
+        try {
+          await deleteDoc(doc(db, 'artifacts', appId, 'users', currentUser.uid, 'members', memberId));
+          showStatus(memberStatus, 'Integrante removido.');
+        } catch (error) {
+          console.error('Erro ao remover integrante:', error);
+          showStatus(memberStatus, 'Não foi possível remover o integrante.', 'error');
+        }
+      });
+
+      taskForm?.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!db || !currentUser) return;
+        const formData = new FormData(taskForm);
+        const title = (formData.get('taskTitle') || '').toString().trim();
+        const dueDate = (formData.get('taskDate') || '').toString();
+        const dueTime = (formData.get('taskTime') || '').toString();
+        const priority = (formData.get('taskPriority') || '').toString();
+        const tips = (formData.get('taskTips') || '').toString();
+        const support = (formData.get('taskSupport') || '').toString();
+        const responsible = (formData.get('taskResponsible') || '').toString();
+
+        if (!title || !dueDate || !dueTime || !priority || !responsible) {
+          showStatus(taskStatus, 'Preencha os campos obrigatórios da tarefa.', 'error');
+          return;
+        }
+
+        setButtonLoading(taskSubmitBtn, true);
+        try {
+          await addDoc(collection(db, 'artifacts', appId, 'users', currentUser.uid, 'tasks'), {
+            title,
+            dueDate,
+            dueTime,
+            priority,
+            tips,
+            supportMaterial: support,
+            responsibleEmail: responsible,
+            ownerUid: currentUser.uid,
+            ownerEmail: currentUser.email || null,
+            createdBy: currentUser.email || currentUser.uid,
+            createdAt: serverTimestamp(),
+          });
+          taskForm.reset();
+          updateResponsibleOptions();
+          showStatus(taskStatus, 'Tarefa registrada com sucesso!');
+        } catch (error) {
+          console.error('Erro ao salvar tarefa:', error);
+          showStatus(taskStatus, 'Não foi possível salvar a tarefa.', 'error');
+        } finally {
+          setButtonLoading(taskSubmitBtn, false);
+        }
+      });
+
+      tasksContainer?.addEventListener('click', async (event) => {
+        const button = event.target.closest('[data-action="delete-task"]');
+        if (!button || !db || !currentUser) return;
+        const taskId = button.dataset.id;
+        if (!taskId) return;
+        if (!confirm('Deseja excluir esta tarefa?')) return;
+        try {
+          await deleteDoc(doc(db, 'artifacts', appId, 'users', currentUser.uid, 'tasks', taskId));
+          showStatus(taskStatus, 'Tarefa excluída.');
+        } catch (error) {
+          console.error('Erro ao excluir tarefa:', error);
+          showStatus(taskStatus, 'Não foi possível excluir a tarefa.', 'error');
+        }
+      });
+
+      updateForm?.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!db || !currentUser) return;
+        const formData = new FormData(updateForm);
+        const title = (formData.get('updateTitle') || '').toString().trim();
+        const message = (formData.get('updateMessage') || '').toString().trim();
+        if (!message) {
+          showStatus(updateStatus, 'Escreva a mensagem da atualização.', 'error');
+          return;
+        }
+
+        setButtonLoading(updateSubmitBtn, true);
+        try {
+          await addDoc(collection(db, 'artifacts', appId, 'users', currentUser.uid, 'updates'), {
+            title,
+            message,
+            ownerUid: currentUser.uid,
+            ownerEmail: currentUser.email || null,
+            createdBy: currentUser.email || currentUser.uid,
+            createdAt: serverTimestamp(),
+          });
+          updateForm.reset();
+          showStatus(updateStatus, 'Atualização publicada com sucesso!');
+        } catch (error) {
+          console.error('Erro ao salvar atualização:', error);
+          showStatus(updateStatus, 'Não foi possível publicar a atualização.', 'error');
+        } finally {
+          setButtonLoading(updateSubmitBtn, false);
+        }
+      });
+
+      updatesContainer?.addEventListener('click', async (event) => {
+        const button = event.target.closest('[data-action="delete-update"]');
+        if (!button || !db || !currentUser) return;
+        const updateId = button.dataset.id;
+        if (!updateId) return;
+        if (!confirm('Deseja remover esta atualização?')) return;
+        try {
+          await deleteDoc(doc(db, 'artifacts', appId, 'users', currentUser.uid, 'updates', updateId));
+          showStatus(updateStatus, 'Atualização removida.');
+        } catch (error) {
+          console.error('Erro ao remover atualização:', error);
+          showStatus(updateStatus, 'Não foi possível remover a atualização.', 'error');
+        }
+      });
+
+      window.addEventListener('focus', () => {
+        if (currentUser) {
+          refreshSharedMemberships();
+        }
+      });
+
+      initializeAuth();
     </script>
-  </div>
-</body>
+  </body>
 </html>

--- a/login.js
+++ b/login.js
@@ -110,6 +110,7 @@ const EXPEDICAO_ALLOWED_MENU_IDS = [
   'menu-expedicao',
   'menu-configuracoes',
   'menu-painel-atualizacoes-gerais',
+  'menu-equipes',
 ];
 const SELLER_ALLOWED_MENU_IDS = [
   'menu-seller-expedicao',
@@ -117,6 +118,7 @@ const SELLER_ALLOWED_MENU_IDS = [
   'menu-email-expedicao',
   'menu-configuracao-perfil',
   'menu-catalogo',
+  'menu-equipes',
 ];
 const POSVENDAS_ALLOWED_MENU_IDS = [
   'menu-painel-atualizacoes-gerais',
@@ -124,6 +126,7 @@ const POSVENDAS_ALLOWED_MENU_IDS = [
   'menu-expedicao',
   'menu-acompanhamento-problemas',
   'menu-catalogo',
+  'menu-equipes',
 ];
 
 const EXPEDICAO_ALLOWED_SUBMENU_LINKS = {

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -508,7 +508,6 @@
         href="/equipes.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-equipes"
-        data-perfil="gestor"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary
- replace the equipes page with a unified hub containing tabs for team registration, shared tasks, and updates/alerts
- implement Firestore listeners that expose teams, tasks, and alerts to any authenticated user whose email is registered by a team owner
- expose the Equipes navigation entry to every sidebar profile so all users can reach the new hub

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fb5f8a3e68832a83625737fe489000