### PR TITLE
Add external image URL option for catalog products

### DIFF
--- a/catalogo.html
+++ b/catalogo.html
@@ -223,6 +223,22 @@
                     Utilize imagens em formato JPG ou PNG com até 10 MB.
                   </p>
                 </div>
+                <div class="flex flex-col">
+                  <label
+                    for="catalogProductPhotoUrls"
+                    class="text-sm font-medium text-gray-700"
+                    >URLs das fotos</label
+                  >
+                  <textarea
+                    id="catalogProductPhotoUrls"
+                    rows="2"
+                    class="mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    placeholder="Cole uma URL por linha (ex.: https://exemplo.com/imagem.jpg)"
+                  ></textarea>
+                  <p class="mt-1 text-xs text-gray-500">
+                    Utilize esta opção caso prefira referenciar imagens hospedadas externamente.
+                  </p>
+                </div>
               </div>
               <div class="flex items-center justify-end gap-3">
                 <button


### PR DESCRIPTION
## Summary
- add a text area to the catalog form so products can include image URLs without uploading files
- capture the provided URLs during submission and attach them to the saved product payload
- make the submission flow more resilient by skipping failed storage uploads and notifying the user

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff62b729c4832a8b63c69230a95315