### PR TITLE
Exibir Catálogo para usuários

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -652,6 +652,7 @@ document.addEventListener('sidebarLoaded', async () => {
         'menu-painel-atualizacoes-gerais',
         'menu-painel-atualizacoes-mentorados',
         'menu-saques',
+        'menu-catalogo',
         'menu-equipes',
       ].includes(id),
   );
@@ -665,6 +666,7 @@ document.addEventListener('sidebarLoaded', async () => {
     'menu-precificacao',
     'menu-expedicao',
     'menu-comunicacao',
+    'menu-catalogo',
     'menu-equipes',
     'menu-configuracoes',
   ];


### PR DESCRIPTION
## Summary
- ensure the Catalog link is not hidden for user profiles
- add the Catalog entry to the client sidebar ordering so it appears alongside other menus

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff714fbd64832a8c524b45fc53c8c6