### PR TITLE
Fix catalog product modal scrolling

### DIFF
--- a/catalogo.html
+++ b/catalogo.html
@@ -286,7 +286,7 @@
 
       <div
         id="catalogDetailsModal"
-        class="fixed inset-0 z-50 hidden"
+        class="fixed inset-0 z-50 hidden overflow-y-auto"
         role="dialog"
         aria-modal="true"
       >
@@ -294,7 +294,7 @@
           id="catalogDetailsBackdrop"
           class="absolute inset-0 bg-black bg-opacity-50"
         ></div>
-        <div class="relative mx-auto mt-20 w-full max-w-3xl px-4">
+        <div class="relative z-10 mx-auto my-12 w-full max-w-3xl px-4">
           <div class="overflow-hidden rounded-lg bg-white shadow-xl">
             <div
               class="flex items-center justify-between border-b border-gray-200 px-6 py-4"


### PR DESCRIPTION
## Summary
- allow the catalog product details modal to scroll independently of the page
- adjust modal container spacing and stacking so long content remains visible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff65da914c832a940c335bfd07aa59