### PR TITLE
Grant pós-vendas access to problemas sidebar entry

### DIFF
--- a/login.js
+++ b/login.js
@@ -125,6 +125,7 @@ const POSVENDAS_ALLOWED_MENU_IDS = [
   'menu-acompanhamento-diario',
   'menu-expedicao',
   'menu-acompanhamento-problemas',
+  'menu-acompanhamento',
   'menu-catalogo',
   'menu-equipes',
 ];

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -1261,7 +1261,7 @@
           href="/problemas.html"
           class="sidebar-link flex items-center py-2 px-4 transition-colors"
           id="menu-acompanhamento"
-          data-perfil="usuario,gestor"
+          data-perfil="usuario,gestor,posvendas"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary
- allow the Problemas sidebar link to be visible for pós-vendas profiles
- permit pós-vendas users to access the problemas menu via the allowed menu list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb69f4e604832ab8eb9eee34e62a41