### PR TITLE
Fix layout overlap on equipes page

### DIFF
--- a/equipes.html
+++ b/equipes.html
@@ -31,11 +31,14 @@
       .page-wrapper {
         min-height: 100vh;
         display: flex;
+        width: 100%;
+        padding-left: min(var(--sidebar-width, 18rem), 80vw);
       }
 
       .main-content {
         flex: 1;
-        padding: 32px 24px 48px;
+        width: 100%;
+        padding: calc(var(--navbar-height, 64px) + 32px) 24px 48px;
         max-width: 1200px;
         margin: 0 auto;
       }
@@ -712,9 +715,19 @@
         color: #ef4444;
       }
 
+      @media (max-width: 1023px) {
+        .page-wrapper {
+          padding-left: 0;
+        }
+
+        .main-content {
+          padding: 96px 20px 40px;
+        }
+      }
+
       @media (max-width: 960px) {
         .main-content {
-          padding: 24px 16px 40px;
+          padding: calc(var(--navbar-height, 64px) + 24px) 16px 40px;
         }
 
         .card {


### PR DESCRIPTION
## Summary
- add desktop left padding to the equipes page wrapper so the sidebar no longer overlaps the content
- increase the main content top padding across breakpoints to keep sections below the fixed navbar

## Testing
- No tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6901044382f4832ab84128b267dfb41c