### PR TITLE
Exibir aba Equipes para gestores financeiros e usuários

### DIFF
--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -508,7 +508,7 @@
         href="/equipes.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-equipes"
-        data-perfil="gestor,responsavel,gestor financeiro,responsavel financeiro"
+        data-perfil="gestor,responsavel,gestor financeiro,responsavel financeiro,usuario"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/shared.js
+++ b/shared.js
@@ -637,6 +637,7 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-mentoria',
     'menu-produtos',
     'menu-configuracoes',
+    'menu-equipes',
     'menu-perfil-mentorado',
     'menu-acompanhamento-gestor',
     'menu-sku-associado',
@@ -650,6 +651,7 @@ document.addEventListener('sidebarLoaded', async () => {
         'menu-painel-atualizacoes-gerais',
         'menu-painel-atualizacoes-mentorados',
         'menu-saques',
+        'menu-equipes',
       ].includes(id),
   );
 
@@ -662,6 +664,7 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-precificacao',
     'menu-expedicao',
     'menu-comunicacao',
+    'menu-equipes',
     'menu-configuracoes',
   ];
 
@@ -705,6 +708,7 @@ document.addEventListener('sidebarLoaded', async () => {
     const acompProblemas = getLi('menu-acompanhamento-problemas');
     const mentoria = getLi('menu-mentoria');
     const gestaoProdutos = getLi('menu-produtos');
+    const equipes = getLi('menu-equipes');
     const configuracoes = getLi('menu-configuracoes');
     const perfilMentorado = getLi('menu-perfil-mentorado');
     const mentoradosVendedores = getLi('menu-acompanhamento-gestor');
@@ -753,6 +757,7 @@ document.addEventListener('sidebarLoaded', async () => {
       acompProblemas,
       mentoria,
       gestaoProdutos,
+      equipes,
     ]);
     const configuracoesGroup = createGroup(
       configuracoes,


### PR DESCRIPTION
## Summary
- mostrar a aba Equipes para perfis de gestor financeiro e usuários completos
- ajustar a montagem do sidebar para incluir o link de Equipes nas estruturas de gestor e cliente

## Testing
- não aplicável

------
https://chatgpt.com/codex/tasks/task_e_68fb89032898832a9b3f655cf1eeff9c