### PR TITLE
Add team registration workflow for financial managers

### DIFF
--- a/responsavel-financeiro.js
+++ b/responsavel-financeiro.js
@@ -37,10 +37,21 @@ export async function fetchResponsavelFinanceiroUsuarios(db, email) {
       } catch (_) {}
     }
     const emailUser = dados.email || '';
+    const cargo = dados.cargo || dados.perfil || '';
+    const responsavelFinanceiroEmail = dados.responsavelFinanceiroEmail || null;
+    const responsavelExpedicaoEmail =
+      dados.responsavelExpedicaoEmail ||
+      (Array.isArray(dados.gestoresExpedicaoEmails)
+        ? dados.gestoresExpedicaoEmails[0]
+        : null);
     usuarios.push({
       uid: d.id,
       nome: nome || emailUser || d.id,
       email: emailUser,
+      cargo,
+      perfil: dados.perfil || '',
+      responsavelFinanceiroEmail,
+      responsavelExpedicaoEmail,
     });
   }
   return usuarios;

--- a/resumo-equipe.html
+++ b/resumo-equipe.html
@@ -124,6 +124,13 @@
             >
               Acompanhamento de Problemas
             </button>
+            <button
+              id="tabBtnCadastroEquipe"
+              class="tab-btn rounded-lg border border-indigo-100 bg-white px-4 py-2 text-sm font-medium text-indigo-600 shadow hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-200 hidden"
+              data-tab="cadastro"
+            >
+              Cadastro da Equipe
+            </button>
           </div>
 
           <div id="tab-diario" class="space-y-4">
@@ -227,6 +234,144 @@
                 class="h-[75vh] w-full border-0"
                 loading="lazy"
               ></iframe>
+            </div>
+          </div>
+
+          <div id="tab-cadastro" class="space-y-4 hidden">
+            <div class="rounded-xl border border-indigo-100 bg-white p-4 shadow">
+              <h3 class="text-lg font-semibold text-gray-700">
+                Limites de integrantes por cargo
+              </h3>
+              <p class="text-sm text-gray-500">
+                Cada responsável financeiro pode cadastrar até o limite abaixo
+                para cada cargo.
+              </p>
+              <ul class="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+                <li class="rounded-lg bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700">
+                  Vendedores:
+                  <span data-cargo-count="vendedor" class="font-semibold">0/10</span>
+                </li>
+                <li class="rounded-lg bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700">
+                  Gestores de expedição:
+                  <span data-cargo-count="gestor_expedicao" class="font-semibold">0/2</span>
+                </li>
+                <li class="rounded-lg bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700">
+                  Pós-vendas:
+                  <span data-cargo-count="posvendas" class="font-semibold">0/3</span>
+                </li>
+                <li class="rounded-lg bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700">
+                  Usuários:
+                  <span data-cargo-count="usuario" class="font-semibold">0/5</span>
+                </li>
+              </ul>
+            </div>
+
+            <form
+              id="cadastroEquipeForm"
+              class="grid gap-4 rounded-xl border border-gray-200 bg-white p-4 shadow md:grid-cols-2"
+            >
+              <div class="md:col-span-1">
+                <label class="block text-sm font-medium text-gray-700"
+                  >Nome completo
+                  <input
+                    type="text"
+                    id="cadastroEquipeNome"
+                    class="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                    required
+                  />
+                </label>
+              </div>
+              <div class="md:col-span-1">
+                <label class="block text-sm font-medium text-gray-700"
+                  >Cargo
+                  <select
+                    id="cadastroEquipeCargo"
+                    class="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                    required
+                  >
+                    <option value="vendedor">Vendedor</option>
+                    <option value="gestor_expedicao">Gestor de expedição</option>
+                    <option value="posvendas">Pós-vendas</option>
+                    <option value="usuario">Usuário</option>
+                  </select>
+                </label>
+              </div>
+              <div class="md:col-span-1">
+                <label class="block text-sm font-medium text-gray-700"
+                  >E-mail de acesso
+                  <input
+                    type="email"
+                    id="cadastroEquipeEmail"
+                    class="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                    required
+                  />
+                </label>
+              </div>
+              <div class="md:col-span-1">
+                <label class="block text-sm font-medium text-gray-700"
+                  >Senha inicial
+                  <input
+                    type="password"
+                    id="cadastroEquipeSenha"
+                    minlength="6"
+                    class="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                    required
+                  />
+                </label>
+              </div>
+              <div class="md:col-span-2">
+                <label class="block text-sm font-medium text-gray-700"
+                  >Responsável pela expedição
+                  <input
+                    type="email"
+                    id="cadastroEquipeResponsavelExpedicao"
+                    placeholder="E-mail do gestor de expedição associado"
+                    class="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                  />
+                </label>
+                <p class="mt-1 text-xs text-gray-500">
+                  Informe o e-mail do gestor de expedição responsável pelo
+                  integrante. Para gestores de expedição deixe em branco para usar
+                  o próprio e-mail cadastrado.
+                </p>
+              </div>
+              <div class="md:col-span-2 flex items-center justify-end gap-3">
+                <span id="cadastroEquipeStatus" class="text-sm text-gray-500"></span>
+                <button
+                  type="submit"
+                  class="inline-flex items-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                >
+                  Cadastrar integrante
+                </button>
+              </div>
+            </form>
+
+            <div class="rounded-xl border border-gray-200 bg-white p-4 shadow">
+              <h3 class="text-lg font-semibold text-gray-700">
+                Equipe cadastrada
+              </h3>
+              <p class="text-sm text-gray-500">
+                Lista dos integrantes vinculados ao seu e-mail de responsável
+                financeiro.
+              </p>
+              <div
+                class="mt-3 overflow-x-auto rounded-lg border border-gray-100"
+              >
+                <table class="min-w-full divide-y divide-gray-200 text-sm">
+                  <thead class="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+                    <tr>
+                      <th class="px-4 py-2 text-left">Nome</th>
+                      <th class="px-4 py-2 text-left">Cargo</th>
+                      <th class="px-4 py-2 text-left">E-mail</th>
+                      <th class="px-4 py-2 text-left">Resp. expedição</th>
+                    </tr>
+                  </thead>
+                  <tbody id="cadastroEquipeTabela" class="divide-y divide-gray-100"></tbody>
+                </table>
+              </div>
+              <p id="cadastroEquipeVazio" class="mt-3 text-sm text-gray-500 hidden">
+                Nenhum integrante cadastrado até o momento.
+              </p>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- add a callable Cloud Function that lets responsáveis financeiros create team members with role quotas, Authentication accounts, and Firestore records
- expose the new team registration tab and form on the resumo da equipe page with UI feedback and integration with the Cloud Function
- include cargo and responsável metadata when loading users associated to a responsável financeiro so the UI can render limits and expedition links

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69013772c714832aa8dbdf85b0ff5cf7