### PR TITLE
Add color variation support to catalog products

### DIFF
--- a/catalogo.html
+++ b/catalogo.html
@@ -106,6 +106,13 @@
           </div>
           <div id="catalogFormWrapper" class="card-body hidden">
             <form id="catalogProductForm" class="space-y-6">
+              <div
+                id="catalogFormEditAlert"
+                class="hidden rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-700"
+              >
+                Editando um produto existente. As alterações serão salvas ao
+                atualizar o cadastro.
+              </div>
               <div class="grid gap-4 sm:grid-cols-2">
                 <div class="flex flex-col">
                   <label
@@ -236,8 +243,36 @@
                     placeholder="Cole uma URL por linha (ex.: https://exemplo.com/imagem.jpg)"
                   ></textarea>
                   <p class="mt-1 text-xs text-gray-500">
-                    Utilize esta opção caso prefira referenciar imagens hospedadas externamente.
+                    Utilize esta opção caso prefira referenciar imagens
+                    hospedadas externamente.
                   </p>
+                </div>
+                <div class="flex flex-col">
+                  <div
+                    class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <label
+                      for="catalogColorVariationsList"
+                      class="text-sm font-medium text-gray-700"
+                      >Variações de cor</label
+                    >
+                    <button
+                      type="button"
+                      id="catalogAddColorVariationBtn"
+                      class="inline-flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-700 transition hover:bg-blue-100"
+                    >
+                      <i class="fa-solid fa-plus"></i>
+                      <span>Adicionar variação</span>
+                    </button>
+                  </div>
+                  <p class="mt-1 text-xs text-gray-500">
+                    Cadastre o nome da cor e o link da imagem representando a
+                    variação.
+                  </p>
+                  <div
+                    id="catalogColorVariationsList"
+                    class="mt-3 space-y-3"
+                  ></div>
                 </div>
               </div>
               <div class="flex items-center justify-end gap-3">
@@ -369,6 +404,12 @@
                   class="mt-1 whitespace-pre-line text-sm text-gray-700"
                   id="catalogDetailsMedidas"
                 ></p>
+              </div>
+              <div id="catalogDetailsVariacoesSection" class="hidden">
+                <p class="text-xs font-semibold uppercase text-gray-500">
+                  Variações de cor
+                </p>
+                <div id="catalogDetailsVariacoes" class="mt-3 space-y-3"></div>
               </div>
               <div>
                 <p class="text-xs font-semibold uppercase text-gray-500">


### PR DESCRIPTION
## Summary
- add color variation inputs to the catalog form and show the data inside the product details modal
- enable editing of existing catalog products, including pre-filling fields and showing an edit alert
- update catalog cards with variation chips and an edit action for quick access

## Testing
- npx prettier --write catalogo.html catalogo.js

------
https://chatgpt.com/codex/tasks/task_e_68ff69e7bf48832a9a46bba7a5b542ea