### PR TITLE
Add shared catalog management experience

### DIFF
--- a/catalogo.html
+++ b/catalogo.html
@@ -1,113 +1,377 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="pt-BR">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Catálogo</title>
-  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/styles.css?v=20240826">
-</head>
-<body class="bg-gray-100 text-gray-800">
-  <div class="app-container">
-    <div id="sidebar-container"></div>
-    <div id="navbar-container"></div>
-    <main class="main-content p-4 space-y-6">
-      <header class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-        <div>
-          <h1 class="text-2xl font-semibold text-gray-900">Catálogo de Produtos</h1>
-          <p class="text-gray-600">Organize os itens que precisam ter etiquetas preparadas para a expedição.</p>
-        </div>
-        <a
-          href="/expedicao.html"
-          class="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-white shadow hover:bg-blue-700 transition"
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Catálogo</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="css/styles.css?v=20240826" />
+  </head>
+  <body class="bg-gray-100 text-gray-800">
+    <div class="app-container">
+      <div id="sidebar-container"></div>
+      <div id="navbar-container"></div>
+      <main class="main-content p-4 space-y-6">
+        <header
+          class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
         >
-          <i class="fa-solid fa-box"></i>
-          <span>Ir para Expedição</span>
-        </a>
-      </header>
-
-      <section class="card">
-        <div class="card-header">
-          <h2 class="text-lg font-semibold">Resumo rápido</h2>
-        </div>
-        <div class="card-body grid gap-4 sm:grid-cols-3">
-          <div class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
-            <p class="text-sm text-gray-500">Produtos aguardando etiqueta</p>
-            <p class="mt-2 text-2xl font-semibold text-gray-900" id="catalogAwaiting">--</p>
-          </div>
-          <div class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
-            <p class="text-sm text-gray-500">Etiquetas impressas hoje</p>
-            <p class="mt-2 text-2xl font-semibold text-gray-900" id="catalogPrintedToday">--</p>
-          </div>
-          <div class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
-            <p class="text-sm text-gray-500">Responsável de expedição</p>
-            <p class="mt-2 text-base font-medium text-gray-900" id="catalogManager">--</p>
-          </div>
-        </div>
-      </section>
-
-      <section class="card">
-        <div class="card-header flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h2 class="text-lg font-semibold">Itens do catálogo</h2>
-            <p class="text-sm text-gray-600">Cadastre aqui os produtos que precisam de preparação especial.</p>
+            <h1 class="text-2xl font-semibold text-gray-900">
+              Catálogo de Produtos
+            </h1>
+            <p class="text-gray-600">
+              Organize os itens que precisam ter etiquetas preparadas para a
+              expedição.
+            </p>
           </div>
-          <button
-            id="catalogAddItemBtn"
-            class="inline-flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-white shadow hover:bg-green-700 transition"
+          <a
+            href="/expedicao.html"
+            class="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-white shadow transition hover:bg-blue-700"
           >
