### PR TITLE
Add sampling cards for top SKUs on financial dashboard

### DIFF
--- a/financeiro.html
+++ b/financeiro.html
@@ -1,107 +1,188 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="pt-BR">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Financeiro</title>
-    <link rel="manifest" href="financeiro-manifest.json">
-  <meta name="theme-color" content="#6366F1">
-  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/styles.css?v=20240826">
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-</head>
-<body class="bg-gray-100 text-gray-800">
-  <div class="app-container">
-  <div id="sidebar-container"></div>
-  <div id="navbar-container"></div>
-  <main class="main-content p-4 space-y-4">
-    <div class="card p-4 flex flex-wrap items-center gap-4">
-      <div class="flex items-center gap-2">
-        <button type="button" id="usuarioIcon" class="text-blue-500 focus:outline-none">
-          <i class="fa fa-user"></i>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Financeiro</title>
+    <link rel="manifest" href="financeiro-manifest.json" />
+    <meta name="theme-color" content="#6366F1" />
+    <link
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="css/styles.css?v=20240826" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  </head>
+  <body class="bg-gray-100 text-gray-800">
+    <div class="app-container">
+      <div id="sidebar-container"></div>
+      <div id="navbar-container"></div>
+      <main class="main-content p-4 space-y-4">
+        <div class="card p-4 flex flex-wrap items-center gap-4">
+          <div class="flex items-center gap-2">
+            <button
+              type="button"
+              id="usuarioIcon"
+              class="text-blue-500 focus:outline-none"
+            >
+              <i class="fa fa-user"></i>
+            </button>
+            <div class="flex flex-col">
+              <label for="usuarioFiltro" class="text-xs font-medium"
+                >Usuário</label
+              >
+              <select
+                id="usuarioFiltro"
+                class="border rounded p-2 text-sm"
+              ></select>
+            </div>
+          </div>
+          <div class="flex items-center gap-2">
+            <button
+              type="button"
+              id="mesIcon"
+              class="text-blue-500 focus:outline-none"
+            >
+              <i class="fa fa-calendar"></i>
+            </button>
+            <div class="flex flex-col">
+              <label for="mesFiltro" class="text-xs font-medium">Mês</label>
+              <input
+                type="month"
+                id="mesFiltro"
+                class="border rounded p-2 text-sm"
+              />
+            </div>
+          </div>
+        </div>
+
+        <button id="installAppBtn" class="btn btn-primary text-sm hidden">
+          Instalar aplicativo
         </button>
-        <div class="flex flex-col">
-          <label for="usuarioFiltro" class="text-xs font-medium">Usuário</label>
-          <select id="usuarioFiltro" class="border rounded p-2 text-sm"></select>
+
+        <h3 id="contexto" class="text-sm text-gray-500"></h3>
+        <h3 id="dataAtual" class="text-sm text-gray-500"></h3>
+
+        <div id="metaSection" class="hidden flex flex-wrap gap-2 items-end">
+          <div>
+            <label for="metaValor" class="text-sm font-medium"
+              >Meta Mensal (R$)</label
+            >
+            <input
+              type="number"
+              id="metaValor"
+              class="border rounded p-2"
+              placeholder="0"
+            />
+          </div>
+          <button id="salvarMeta" class="btn btn-primary text-sm">
+            Salvar Meta
+          </button>
         </div>
-      </div>
-      <div class="flex items-center gap-2">
-        <button type="button" id="mesIcon" class="text-blue-500 focus:outline-none">
-          <i class="fa fa-calendar"></i>
-        </button>
-        <div class="flex flex-col">
-          <label for="mesFiltro" class="text-xs font-medium">Mês</label>
-          <input type="month" id="mesFiltro" class="border rounded p-2 text-sm" />
+
+        <div
+          id="overviewCards"
+          class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+        ></div>
+
+        <section id="amostragemSection" class="card hidden">
+          <div class="flex flex-col gap-3">
+            <div class="flex flex-wrap items-center justify-between gap-2">
+              <h2 class="text-lg font-semibold text-gray-800">
+                Amostragem de SKUs
+              </h2>
+              <span id="amostragemPeriodo" class="text-sm text-gray-500"></span>
+            </div>
+            <p class="text-xs text-gray-500">
+              Top 10 SKUs mais vendidos dos últimos 15 dias utilizando a sobra
+              real (líquido).
+            </p>
+            <div
+              id="amostragemCards"
+              class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4"
+            ></div>
+            <p id="amostragemEmpty" class="text-sm text-gray-500 hidden">
+              Sem dados de amostragem para os últimos 15 dias.
+            </p>
+          </div>
+        </section>
+
+        <div class="card p-4">
+          <h4 class="text-sm text-gray-500 mb-2">Evolução das Vendas</h4>
+          <canvas id="vendasChart" height="120"></canvas>
+          <div
+            id="financeiroUsuarios"
+            class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mt-4"
+          ></div>
         </div>
