### PR TITLE
Add dedicated sidebar for casarosa profile

### DIFF
--- a/login.js
+++ b/login.js
@@ -112,6 +112,20 @@ const EXPEDICAO_ALLOWED_MENU_IDS = [
   'menu-painel-atualizacoes-gerais',
   'menu-equipes',
 ];
+const CASAROSA_ALLOWED_MENU_IDS = [
+  'menu-casarosa-controle-vendas',
+  'menu-casarosa-saques',
+  'menu-casarosa-etiquetas',
+  'menu-casarosa-precificacao',
+  'menu-casarosa-expedicao',
+  'menu-casarosa-configuracoes',
+  'menu-casarosa-marketing',
+  'menu-casarosa-problemas',
+  'menu-casarosa-previsao',
+  'menu-casarosa-conferir-sobras',
+  'menu-casarosa-equipes',
+  'menu-casarosa-painel-atualizacoes',
+];
 const SELLER_ALLOWED_MENU_IDS = [
   'menu-seller-expedicao',
   'menu-etiqueta-shopee',
@@ -563,6 +577,7 @@ function normalizePerfil(perfil) {
     return 'expedicao';
   if (['posvendas', 'pos-vendas', 'pos vendas'].includes(base))
     return 'posvendas';
+  if (['casarosa', 'casa rosa', 'casa-rosa'].includes(base)) return 'casarosa';
   return base;
 }
 function applyPerfilRestrictions(perfil) {
@@ -637,6 +652,7 @@ function applyPerfilRestrictions(perfil) {
     seller: SELLER_ALLOWED_MENU_IDS,
     posvendas: POSVENDAS_ALLOWED_MENU_IDS,
     expedicao: EXPEDICAO_ALLOWED_MENU_IDS,
+    casarosa: CASAROSA_ALLOWED_MENU_IDS,
   };
 
   const allowed = nivelMenus[currentPerfil];

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -42,6 +42,546 @@
     </a>
   </div>
   <ul class="sidebar-menu py-4">
+    <li data-perfil="casarosa">
+      <div class="sidebar-item flex items-center justify-between">
+        <a
+          href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento"
+          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          id="menu-casarosa-controle-vendas"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5 mr-3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"
+            />
+          </svg>
+          <span class="link-text">Controle Vendas</span>
+        </a>
+        <button
+          class="submenu-toggle p-2"
+          onclick="toggleMenu('menuCasarosaControleVendas', this)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
+          </svg>
+        </button>
+      </div>
+      <ul
+        id="menuCasarosaControleVendas"
+        class="submenu space-y-1 overflow-hidden transition-all duration-300"
+      >
+        <li>
+          <a
+            href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=faturamento"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Registrar Faturamento</a
+          >
+        </li>
+        <li>
+          <a
+            href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=registroFaturamento"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Acompanhamento Faturamento</a
+          >
+        </li>
+        <li>
+          <a
+            href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=vendasML"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Vendas ML</a
+          >
+        </li>
+        <li>
+          <a
+            href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=controleVendas"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Acompanhamento Vendas</a
+          >
+        </li>
+        <li>
+          <a
+            href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=acompanhamento"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Acompanhamento Mensal</a
+          >
+        </li>
+      </ul>
+    </li>
+    <li data-perfil="casarosa">
+      <a
+        href="/saques.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-casarosa-saques"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M2.25 18.75C7.717 18.75 13.014 19.481 18.047 20.851c.728.198 1.454-.343 1.454-1.096V18.75M3.75 4.5V5.25A.75.75 0 0 1 3 6H2.25M2.25 6V5.625A1.125 1.125 0 0 1 3.375 4.5H20.25M2.25 6v9M20.25 4.5V5.25A.75.75 0 0 0 21 6h.75M20.25 4.5h.375A1.125 1.125 0 0 1 21.75 5.625V15.375A1.125 1.125 0 0 1 20.625 16.5H20.25M21.75 15H21a.75.75 0 0 0-.75.75V16.5M20.25 16.5H3.75m0 0H3.375A1.125 1.125 0 0 1 2.25 15.375V15M3.75 16.5V15.75A.75.75 0 0 0 3 15H2.25M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z"
+          />
+        </svg>
+        <span class="link-text">Saques</span>
+      </a>
+    </li>
+    <li data-perfil="casarosa">
+      <div class="sidebar-item flex items-center justify-between">
+        <a
+          href="/etiquetas-ocr.html"
+          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          id="menu-casarosa-etiquetas"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5 mr-3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"
+            />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M6 6h.008v.008H6V6Z"
+            />
+          </svg>
+          <span class="link-text">Etiquetas</span>
+        </a>
+        <button
+          class="submenu-toggle p-2"
+          onclick="toggleMenu('menuCasarosaEtiquetas', this)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
+          </svg>
+        </button>
+      </div>
+      <ul
+        id="menuCasarosaEtiquetas"
+        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
+      >
+        <li>
+          <a
+            href="/etiquetas-shopee.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Etiqueta Shopee</a
+          >
+        </li>
+      </ul>
+    </li>
+    <li data-perfil="casarosa">
+      <div class="sidebar-item flex items-center justify-between">
+        <a
+          href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao"
+          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          id="menu-casarosa-precificacao"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5 mr-3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M3 3v1.5M3 21v-6m0 0c0-1.5918.5156-3.058 1.3943-4.2412M3 15h1.9959M5.25 8.25h15m-15 0V6A2.25 2.25 0 0 1 7.5 3.75h10.5A2.25 2.25 0 0 1 20.25 6v2.25m-15 0V12m15-3.75c0 1.5918-.5156 3.058-1.3943 4.2412M20.25 8.25H18.254m-1.0676 5.3307c-.6556.8661-1.3072 1.6019-1.8571 2.0289-1.6017 1.2403-3.161 1.5864-4.8291.6744-1.5324-.8358-2.6895-2.8579-3.4909-5.2166"
+            />
+          </svg>
+          <span class="link-text">Precificação</span>
+        </a>
+        <button
+          class="submenu-toggle p-2"
+          onclick="toggleMenu('menuCasarosaPrecificacao', this)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
+          </svg>
+        </button>
+      </div>
+      <ul
+        id="menuCasarosaPrecificacao"
+        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
+      >
+        <li>
+          <a
+            href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=precificacao"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Precificação</a
+          >
+        </li>
+        <li>
+          <a
+            href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=lista-precos"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Lista Preços</a
+          >
+        </li>
+      </ul>
+    </li>
+    <li data-perfil="casarosa">
+      <div class="sidebar-item flex items-center justify-between">
+        <a
+          href="/expedicao.html"
+          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          id="menu-casarosa-expedicao"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5 mr-3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M8.25 18.75a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h6m-9 0H3.375A1.125 1.125 0 0 1 2.25 17.625V14.25m17.25 4.5a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 0 0-3.213-9.193 2.056 2.056 0 0 0-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 0 0-10.026 0 1.106 1.106 0 0 0-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12"
+            />
+          </svg>
+          <span class="link-text">Expedição</span>
+        </a>
+        <button
+          class="submenu-toggle p-2"
+          onclick="toggleMenu('menuCasarosaExpedicao', this)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
+          </svg>
+        </button>
+      </div>
+      <ul
+        id="menuCasarosaExpedicao"
+        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
+      >
+        <li>
+          <a
+            href="/expedicao.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Expedição</a
+          >
+        </li>
+        <li>
+          <a
+            href="/configuracao-expedicao.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Configuração Expedição</a
+          >
+        </li>
+        <li>
+          <a
+            href="/email-expedicao.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >E-mail de Expedição</a
+          >
+        </li>
+      </ul>
+    </li>
+    <li data-perfil="casarosa">
+      <div class="sidebar-item flex items-center justify-between">
+        <a
+          href="/configuracao-perfil.html"
+          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          id="menu-casarosa-configuracoes"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5 mr-3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15.75 9.75a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 19.5a7.5 7.5 0 1 1 15 0"
+            />
+          </svg>
+          <span class="link-text">Configurações</span>
+        </a>
+        <button
+          class="submenu-toggle p-2"
+          onclick="toggleMenu('menuCasarosaConfiguracoes', this)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
+          </svg>
+        </button>
+      </div>
+      <ul
+        id="menuCasarosaConfiguracoes"
+        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
+      >
+        <li>
+          <a
+            href="/configuracao-perfil.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Configuração de Perfil</a
+          >
+        </li>
+        <li>
+          <a
+            href="/Sistema%20de%20Precifica%C3%A7%C3%A3o%20COM%20IMPORTA%C3%87%C3%83O%20DE%20PLANILHA%20DE%20PROMO%C3%87%C3%95ES%20SHOPEE.html?tab=historico"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Histórico</a
+          >
+        </li>
+      </ul>
+    </li>
+    <li data-perfil="casarosa">
+      <div class="sidebar-item flex items-center justify-between">
+        <a
+          href="/promocoes-shopee.html"
+          class="sidebar-link flex items-center py-2 px-4 transition-colors"
+          id="menu-casarosa-marketing"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5 mr-3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"
+            />
+          </svg>
+          <span class="link-text">Marketing</span>
+        </a>
+        <button
+          class="submenu-toggle p-2"
+          onclick="toggleMenu('menuCasarosaMarketing', this)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m19.5 8.25-7.5 7.5-7.5-7.5"
+            />
+          </svg>
+        </button>
+      </div>
+      <ul
+        id="menuCasarosaMarketing"
+        class="submenu pl-8 space-y-1 overflow-hidden transition-all duration-300"
+      >
+        <li>
+          <a
+            href="/promocoes-shopee.html"
+            class="sidebar-link block py-2 px-4 transition-colors"
+            >Promoções Shopee</a
+          >
+        </li>
+      </ul>
+    </li>
+    <li data-perfil="casarosa">
+      <a
+        href="/problemas.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-casarosa-problemas"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M10.343 3.94c.562-1.003 1.752-1.003 2.314 0l7.79 13.88c.562 1-.141 2.25-1.157 2.25H3.71c-1.016 0-1.719-1.25-1.157-2.25l7.79-13.88z"
+          />
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M12 9v4.5m0 3h.008v.008H12V16.5Z"
+          />
+        </svg>
+        <span class="link-text">Problemas</span>
+      </a>
+    </li>
+    <li data-perfil="casarosa">
+      <a
+        href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=previsao"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-casarosa-previsao"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+          />
+        </svg>
+        <span class="link-text">Previsão</span>
+      </a>
+    </li>
+    <li data-perfil="casarosa">
+      <a
+        href="/CONTROLE%20DE%20SOBRAS%20SHOPEE.html?tab=importar"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-casarosa-conferir-sobras"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182A3.221 3.221 0 0 0 12 12c-.725 0-1.45-.219-2.003-.659-1.106-.879-1.106-2.303 0-3.182 1.106-.879 2.899-.879 4.005 0l.415.33M21 12c0 4.971-4.029 9-9 9s-9-4.029-9-9 4.029-9 9-9 9 4.029 9 9Z"
+          />
+        </svg>
+        <span class="link-text">Conferir Sobras</span>
+      </a>
+    </li>
+    <li data-perfil="casarosa">
+      <a
+        href="/equipes.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-casarosa-equipes"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M15 19.128c.833.242 1.714.372 2.625.372 1.479 0 2.878-.342 4.122-.952v-.173c0-2.278-1.847-4.125-4.125-4.125-1.418 0-2.669.716-3.411 1.806M15 19.128V19.125c0-3.52-2.854-6.375-6.375-6.375S2.25 15.605 2.25 19.125v.009A11.953 11.953 0 0 0 12 21c2.678 0 5.218-.585 7.499-1.632M12.75 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM20.25 8.625a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z"
+          />
+        </svg>
+        <span class="link-text">Equipes</span>
+      </a>
+    </li>
+    <li data-perfil="casarosa">
+      <a
+        href="/painel-atualizacoes-gerais.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-casarosa-painel-atualizacoes"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M8.25 4.5h-2.5A1.75 1.75 0 0 0 4 6.25v11.5A1.75 1.75 0 0 0 5.75 19.5h12.5A1.75 1.75 0 0 0 20 17.75V9.75a1.75 1.75 0 0 0-1.75-1.75h-5.5a1.75 1.75 0 0 1-1.75-1.75v-1.75A1.75 1.75 0 0 0 9.25 3H8.25m0 0V4.5m0-1.5h3"
+          />
+        </svg>
+        <span class="link-text">Painel Atualizações</span>
+      </a>
+    </li>
     <li data-perfil="seller">
       <a
         href="/expedicao.html"


### PR DESCRIPTION
## Summary
- add sidebar navigation limited to casarosa profile with ordered sections for faturamento, expedição, precificação, and acompanhamento links
- configure login profile handling so casarosa resolves correctly and only sees the intended menu entries

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fbab588f98832ab3c3cb1fe5d41777