### PR TITLE
Ensure finance managers see catalog sidebar entry

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -636,6 +636,7 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-acompanhamento-problemas',
     'menu-mentoria',
     'menu-produtos',
+    'menu-catalogo',
     'menu-configuracoes',
     'menu-equipes',
     'menu-perfil-mentorado',
@@ -708,6 +709,7 @@ document.addEventListener('sidebarLoaded', async () => {
     const acompProblemas = getLi('menu-acompanhamento-problemas');
     const mentoria = getLi('menu-mentoria');
     const gestaoProdutos = getLi('menu-produtos');
+    const catalogo = getLi('menu-catalogo');
     const equipes = getLi('menu-equipes');
     const configuracoes = getLi('menu-configuracoes');
     const perfilMentorado = getLi('menu-perfil-mentorado');
@@ -757,6 +759,7 @@ document.addEventListener('sidebarLoaded', async () => {
       acompProblemas,
       mentoria,
       gestaoProdutos,
+      catalogo,
       equipes,
     ]);
     const configuracoesGroup = createGroup(


### PR DESCRIPTION
## Summary
- allow the gestor/financeiro sidebar layout to keep the Catálogo link visible
- include the catalog item inside the gestor grouping so it remains accessible

## Testing
- No automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff600a0064832a80ac1079f0d33244