### PR TITLE
Compartilhar problemas com responsável pós-vendas

### DIFF
--- a/email-expedicao.html
+++ b/email-expedicao.html
@@ -19,6 +19,7 @@
     <form id="emailForm" class="space-y-4 max-w-lg">
       <input type="text" id="emailExpedicao" placeholder="email@empresa.com, outro@empresa.com (máximo 2)" class="w-full p-2 border rounded">
       <input type="email" id="emailFinanceiro" placeholder="financeiro@empresa.com" class="w-full p-2 border rounded">
+      <input type="email" id="emailPosVendas" placeholder="posvendas@empresa.com" class="w-full p-2 border rounded">
       <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Salvar</button>
     </form>
     <p id="status" class="mt-4 text-green-600 hidden"></p>
@@ -47,6 +48,7 @@
     let currentUser = null;
     const input = document.getElementById('emailExpedicao');
     const financeInput = document.getElementById('emailFinanceiro');
+    const posInput = document.getElementById('emailPosVendas');
     const statusEl = document.getElementById('status');
     const teamForm = document.getElementById('teamMemberForm');
     const teamMembersList = document.getElementById('teamMembersList');
@@ -66,6 +68,7 @@
         const emails = data.gestoresExpedicaoEmails || data.responsavelExpedicaoEmail || '';
         input.value = Array.isArray(emails) ? emails.join(', ') : emails;
         financeInput.value = data.responsavelFinanceiroEmail || '';
+        posInput.value = data.responsavelPosVendasEmail || '';
       } catch (e) {
         console.error('Erro ao carregar e-mail:', e);
       }
@@ -110,17 +113,20 @@
         return;
       }
       const emailFinanceiro = financeInput.value.trim();
+      const emailPosVendas = posInput.value.trim();
       try {
         await db.collection('uid').doc(currentUser.uid).set({
           responsavelExpedicaoEmail: emails[0] || null,
           gestoresExpedicaoEmails: emails,
           responsavelFinanceiroEmail: emailFinanceiro || null,
+          responsavelPosVendasEmail: emailPosVendas || null,
           uid: currentUser.uid,
           email: currentUser.email
         }, { merge: true });
         await db.collection('usuarios').doc(currentUser.uid).set({
           responsavelFinanceiroEmail: emailFinanceiro || null,
           gestoresExpedicaoEmails: emails,
+          responsavelPosVendasEmail: emailPosVendas || null,
           email: currentUser.email
         }, { merge: true });
         statusEl.textContent = 'E-mail salvo com sucesso!';

--- a/problemas.js
+++ b/problemas.js
@@ -14,7 +14,7 @@ import {
   onAuthStateChanged,
 } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
 import { firebaseConfig } from './firebase-config.js';
-import { setDocWithCopy } from './secure-firestore.js';
+import { setDocWithCopy, getObserverUids } from './secure-firestore.js';
 
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 const db = getFirestore(app);
@@ -1061,17 +1061,19 @@ async function excluirReembolso(id) {
 
 async function deleteDocWithCopy(ref) {
   await deleteDoc(ref);
-  const responsavelUid =
-    typeof window !== 'undefined' && window.responsavelFinanceiro?.uid;
-  if (responsavelUid && responsavelUid !== uidAtual) {
-    const segmentos = ref.path.split('/');
-    const relativo = segmentos.slice(2).join('/');
-    const copiaRef = doc(
-      ref.firestore,
-      `uid/${responsavelUid}/uid/${uidAtual}/${relativo}`,
-    );
-    await deleteDoc(copiaRef);
-  }
+  const observers = getObserverUids(uidAtual);
+  if (!observers.length) return;
+  const segmentos = ref.path.split('/');
+  const relativo = segmentos.slice(2).join('/');
+  await Promise.all(
+    observers.map((targetUid) => {
+      const copiaRef = doc(
+        ref.firestore,
+        `uid/${targetUid}/uid/${uidAtual}/${relativo}`,
+      );
+      return deleteDoc(copiaRef).catch(() => {});
+    }),
+  );
 }
 
 // Tabs


### PR DESCRIPTION
## Summary
- allow sellers to cadastrar o e-mail do responsável pós-vendas na aba de e-mails de expedição
- replicar registros de problemas para os observadores configurados (financeiro e pós-vendas) e manter as cópias sincronizadas
- expor os mentorados ligados ao usuário por vínculo de pós-vendas para que o login e os painéis reconheçam o relacionamento

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69016443bb84832ab9fd374c5a967659