### PR TITLE
Ensure gestor financeiro can access Equipes tab

### DIFF
--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -508,6 +508,7 @@
         href="/equipes.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-equipes"
+        data-perfil="gestor,responsavel,gestor financeiro,responsavel financeiro"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary
- allow financial manager profiles to see the Equipes sidebar entry by tagging it with the correct data-perfil values

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fb8428d940832ab7ea656fc6091ccf