### PR TITLE
Add copy and download controls to catalog product modal

### DIFF
--- a/catalogo.html
+++ b/catalogo.html
@@ -380,12 +380,22 @@
             <div
               class="flex items-center justify-between border-b border-gray-200 px-6 py-4"
             >
-              <h3
-                class="text-lg font-semibold text-gray-900"
-                id="catalogDetailsTitle"
-              >
-                Detalhes do produto
-              </h3>
+              <div class="flex items-center gap-3">
+                <h3
+                  class="text-lg font-semibold text-gray-900"
+                  id="catalogDetailsTitle"
+                >
+                  Detalhes do produto
+                </h3>
+                <button
+                  type="button"
+                  id="catalogCopyTitleBtn"
+                  class="inline-flex items-center gap-2 rounded-md bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-600 transition hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1"
+                >
+                  <i class="fa-solid fa-copy text-xs"></i>
+                  <span>Copiar título</span>
+                </button>
+              </div>
               <button
                 id="catalogDetailsClose"
                 class="text-gray-500 transition hover:text-gray-700"
@@ -434,9 +444,19 @@
                 </div>
               </div>
               <div>
-                <p class="text-xs font-semibold uppercase text-gray-500">
-                  Descrição
-                </p>
+                <div class="flex items-center justify-between gap-3">
+                  <p class="text-xs font-semibold uppercase text-gray-500">
+                    Descrição
+                  </p>
+                  <button
+                    type="button"
+                    id="catalogCopyDescriptionBtn"
+                    class="inline-flex items-center gap-2 rounded-md bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600 transition hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1"
+                  >
+                    <i class="fa-solid fa-copy text-xs"></i>
+                    <span>Copiar descrição</span>
+                  </button>
+                </div>
                 <p
                   class="mt-1 whitespace-pre-line text-sm text-gray-700"
                   id="catalogDetailsDescricao"
@@ -461,9 +481,19 @@
                 ></div>
               </div>
               <div>
-                <p class="text-xs font-semibold uppercase text-gray-500">
-                  Fotos
-                </p>
+                <div class="flex items-center justify-between gap-3">
+                  <p class="text-xs font-semibold uppercase text-gray-500">
+                    Fotos
+                  </p>
+                  <button
+                    type="button"
+                    id="catalogDownloadImagesBtn"
+                    class="inline-flex items-center gap-2 rounded-md bg-blue-50 px-3 py-1 text-xs font-medium text-blue-600 transition hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
+                  >
+                    <i class="fa-solid fa-download text-xs"></i>
+                    <span>Baixar imagens</span>
+                  </button>
+                </div>
                 <div
                   id="catalogDetailsFotos"
                   class="mt-3 grid gap-3 sm:grid-cols-3"


### PR DESCRIPTION
## Summary
- add copy buttons for the product title and description inside the catalog details modal
- add a control to download every product image with loading feedback and graceful error handling
- wire up clipboard and download helpers plus modal state resets in `catalogo.js`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6900a0de4200832a87cbb538eb383e7e