### PR TITLE
Fix regex escaping for task support material and tips

### DIFF
--- a/equipes.html
+++ b/equipes.html
@@ -833,10 +833,8 @@
             const cards = tasks
               .map((task) => {
                 const dueDate = task.dueDate ? new Date(`${task.dueDate}T00:00:00`) : null;
-                const material = task.supportMaterial ? `<div><strong>Material:</strong> ${task.supportMaterial.replace(/\n
-/g, '<br>')}</div>` : '';
-                const tips = task.tips ? `<div><strong>Dicas:</strong> ${task.tips.replace(/\n
-/g, '<br>')}</div>` : '';
+                const material = task.supportMaterial ? `<div><strong>Material:</strong> ${task.supportMaterial.replace(/\n/g, '<br>')}</div>` : '';
+                const tips = task.tips ? `<div><strong>Dicas:</strong> ${task.tips.replace(/\n/g, '<br>')}</div>` : '';
                 const responsible = resolveMemberName(ownerUid, task.responsibleEmail);
 
                 return `


### PR DESCRIPTION
## Summary
- correct the regular expressions that format support materials and tips in the task cards to avoid syntax errors when rendering the Equipes tab

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb764c9220832a80c45017e562a846