-            <i class="fa-solid fa-plus"></i>
-            <span>Novo item</span>
-          </button>
-        </div>
-        <div class="card-body">
-          <div class="overflow-x-auto">
-            <table class="min-w-full divide-y divide-gray-200">
-              <thead class="bg-gray-50">
-                <tr>
-                  <th class="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">Produto</th>
-                  <th class="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">SKU</th>
-                  <th class="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">Status</th>
-                  <th class="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">Observações</th>
-                </tr>
-              </thead>
-              <tbody id="catalogTableBody" class="divide-y divide-gray-100 bg-white">
-                <tr>
-                  <td class="px-4 py-3 text-sm text-gray-600" colspan="4">
-                    Nenhum item cadastrado ainda. Utilize o botão "Novo item" para começar.
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+            <i class="fa-solid fa-box"></i>
+            <span>Ir para Expedição</span>
+          </a>
+        </header>
+
+        <section class="card">
+          <div class="card-header">
+            <h2 class="text-lg font-semibold">Resumo rápido</h2>
+          </div>
+          <div class="card-body grid gap-4 sm:grid-cols-3">
+            <div
+              class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+            >
+              <p class="text-sm text-gray-500">Produtos cadastrados</p>
+              <p
+                class="mt-2 text-2xl font-semibold text-gray-900"
+                id="catalogTotal"
+              >
+                --
+              </p>
+            </div>
+            <div
+              class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+            >
+              <p class="text-sm text-gray-500">Novos produtos hoje</p>
+              <p
+                class="mt-2 text-2xl font-semibold text-gray-900"
+                id="catalogToday"
+              >
+                --
+              </p>
+            </div>
+            <div
+              class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+            >
+              <p class="text-sm text-gray-500">Responsável pelo catálogo</p>
+              <p
+                class="mt-2 text-base font-medium text-gray-900"
+                id="catalogManager"
+              >
+                --
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section class="card">
+          <div
+            class="card-header flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div>
+              <h2 class="text-lg font-semibold">Cadastro de produtos</h2>
+              <p class="text-sm text-gray-600">
+                Cadastre os itens que devem ser compartilhados com os usuários
+                da sua equipe.
+              </p>
+            </div>
+            <button
+              id="catalogAddItemBtn"
+              class="inline-flex hidden items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-white shadow transition hover:bg-green-700"
+            >
+              <i class="fa-solid fa-plus"></i>
+              <span>Novo produto</span>
+            </button>
+          </div>
+          <div id="catalogFormWrapper" class="card-body hidden">
+            <form id="catalogProductForm" class="space-y-6">
+              <div class="grid gap-4 sm:grid-cols-2">
+                <div class="flex flex-col">
+                  <label
+                    for="catalogProductName"
+                    class="text-sm font-medium text-gray-700"
+                    >Nome do produto *</label
+                  >
+                  <input
+                    id="catalogProductName"
+                    type="text"
+                    required
+                    class="mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    placeholder="Nome que identifica o produto"
+                  />
+                </div>
+                <div class="flex flex-col">
+                  <label
+                    for="catalogProductSku"
+                    class="text-sm font-medium text-gray-700"
+                    >SKU *</label
+                  >
+                  <input
+                    id="catalogProductSku"
+                    type="text"
+                    required
+                    class="mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    placeholder="Código ou referência"
+                  />
+                </div>
+                <div class="flex flex-col">
+                  <label
+                    for="catalogProductCost"
+                    class="text-sm font-medium text-gray-700"
+                    >Custo</label
+                  >
+                  <input
+                    id="catalogProductCost"
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    class="mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    placeholder="0,00"
+                  />
+                </div>
+                <div class="flex flex-col">
+                  <label
+                    for="catalogProductPrice"
+                    class="text-sm font-medium text-gray-700"
+                    >Preço de venda sugerido</label
+                  >
+                  <input
+                    id="catalogProductPrice"
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    class="mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    placeholder="0,00"
+                  />
+                </div>
+                <div class="flex flex-col sm:col-span-2">
+                  <label
+                    for="catalogProductCategory"
+                    class="text-sm font-medium text-gray-700"
+                    >Categoria</label
+                  >
+                  <input
+                    id="catalogProductCategory"
+                    type="text"
+                    class="mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    placeholder="Ex.: Utilidades, Moda, Acessórios"
+                  />
+                </div>
+              </div>
+              <div class="grid gap-4">
+                <div class="flex flex-col">
+                  <label
+                    for="catalogProductDescription"
+                    class="text-sm font-medium text-gray-700"
+                    >Descrição</label
+                  >
+                  <textarea
+                    id="catalogProductDescription"
+                    rows="3"
+                    class="mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    placeholder="Detalhes importantes sobre o produto"
+                  ></textarea>
+                </div>
+                <div class="flex flex-col">
+                  <label
+                    for="catalogProductMeasures"
+                    class="text-sm font-medium text-gray-700"
+                    >Medidas</label
+                  >
+                  <textarea
+                    id="catalogProductMeasures"
+                    rows="2"
+                    class="mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    placeholder="Tamanho, peso, dimensões, etc."
+                  ></textarea>
+                </div>
+                <div class="flex flex-col">
+                  <label
+                    for="catalogProductPhotos"
+                    class="text-sm font-medium text-gray-700"
+                    >Fotos</label
+                  >
+                  <input
+                    id="catalogProductPhotos"
+                    type="file"
+                    accept="image/*"
+                    multiple
+                    class="mt-1 text-sm text-gray-700"
+                  />
+                  <p class="mt-1 text-xs text-gray-500">
+                    Utilize imagens em formato JPG ou PNG com até 10 MB.
+                  </p>
+                </div>
+              </div>
+              <div class="flex items-center justify-end gap-3">
+                <button
+                  type="button"
+                  id="catalogCancelForm"
+                  class="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  class="inline-flex items-center gap-2 rounded-lg bg-green-600 px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-green-700"
+                >
+                  <i class="fa-solid fa-floppy-disk"></i>
+                  <span>Salvar produto</span>
+                </button>
+              </div>
+            </form>
+          </div>
+        </section>
+
+        <section class="card">
+          <div class="card-header">
+            <h2 class="text-lg font-semibold">Produtos cadastrados</h2>
+            <p class="text-sm text-gray-600">
+              Os produtos cadastrados ficam visíveis para todos os usuários
+              vinculados ao responsável financeiro.
+            </p>
+          </div>
+          <div class="card-body">
+            <div
+              id="catalogCards"
+              class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3"
+            ></div>
+            <p
+              id="catalogEmptyState"
+              class="rounded-lg border border-dashed border-gray-300 bg-white p-6 text-center text-sm text-gray-500"
+            >
+              Nenhum produto cadastrado ainda. Utilize o botão "Novo produto"
+              para adicionar itens ao catálogo.
+            </p>
+          </div>
+        </section>
+      </main>
+
+      <div
+        id="catalogDetailsModal"
+        class="fixed inset-0 z-50 hidden"
+        role="dialog"
+        aria-modal="true"
+      >
+        <div
+          id="catalogDetailsBackdrop"
+          class="absolute inset-0 bg-black bg-opacity-50"
+        ></div>
+        <div class="relative mx-auto mt-20 w-full max-w-3xl px-4">
+          <div class="overflow-hidden rounded-lg bg-white shadow-xl">
+            <div
+              class="flex items-center justify-between border-b border-gray-200 px-6 py-4"
+            >
+              <h3
+                class="text-lg font-semibold text-gray-900"
+                id="catalogDetailsTitle"
+              >
+                Detalhes do produto
+              </h3>
+              <button
+                id="catalogDetailsClose"
+                class="text-gray-500 transition hover:text-gray-700"
+                aria-label="Fechar"
+              >
+                <i class="fa-solid fa-xmark text-xl"></i>
+              </button>
+            </div>
+            <div class="space-y-5 px-6 py-5">
+              <div class="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <p class="text-xs font-semibold uppercase text-gray-500">
+                    SKU
+                  </p>
+                  <p
+                    class="mt-1 text-sm font-medium text-gray-900"
+                    id="catalogDetailsSku"
+                  ></p>
+                </div>
+                <div>
+                  <p class="text-xs font-semibold uppercase text-gray-500">
+                    Categoria
+                  </p>
+                  <p
+                    class="mt-1 text-sm font-medium text-gray-900"
+                    id="catalogDetailsCategoria"
+                  ></p>
+                </div>
+                <div>
+                  <p class="text-xs font-semibold uppercase text-gray-500">
+                    Custo
+                  </p>
+                  <p
+                    class="mt-1 text-sm font-medium text-gray-900"
+                    id="catalogDetailsCusto"
+                  ></p>
+                </div>
+                <div>
+                  <p class="text-xs font-semibold uppercase text-gray-500">
+                    Preço sugerido
+                  </p>
+                  <p
+                    class="mt-1 text-sm font-medium text-gray-900"
+                    id="catalogDetailsPreco"
+                  ></p>
+                </div>
+              </div>
+              <div>
+                <p class="text-xs font-semibold uppercase text-gray-500">
+                  Descrição
+                </p>
+                <p
+                  class="mt-1 whitespace-pre-line text-sm text-gray-700"
+                  id="catalogDetailsDescricao"
+                ></p>
+              </div>
+              <div>
+                <p class="text-xs font-semibold uppercase text-gray-500">
+                  Medidas
+                </p>
+                <p
+                  class="mt-1 whitespace-pre-line text-sm text-gray-700"
+                  id="catalogDetailsMedidas"
+                ></p>
+              </div>
+              <div>
+                <p class="text-xs font-semibold uppercase text-gray-500">
+                  Fotos
+                </p>
+                <div
+                  id="catalogDetailsFotos"
+                  class="mt-3 grid gap-3 sm:grid-cols-3"
+                ></div>
+              </div>
+            </div>
           </div>
         </div>