-      </div>
+
+        <div id="cardsContainer"></div>
+
+        <section id="saquesGestor" class="card hidden">
+          <div class="card-header flex justify-between items-center">
+            <h2 class="text-xl font-bold">Saques e Comissões</h2>
+            <div class="flex items-center gap-2">
+              <select id="percentualMarcar" class="form-control">
+                <option value="0">0%</option>
+                <option value="0.03">3%</option>
+                <option value="0.04">4%</option>
+                <option value="0.05">5%</option>
+              </select>
+              <button id="btnMarcarPago" class="btn btn-primary text-sm">
+                Marcar como Pago
+              </button>
+            </div>
+          </div>
+          <div
+            id="cardsResumoFinanceiro"
+            class="card-body grid grid-cols-1 md:grid-cols-4 gap-4 text-center"
+          ></div>
+          <p
+            id="faltasTextoFinanceiro"
+            class="px-4 pb-4 text-center text-sm text-gray-600"
+          ></p>
+          <div class="card-body overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-4 py-2">
+                    <input type="checkbox" id="chkSaquesFinanceiro" />
+                  </th>
+                  <th class="px-4 py-2 text-left">Data</th>
+                  <th class="px-4 py-2 text-left">Loja</th>
+                  <th class="px-4 py-2 text-right">Saque</th>
+                  <th class="px-4 py-2 text-right">%</th>
+                  <th class="px-4 py-2 text-right">Comissão</th>
+                  <th class="px-4 py-2 text-center">Status</th>
+                </tr>
+              </thead>
+              <tbody
+                id="tbodySaquesFinanceiro"
+                class="divide-y divide-gray-200"
+              ></tbody>
+            </table>
+          </div>
+          <div
+            class="card-footer text-right text-sm"
+            id="resumoSaquesFinanceiro"
+          ></div>
+        </section>
+      </main>
+      <script>
+        window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';
+        window.CUSTOM_NAVBAR_PATH = '/partials/navbar.html';
+      </script>
+      <script src="shared.js"></script>
+      <script type="module" src="firebase-config.js"></script>
+      <script type="module" src="financeiro.js"></script>
     </div>
