### PR TITLE
Fix Equipes task modal display when opening new task

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1272,6 +1272,20 @@ body.dark-mode .table tr:nth-child(2n) {
   backdrop-filter: blur(4px);
   animation: 0.3s fadeIn;
 }
+
+dialog.modal[open] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background-color: transparent;
+}
+
+dialog.modal::backdrop {
+  background-color: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
 .modal-content {
   background-color: var(--background);
   margin: 5% auto;


### PR DESCRIPTION
## Summary
- ensure dialog-based task modal displays when the dialog is opened
- style the dialog backdrop so the overlay appears consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6900b0a3b648832a9778b25a9bea2a43