-      </section>
-    </main>
-    <script src="shared.js"></script>
-    <script type="module" src="firebase-config.js"></script>
-    <script type="module" src="login.js"></script>
-    <script>
-      document.addEventListener('DOMContentLoaded', () => {
-        const awaitingEl = document.getElementById('catalogAwaiting');
-        const printedEl = document.getElementById('catalogPrintedToday');
-        const managerEl = document.getElementById('catalogManager');
-        const addItemBtn = document.getElementById('catalogAddItemBtn');
+      </div>
 
-        const updatePlaceholders = () => {
-          awaitingEl.textContent = '0';
-          printedEl.textContent = '0';
-          managerEl.textContent = 'Defina na Configuração de Perfil';
-        };
-
-        updatePlaceholders();
-
-        addItemBtn?.addEventListener('click', () => {
-          window.showToast?.('Em breve você poderá cadastrar itens do catálogo.', 'info');
-        });
-      });
-    </script>
-  </div>
-</body>
+      <script src="shared.js"></script>
+      <script type="module" src="firebase-config.js"></script>
+      <script type="module" src="login.js"></script>
+      <script type="module" src="catalogo.js"></script>
+    </div>
+  </body>
 </html>

--- a/catalogo.js
+++ b/catalogo.js
@@ -1,0 +1,546 @@
+import {
+  initializeApp,
+  getApps,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import {
+  getFirestore,
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  onSnapshot,
+  orderBy,
+  query,
+  where,
+  setDoc,
+  serverTimestamp,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import {
+  getAuth,
+  onAuthStateChanged,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import {
+  getStorage,
+  ref,
+  uploadBytes,
+  getDownloadURL,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-storage.js';
+import { firebaseConfig } from './firebase-config.js';
+import { showToast } from './utils.js';
+import { loadUserProfile } from './login.js';
+
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+const db = getFirestore(app);
+const auth = getAuth(app);
+const storage = getStorage(app);
+
+const totalEl = document.getElementById('catalogTotal');
+const todayEl = document.getElementById('catalogToday');
+const managerEl = document.getElementById('catalogManager');
+const cardsContainer = document.getElementById('catalogCards');
+const emptyStateEl = document.getElementById('catalogEmptyState');
+const addItemBtn = document.getElementById('catalogAddItemBtn');
+const formWrapper = document.getElementById('catalogFormWrapper');
+const form = document.getElementById('catalogProductForm');
+const cancelFormBtn = document.getElementById('catalogCancelForm');
+const modal = document.getElementById('catalogDetailsModal');
+const modalBackdrop = document.getElementById('catalogDetailsBackdrop');
+const modalCloseBtn = document.getElementById('catalogDetailsClose');
+const modalTitle = document.getElementById('catalogDetailsTitle');
+const modalSku = document.getElementById('catalogDetailsSku');
+const modalCategoria = document.getElementById('catalogDetailsCategoria');
+const modalCusto = document.getElementById('catalogDetailsCusto');
+const modalPreco = document.getElementById('catalogDetailsPreco');
+const modalDescricao = document.getElementById('catalogDetailsDescricao');
+const modalMedidas = document.getElementById('catalogDetailsMedidas');
+const modalFotos = document.getElementById('catalogDetailsFotos');
+
+const nameInput = document.getElementById('catalogProductName');
+const skuInput = document.getElementById('catalogProductSku');
+const costInput = document.getElementById('catalogProductCost');
+const priceInput = document.getElementById('catalogProductPrice');
+const categoryInput = document.getElementById('catalogProductCategory');
+const descriptionInput = document.getElementById('catalogProductDescription');
+const measuresInput = document.getElementById('catalogProductMeasures');
+const photosInput = document.getElementById('catalogProductPhotos');
+const submitBtn = form?.querySelector('button[type="submit"]');
+
+let currentUser = null;
+let currentProfile = null;
+let scopeUid = null;
+let responsavelInfo = null;
+let canEdit = false;
+let catalogUnsub = null;
+let isSubmitting = false;
+const productCache = new Map();
+
+function normalizePerfil(perfil) {
+  const base = (perfil || '')
+    .toLowerCase()
+    .trim()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+  if (!base) return '';
+  if (['adm', 'admin', 'administrador'].includes(base)) return 'adm';
+  if (['usuario completo', 'usuario'].includes(base)) return 'usuario';
+  if (['usuario basico', 'cliente'].includes(base)) return 'cliente';
+  if (
+    [
+      'gestor',
+      'mentor',
+      'responsavel',
+      'gestor financeiro',
+      'responsavel financeiro',
+      'gerente',
+    ].includes(base)
+  )
+    return 'gestor';
+  if (['seller', 'vendedor'].includes(base)) return 'seller';
+  if (['expedicao', 'gestor expedicao', 'gestor de expedicao'].includes(base))
+    return 'expedicao';
+  if (['posvendas', 'pos-vendas', 'pos vendas'].includes(base))
+    return 'posvendas';
+  if (['casarosa', 'casa rosa', 'casa-rosa'].includes(base)) return 'casarosa';
+  return base;
+}
+
+function formatCurrency(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '--';
+  try {
+    return new Intl.NumberFormat('pt-BR', {
+      style: 'currency',
+      currency: 'BRL',
+      minimumFractionDigits: 2,
+    }).format(value);
+  } catch (err) {
+    console.warn('Não foi possível formatar o valor:', err);
+    return value.toFixed(2);
+  }
+}
+
+function toggleForm(visible) {
+  if (!formWrapper || !addItemBtn) return;
+  if (!canEdit) {
+    formWrapper.classList.add('hidden');
+    addItemBtn.classList.add('hidden');
+    return;
+  }
+  const shouldShow =
+    typeof visible === 'boolean'
+      ? visible
+      : formWrapper.classList.contains('hidden');
+  if (shouldShow) {
+    formWrapper.classList.remove('hidden');
+    addItemBtn.classList.add('hidden');
+  } else {
+    formWrapper.classList.add('hidden');
+    addItemBtn.classList.remove('hidden');
+  }
+}
+
+function clearForm() {
+  form?.reset();
+  if (photosInput) photosInput.value = '';
+}
+
+function closeModal() {
+  if (!modal) return;
+  modal.classList.add('hidden');
+  document.body.classList.remove('overflow-hidden');
+}
+
+function openModal(produto) {
+  if (!modal || !produto) return;
+  modalTitle.textContent = produto.nome || 'Detalhes do produto';
+  modalSku.textContent = produto.sku || '--';
+  modalCategoria.textContent = produto.categoria || 'Sem categoria';
+  modalCusto.textContent = formatCurrency(produto.custo);
+  modalPreco.textContent = formatCurrency(produto.precoSugerido);
+  modalDescricao.textContent = produto.descricao || 'Sem descrição cadastrada.';
+  modalMedidas.textContent = produto.medidas || 'Sem medidas cadastradas.';
+
+  modalFotos.innerHTML = '';
+  const fotos = Array.isArray(produto.fotos) ? produto.fotos : [];
+  if (!fotos.length) {
+    const empty = document.createElement('p');
+    empty.className = 'text-sm text-gray-500';
+    empty.textContent = 'Nenhuma foto cadastrada.';
+    modalFotos.appendChild(empty);
+  } else {
+    fotos.forEach((foto) => {
+      if (!foto?.url) return;
+      const link = document.createElement('a');
+      link.href = foto.url;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.className =
+        'group block overflow-hidden rounded-lg border border-gray-200 shadow-sm';
+
+      const img = document.createElement('img');
+      img.src = foto.url;
+      img.alt = foto.nome || produto.nome || 'Foto do produto';
+      img.className =
+        'h-32 w-full object-cover transition duration-200 group-hover:scale-105';
+
+      link.appendChild(img);
+      modalFotos.appendChild(link);
+    });
+  }
+
+  modal.classList.remove('hidden');
+  document.body.classList.add('overflow-hidden');
+}
+
+function updateSummary(produtos) {
+  if (totalEl) totalEl.textContent = produtos.length.toString();
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const todayCount = produtos.filter((produto) => {
+    const ts = produto.createdAt;
+    const date =
+      ts && typeof ts.toDate === 'function'
+        ? ts.toDate()
+        : ts instanceof Date
+          ? ts
+          : null;
+    if (!date) return false;
+    const normalized = new Date(date);
+    normalized.setHours(0, 0, 0, 0);
+    return normalized.getTime() === today.getTime();
+  }).length;
+  if (todayEl) todayEl.textContent = todayCount.toString();
+}
+
+function renderProducts(produtos) {
+  productCache.clear();
+  if (cardsContainer) cardsContainer.innerHTML = '';
+
+  const sorted = [...produtos];
+  sorted.forEach((produto) => productCache.set(produto.id, produto));
+
+  if (!sorted.length) {
+    if (emptyStateEl) emptyStateEl.classList.remove('hidden');
+  } else {
+    if (emptyStateEl) emptyStateEl.classList.add('hidden');
+    sorted.forEach((produto) => {
+      const card = document.createElement('div');
+      card.className =
+        'flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition hover:shadow-md';
+
+      const media = document.createElement('div');
+      media.className = 'relative h-40 w-full bg-gray-100';
+      const fotos = Array.isArray(produto.fotos) ? produto.fotos : [];
+      const primeiraFoto = fotos.find((foto) => foto?.url);
+      if (primeiraFoto) {
+        const img = document.createElement('img');
+        img.src = primeiraFoto.url;
+        img.alt = produto.nome || primeiraFoto.nome || 'Produto';
+        img.className = 'h-full w-full object-cover';
+        media.appendChild(img);
+      } else {
+        const placeholder = document.createElement('div');
+        placeholder.className =
+          'flex h-full w-full items-center justify-center bg-gradient-to-br from-gray-200 to-gray-100 text-gray-400';
+        placeholder.innerHTML = '<i class="fa-solid fa-image text-4xl"></i>';
+        media.appendChild(placeholder);
+      }
+      card.appendChild(media);
+
+      const body = document.createElement('div');
+      body.className = 'flex flex-1 flex-col px-4 py-4';
+
+      const skuLabel = document.createElement('p');
+      skuLabel.className =
+        'text-xs font-semibold uppercase tracking-wide text-gray-500';
+      skuLabel.textContent = 'SKU';
+
+      const skuValue = document.createElement('p');
+      skuValue.className = 'text-sm font-semibold text-gray-900';
+      skuValue.textContent = produto.sku || '--';
+
+      const nameEl = document.createElement('h3');
+      nameEl.className = 'mt-2 text-lg font-semibold text-gray-900';
+      nameEl.textContent = produto.nome || 'Produto sem nome';
+
+      const categoryEl = document.createElement('p');
+      categoryEl.className = 'mt-1 text-sm text-gray-500';
+      categoryEl.textContent = produto.categoria || 'Sem categoria';
+
+      const detailsBtn = document.createElement('button');
+      detailsBtn.type = 'button';
+      detailsBtn.className =
+        'mt-auto inline-flex items-center gap-2 text-sm font-semibold text-red-600 transition hover:text-red-700';
+      detailsBtn.innerHTML =
+        '<span>Ver mais</span><i class="fa-solid fa-arrow-right"></i>';
+      detailsBtn.addEventListener('click', () => openModal(produto));
+
+      body.appendChild(skuLabel);
+      body.appendChild(skuValue);
+      body.appendChild(nameEl);
+      body.appendChild(categoryEl);
+      body.appendChild(detailsBtn);
+      card.appendChild(body);
+
+      cardsContainer?.appendChild(card);
+    });
+  }
+
+  updateSummary(sorted);
+}
+
+function subscribeToCatalog(uid) {
+  if (catalogUnsub) {
+    catalogUnsub();
+    catalogUnsub = null;
+  }
+  if (!uid) return;
+  const colRef = collection(db, 'usuarios', uid, 'catalogoProdutos');
+  const q = query(colRef, orderBy('createdAt', 'desc'));
+  catalogUnsub = onSnapshot(
+    q,
+    (snapshot) => {
+      const produtos = [];
+      snapshot.forEach((docSnap) => {
+        const data = docSnap.data() || {};
+        produtos.push({ id: docSnap.id, ...data });
+      });
+      renderProducts(produtos);
+    },
+    (error) => {
+      console.error('Erro ao carregar catálogo:', error);
+      showToast('Não foi possível carregar os produtos do catálogo.', 'error');
+    },
+  );
+}
+
+async function resolveResponsavel(user, profile) {
+  if (typeof window !== 'undefined' && window.responsavelFinanceiro) {
+    return window.responsavelFinanceiro;
+  }
+  let email = null;
+  try {
+    const userDoc = await getDoc(doc(db, 'usuarios', user.uid));
+    if (userDoc.exists()) {
+      const data = userDoc.data() || {};
+      email = (data.responsavelFinanceiroEmail || '').trim() || email;
+    }
+  } catch (err) {
+    console.warn('Não foi possível obter dados do usuário:', err);
+  }
+  if (!email && profile && profile.responsavelFinanceiroEmail) {
+    email = (profile.responsavelFinanceiroEmail || '').trim();
+  }
+  if (!email) {
+    try {
+      const uidDoc = await getDoc(doc(db, 'uid', user.uid));
+      if (uidDoc.exists()) {
+        email =
+          (uidDoc.data().responsavelFinanceiroEmail || '').trim() || email;
+      }
+    } catch (err) {
+      console.warn('Falha ao consultar documento UID:', err);
+    }
+  }
+  if (!email) return null;
+
+  try {
+    const responsavelQuery = query(
+      collection(db, 'usuarios'),
+      where('email', '==', email),
+    );
+    const responsavelDocs = await getDocs(responsavelQuery);
+    if (!responsavelDocs.empty) {
+      const docSnap = responsavelDocs.docs[0];
+      const data = docSnap.data() || {};
+      return {
+        uid: docSnap.id,
+        email,
+        nome: data.nome || email,
+      };
+    }
+    return { uid: null, email, nome: email };
+  } catch (err) {
+    console.error('Erro ao localizar responsável financeiro:', err);
+    return { uid: null, email, nome: email };
+  }
+}
+
+function definirResponsavelCatalogo(perfilNormalizado) {
+  if (perfilNormalizado === 'gestor' || perfilNormalizado === 'adm') {
+    responsavelInfo = {
+      uid: currentUser.uid,
+      email: currentUser.email,
+      nome:
+        currentProfile?.nome ||
+        currentUser.displayName ||
+        currentUser.email ||
+        'Responsável',
+    };
+    scopeUid = currentUser.uid;
+    if (managerEl) managerEl.textContent = responsavelInfo.nome;
+    return;
+  }
+
+  if (responsavelInfo?.uid) {
+    scopeUid = responsavelInfo.uid;
+    if (managerEl)
+      managerEl.textContent = responsavelInfo.nome || responsavelInfo.email;
+  } else {
+    scopeUid = currentUser.uid;
+    if (managerEl)
+      managerEl.textContent =
+        currentProfile?.nome || currentUser.displayName || currentUser.email;
+  }
+}
+
+async function handleSubmit(event) {
+  event.preventDefault();
+  if (!canEdit || !form || isSubmitting) return;
+  if (!scopeUid) {
+    showToast(
+      'Não foi possível identificar o responsável pelo catálogo.',
+      'error',
+    );
+    return;
+  }
+
+  const nome = nameInput?.value.trim();
+  const sku = skuInput?.value.trim();
+  const custoValor = costInput?.value.trim();
+  const precoValor = priceInput?.value.trim();
+  const categoria = categoryInput?.value.trim();
+  const descricao = descriptionInput?.value.trim();
+  const medidas = measuresInput?.value.trim();
+  const arquivos = photosInput?.files ? Array.from(photosInput.files) : [];
+
+  if (!nome || !sku) {
+    showToast('Preencha os campos obrigatórios (nome e SKU).', 'warning');
+    return;
+  }
+
+  const custo = custoValor ? Number(custoValor.replace(',', '.')) : null;
+  const preco = precoValor ? Number(precoValor.replace(',', '.')) : null;
+
+  const responsavel =
+    scopeUid === currentUser.uid
+      ? {
+          uid: currentUser.uid,
+          email: currentUser.email,
+          nome:
+            currentProfile?.nome ||
+            currentUser.displayName ||
+            currentUser.email,
+        }
+      : responsavelInfo;
+
+  const payload = {
+    nome,
+    sku,
+    custo: typeof custo === 'number' && !Number.isNaN(custo) ? custo : null,
+    precoSugerido:
+      typeof preco === 'number' && !Number.isNaN(preco) ? preco : null,
+    categoria: categoria || null,
+    descricao: descricao || null,
+    medidas: medidas || null,
+    fotos: [],
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+    criadoPorUid: currentUser.uid,
+    criadoPorEmail: currentUser.email,
+    criadoPorNome:
+      currentProfile?.nome || currentUser.displayName || currentUser.email,
+    responsavelUid: responsavel?.uid || scopeUid,
+    responsavelEmail: responsavel?.email || null,
+    responsavelNome: responsavel?.nome || null,
+  };
+
+  const colRef = collection(db, 'usuarios', scopeUid, 'catalogoProdutos');
+  const docRef = doc(colRef);
+
+  try {
+    isSubmitting = true;
+    if (submitBtn) {
+      submitBtn.disabled = true;
+      submitBtn.classList.add('opacity-60');
+    }
+
+    const fotosSalvas = [];
+    for (const arquivo of arquivos) {
+      if (!(arquivo instanceof File)) continue;
+      const path = `catalogo/${scopeUid}/${docRef.id}/${Date.now()}-${arquivo.name}`;
+      const storageRef = ref(storage, path);
+      await uploadBytes(storageRef, arquivo);
+      const url = await getDownloadURL(storageRef);
+      fotosSalvas.push({ nome: arquivo.name, url, storagePath: path });
+    }
+    payload.fotos = fotosSalvas;
+
+    await setDoc(docRef, payload);
+    showToast('Produto cadastrado no catálogo com sucesso!');
+    clearForm();
+    toggleForm(false);
+  } catch (err) {
+    console.error('Erro ao cadastrar produto no catálogo:', err);
+    showToast('Erro ao cadastrar produto. Tente novamente.', 'error');
+  } finally {
+    isSubmitting = false;
+    if (submitBtn) {
+      submitBtn.disabled = false;
+      submitBtn.classList.remove('opacity-60');
+    }
+  }
+}
+
+function setupEventListeners() {
+  addItemBtn?.addEventListener('click', () => toggleForm(true));
+  cancelFormBtn?.addEventListener('click', () => {
+    clearForm();
+    toggleForm(false);
+  });
+  form?.addEventListener('submit', handleSubmit);
+  modalCloseBtn?.addEventListener('click', closeModal);
+  modalBackdrop?.addEventListener('click', closeModal);
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && !modal?.classList.contains('hidden')) {
+      closeModal();
+    }
+  });
+}
+
+setupEventListeners();
+
+onAuthStateChanged(auth, async (user) => {
+  if (!user) {
+    window.location.href = 'login.html?login=1';
+    return;
+  }
+  currentUser = user;
+  currentProfile =
+    (typeof window !== 'undefined' && window.userProfile) ||
+    (await loadUserProfile(user.uid));
+  const perfilNormalizado = normalizePerfil(currentProfile?.perfil);
+  const isFinanceiroResponsavel =
+    typeof window !== 'undefined' && Boolean(window.isFinanceiroResponsavel);
+  canEdit =
+    perfilNormalizado === 'gestor' ||
+    perfilNormalizado === 'adm' ||
+    isFinanceiroResponsavel;
+
+  if (!canEdit && addItemBtn) {
+    addItemBtn.classList.add('hidden');
+  } else if (canEdit && addItemBtn) {
+    addItemBtn.classList.remove('hidden');
+  }
+
+  responsavelInfo = await resolveResponsavel(user, currentProfile);
+  definirResponsavelCatalogo(perfilNormalizado);
+  subscribeToCatalog(scopeUid);
+});
+
+window.catalogo = {
+  abrirDetalhesPorId(id) {
+    if (!id) return;
+    const produto = productCache.get(id);
+    if (produto) openModal(produto);
+  },
+};

--- a/login.js
+++ b/login.js
@@ -111,6 +111,7 @@ const EXPEDICAO_ALLOWED_MENU_IDS = [
   'menu-configuracoes',
   'menu-painel-atualizacoes-gerais',
   'menu-equipes',
+  'menu-catalogo',
 ];
 const CASAROSA_ALLOWED_MENU_IDS = [
   'menu-casarosa-controle-vendas',
@@ -125,6 +126,7 @@ const CASAROSA_ALLOWED_MENU_IDS = [
   'menu-casarosa-conferir-sobras',
   'menu-casarosa-equipes',
   'menu-casarosa-painel-atualizacoes',
+  'menu-catalogo',
 ];
 const SELLER_ALLOWED_MENU_IDS = [
   'menu-seller-expedicao',
@@ -569,6 +571,7 @@ function normalizePerfil(perfil) {
       'responsavel',
       'gestor financeiro',
       'responsavel financeiro',
+      'gerente',
     ].includes(base)
   )
     return 'gestor';
@@ -618,6 +621,7 @@ function applyPerfilRestrictions(perfil) {
       'menu-comunicacao',
       'menu-painel-atualizacoes-gerais',
       'menu-painel-atualizacoes-mentorados',
+      'menu-catalogo',
     ],
     cliente: [
       'menu-vendas',
@@ -629,6 +633,7 @@ function applyPerfilRestrictions(perfil) {
       'menu-comunicacao',
       'menu-painel-atualizacoes-gerais',
       'menu-painel-atualizacoes-mentorados',
+      'menu-catalogo',
     ],
     gestor: [
       'menu-atualizacoes',
@@ -648,6 +653,7 @@ function applyPerfilRestrictions(perfil) {
       'menu-acompanhamento-gestor',
       'menu-sku-associado',
       'menu-desempenho',
+      'menu-catalogo',
     ],
     seller: SELLER_ALLOWED_MENU_IDS,
     posvendas: POSVENDAS_ALLOWED_MENU_IDS,

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -679,7 +679,7 @@
         <span class="link-text">Configuração de Perfil</span>
       </a>
     </li>
-    <li data-perfil="seller,posvendas">
+    <li>
       <a
         href="/catalogo.html"
         class="sidebar-link flex items-center py-2 px-4 transition-colors"


### PR DESCRIPTION
## Summary
- expose the Catálogo menu item for every profile and align profile normalization for gerentes
- redesign the catalog page with a registration form, card grid, and details modal tailored to the catalog workflow
- add a catalog controller that syncs products to Firestore/Storage so gestores can publish items that their teams can view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff5831f644832a9e6d547cd0aa0219