### PR TITLE
Ajusta cálculo da média de sobra real por SKU

### DIFF
--- a/financeiro.js
+++ b/financeiro.js
@@ -594,10 +594,12 @@ async function carregarAmostragemSkus(uid) {
     const itens = Array.from(agregador.entries())
       .map(([sku, info]) => {
         const diasCount = info.dias.size;
+        const mediaLiquido =
+          info.quantidade > 0 ? info.valorLiquido / info.quantidade : 0;
         return {
           sku,
           quantidade: info.quantidade,
-          mediaLiquido: diasCount ? info.valorLiquido / diasCount : 0,
+          mediaLiquido,
           dias: diasCount,
         };
       })


### PR DESCRIPTION
## Summary
- ajusta o cálculo da média de sobra real dos SKUs na amostragem para considerar a quantidade vendida

## Testing
- husky pre-commit

------
https://chatgpt.com/codex/tasks/task_e_68fb775bf9ac832a8f73a6aef08bcde5