### PR TITLE
Include equipes menu for posvendas profile

### DIFF
--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -508,7 +508,7 @@
         href="/equipes.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"
         id="menu-equipes"
-        data-perfil="gestor,responsavel,gestor financeiro,responsavel financeiro,usuario"
+        data-perfil="gestor,responsavel,gestor financeiro,responsavel financeiro,usuario,posvendas"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary
- allow users with the posvendas profile to access the equipes section from the sidebar

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68fbae15919c832a843407a48d862853