-
-        <button id="installAppBtn" class="btn btn-primary text-sm hidden">Instalar aplicativo</button>
-
-    <h3 id="contexto" class="text-sm text-gray-500"></h3>
-    <h3 id="dataAtual" class="text-sm text-gray-500"></h3>
-
-    <div id="metaSection" class="hidden flex flex-wrap gap-2 items-end">
-      <div>
-        <label for="metaValor" class="text-sm font-medium">Meta Mensal (R$)</label>
-        <input type="number" id="metaValor" class="border rounded p-2" placeholder="0" />
-      </div>
-      <button id="salvarMeta" class="btn btn-primary text-sm">Salvar Meta</button>
-    </div>
-
-    <div id="overviewCards" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
-
-    <div class="card p-4">
-      <h4 class="text-sm text-gray-500 mb-2">Evolução das Vendas</h4>
-      <canvas id="vendasChart" height="120"></canvas>
-      <div id="financeiroUsuarios" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mt-4"></div>
-    </div>
-
-    <div id="cardsContainer"></div>
-
-    <section id="saquesGestor" class="card hidden">
-      <div class="card-header flex justify-between items-center">
-        <h2 class="text-xl font-bold">Saques e Comissões</h2>
-        <div class="flex items-center gap-2">
-          <select id="percentualMarcar" class="form-control">
-            <option value="0">0%</option>
-            <option value="0.03">3%</option>
-            <option value="0.04">4%</option>
-            <option value="0.05">5%</option>
-          </select>
-          <button id="btnMarcarPago" class="btn btn-primary text-sm">Marcar como Pago</button>
-        </div>
-      </div>
-      <div id="cardsResumoFinanceiro" class="card-body grid grid-cols-1 md:grid-cols-4 gap-4 text-center"></div>
-      <p id="faltasTextoFinanceiro" class="px-4 pb-4 text-center text-sm text-gray-600"></p>
-      <div class="card-body overflow-x-auto">
-        <table class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50">
-            <tr>
-              <th class="px-4 py-2"><input type="checkbox" id="chkSaquesFinanceiro" /></th>
-              <th class="px-4 py-2 text-left">Data</th>
-              <th class="px-4 py-2 text-left">Loja</th>
-              <th class="px-4 py-2 text-right">Saque</th>
-              <th class="px-4 py-2 text-right">%</th>
-              <th class="px-4 py-2 text-right">Comissão</th>
-              <th class="px-4 py-2 text-center">Status</th>
-            </tr>
-          </thead>
-          <tbody id="tbodySaquesFinanceiro" class="divide-y divide-gray-200"></tbody>
-        </table>
-      </div>
-      <div class="card-footer text-right text-sm" id="resumoSaquesFinanceiro"></div>
-    </section>
-  </main>
-  <script>
-    window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';
-    window.CUSTOM_NAVBAR_PATH = '/partials/navbar.html';
-  </script>
-  <script src="shared.js"></script>
-  <script type="module" src="firebase-config.js"></script>
-  <script type="module" src="financeiro.js"></script>
-    </div>
-</body>
+  </body>
 </html>

--- a/financeiro.js
+++ b/financeiro.js
@@ -227,6 +227,7 @@ async function carregar() {
     carregarDevolucoes(listaUsuarios, mes),
   ]);
   renderResumoUsuarios(Object.values(resumoUsuarios));
