### PR TITLE
Fix newline replacement rendering on equipes page

### DIFF
--- a/equipes.html
+++ b/equipes.html
@@ -833,10 +833,12 @@
             const cards = tasks
               .map((task) => {
                 const dueDate = task.dueDate ? new Date(`${task.dueDate}T00:00:00`) : null;
-                const material = task.supportMaterial ? `<div><strong>Material:</strong> ${task.supportMaterial.replace(/\n
-/g, '<br>')}</div>` : '';
-                const tips = task.tips ? `<div><strong>Dicas:</strong> ${task.tips.replace(/\n
-/g, '<br>')}</div>` : '';
+                const material = task.supportMaterial
+                  ? `<div><strong>Material:</strong> ${task.supportMaterial.replace(/\n/g, '<br>')}</div>`
+                  : '';
+                const tips = task.tips
+                  ? `<div><strong>Dicas:</strong> ${task.tips.replace(/\n/g, '<br>')}</div>`
+                  : '';
                 const responsible = resolveMemberName(ownerUid, task.responsibleEmail);
 
                 return `


### PR DESCRIPTION
## Summary
- fix the task material and tips rendering by using a valid newline replacement expression
- ensure multiline text renders correctly without breaking the Teams page script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb764c9220832a80c45017e562a846