+  await carregarAmostragemSkus(uid !== 'todos' ? uid : null);
   renderTabelaSaques();
   if (uid !== 'todos') {
     assistirResumoFinanceiro(uid, mes);
@@ -286,6 +287,13 @@ function formatMes(date) {
   const ano = date.getFullYear();
   const mes = String(date.getMonth() + 1).padStart(2, '0');
   return `${ano}-${mes}`;
+}
+
+function formatDateISO(date) {
+  const ano = date.getFullYear();
+  const mes = String(date.getMonth() + 1).padStart(2, '0');
+  const dia = String(date.getDate()).padStart(2, '0');
+  return `${ano}-${mes}-${dia}`;
 }
 
 function sameMonth(a, b) {
@@ -503,6 +511,141 @@ async function carregarDevolucoes(usuarios, mes) {
       total += Number(dados.quantidade || dados.total || 1);
     });
     resumoUsuarios[usuario.uid].devolucoes = total;
+  }
+}
+
+async function carregarAmostragemSkus(uid) {
+  const section = document.getElementById('amostragemSection');
+  const cardsEl = document.getElementById('amostragemCards');
+  const emptyEl = document.getElementById('amostragemEmpty');
+  const periodoEl = document.getElementById('amostragemPeriodo');
+  if (!section || !cardsEl || !emptyEl) return;
+
+  if (!uid) {
+    section.classList.add('hidden');
+    cardsEl.innerHTML = '';
+    emptyEl.classList.add('hidden');
+    if (periodoEl) periodoEl.textContent = '';
+    return;
+  }
+
+  const fim = new Date();
+  const inicio = new Date();
+  inicio.setDate(fim.getDate() - 14);
+  const inicioStr = formatDateISO(inicio);
+  const fimStr = formatDateISO(fim);
+
+  if (periodoEl) {
+    periodoEl.textContent = `Período: ${inicio.toLocaleDateString('pt-BR')} – ${fim.toLocaleDateString('pt-BR')}`;
+  }
+
+  section.classList.remove('hidden');
+  cardsEl.innerHTML =
+    '<p class="text-sm text-gray-500 col-span-full">Carregando amostragem...</p>';
+  emptyEl.classList.add('hidden');
+
+  try {
+    const skusRef = collection(db, `uid/${uid}/skusVendidos`);
+    const q = query(
+      skusRef,
+      orderBy('__name__'),
+      startAt(inicioStr),
+      endAt(fimStr),
+    );
+    const snap = await getDocs(q);
+    const agregador = new Map();
+
+    await Promise.all(
+      snap.docs.map(async (docSnap) => {
+        const dataDia = docSnap.id;
+        const listaRef = collection(
+          db,
+          `uid/${uid}/skusVendidos/${docSnap.id}/lista`,
+        );
+        const listaSnap = await getDocs(listaRef);
+        listaSnap.forEach((item) => {
+          const dados = item.data() || {};
+          const sku = dados.sku || item.id;
+          if (!sku) return;
+          const quantidade = Number(dados.total ?? dados.quantidade ?? 0) || 0;
+          const valorLiquido =
+            Number(
+              dados.valorLiquido ??
+                dados.totalLiquido ??
+                dados.liquido ??
+                dados.sobraReal ??
+                0,
+            ) || 0;
+          if (!agregador.has(sku)) {
+            agregador.set(sku, {
+              quantidade: 0,
+              valorLiquido: 0,
+              dias: new Set(),
+            });
+          }
+          const info = agregador.get(sku);
+          info.quantidade += quantidade;
+          info.valorLiquido += valorLiquido;
+          info.dias.add(dataDia);
+        });
+      }),
+    );
+
+    const itens = Array.from(agregador.entries())
+      .map(([sku, info]) => {
+        const diasCount = info.dias.size;
+        return {
+          sku,
+          quantidade: info.quantidade,
+          mediaLiquido: diasCount ? info.valorLiquido / diasCount : 0,
+          dias: diasCount,
+        };
+      })
+      .filter((item) => item.quantidade > 0 || item.mediaLiquido !== 0)
+      .sort((a, b) => {
+        if (b.quantidade !== a.quantidade) return b.quantidade - a.quantidade;
+        return b.mediaLiquido - a.mediaLiquido;
+      })
+      .slice(0, 10);
+
+    cardsEl.innerHTML = '';
+    if (!itens.length) {
+      emptyEl.textContent = 'Sem dados de amostragem para os últimos 15 dias.';
+      emptyEl.classList.remove('hidden');
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    itens.forEach((item) => {
+      const card = document.createElement('div');
+      card.className = 'card p-4 flex flex-col gap-2';
+      card.innerHTML = `
+        <div>
+          <span class="text-xs uppercase tracking-wide text-gray-500">SKU</span>
+          <div class="text-lg font-semibold text-gray-800 break-words">${item.sku}</div>
+        </div>
+        <div class="text-sm text-gray-600">Qtd. vendida (15 dias):
+          <span class="font-medium text-gray-800">${item.quantidade}</span>
+        </div>
+        <div class="text-sm text-gray-600">Média sobra real:
+          <span class="font-semibold text-gray-800">R$ ${item.mediaLiquido.toLocaleString(
+            'pt-BR',
+            {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            },
+          )}</span>
+        </div>
+        <div class="text-xs text-gray-400">Dias com vendas: ${item.dias}</div>
+      `;
+      fragment.appendChild(card);
+    });
+    cardsEl.appendChild(fragment);
+  } catch (err) {
+    console.error('Erro ao carregar amostragem de SKUs:', err);
+    cardsEl.innerHTML = '';
+    emptyEl.textContent = 'Não foi possível carregar a amostragem de SKUs.';
+    emptyEl.classList.remove('hidden');
   }
 }
 


### PR DESCRIPTION
## Summary
- add an "Amostragem de SKUs" section to the financial dashboard showing the top 10 SKUs for the selected user
- compute the average sobra real for each SKU using the last 15 days of sales data and render the results as cards

## Testing
- npx prettier --write financeiro.js financeiro.html

------
https://chatgpt.com/codex/tasks/task_e_68fb74525004832a9a74483f4e2172f0