### PR TITLE
Add pós-vendas dashboard for managing vendedor problemas

### DIFF
--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -844,6 +844,29 @@
         <span class="link-text">Acompanhamento Diário</span>
       </a>
     </li>
+    <li data-perfil="posvendas">
+      <a
+        href="/problemas-vendedores.html"
+        class="sidebar-link flex items-center py-2 px-4 transition-colors"
+        id="menu-problemas-vendedores"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-5 h-5 mr-3"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M8.25 4.5h-2.5A1.75 1.75 0 0 0 4 6.25v11.5A1.75 1.75 0 0 0 5.75 19.5h12.5A1.75 1.75 0 0 0 20 17.75V9.75a1.75 1.75 0 0 0-1.75-1.75h-5.5a1.75 1.75 0 0 1-1.75-1.75v-1.75A1.75 1.75 0 0 0 9.25 3H8.25m0 0V4.5m0-1.5h3"
+          />
+        </svg>
+        <span class="link-text">Problemas Vendedores</span>
+      </a>
+    </li>
     <li>
       <a
         href="/painel-atualizacoes-mentorados.html"

--- a/problemas-vendedores.html
+++ b/problemas-vendedores.html
@@ -1,0 +1,238 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Problemas Vendedores</title>
+    <script src="https://cdn.tailwindcss.com/3.3.5"></script>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="css/styles.css?v=20240826" />
+    <link rel="stylesheet" href="css/tabs-mobile.css?v=20240826" />
+  </head>
+  <body class="min-h-screen bg-slate-50 text-slate-700">
+    <div class="app-container">
+      <div id="sidebar-container"></div>
+      <div id="navbar-container"></div>
+      <main class="main-content px-4 sm:px-6 lg:px-8 py-6">
+        <div class="max-w-7xl mx-auto space-y-6">
+          <header class="space-y-2">
+            <h1 class="text-2xl font-semibold text-slate-800">
+              Problemas Vendedores
+            </h1>
+            <p class="text-sm text-slate-500 max-w-3xl">
+              Acompanhe e atualize os reembolsos e registros de peças faltantes
+              de todos os vendedores que indicaram este pós-vendas.
+            </p>
+          </header>
+
+          <section class="card">
+            <div class="card-body grid gap-4 md:grid-cols-2 lg:grid-cols-4 items-end">
+              <div class="space-y-1 md:col-span-2">
+                <label for="filtroVendedor" class="text-sm font-medium text-slate-600"
+                  >Selecionar vendedor</label
+                >
+                <select
+                  id="filtroVendedor"
+                  class="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500"
+                >
+                  <option value="">Todos os vendedores vinculados</option>
+                </select>
+              </div>
+              <div class="space-y-1">
+                <label for="buscaGlobal" class="text-sm font-medium text-slate-600"
+                  >Busca geral</label
+                >
+                <input
+                  type="text"
+                  id="buscaGlobal"
+                  placeholder="Filtrar por apelido, pedido, loja..."
+                  class="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500"
+                />
+              </div>
+              <div class="flex flex-col gap-2">
+                <span class="text-xs uppercase text-slate-500 tracking-wide"
+                  >Resumo</span
+                >
+                <p id="resumoVendedores" class="text-sm text-slate-600">
+                  Buscando vendedores vinculados...
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <nav class="border-b border-slate-200 flex space-x-6 text-sm font-medium">
+            <button
+              class="tab-btn pb-2 -mb-px border-b-2 border-violet-600 text-violet-600"
+              data-tab="tab-reembolsos"
+            >
+              Reembolsos
+            </button>
+            <button
+              class="tab-btn pb-2 -mb-px border-b-2 border-transparent text-slate-500"
+              data-tab="tab-pecas"
+            >
+              Peças Faltando
+            </button>
+          </nav>
+
+          <section id="tab-reembolsos" class="tab-panel space-y-4">
+            <div class="card">
+              <div class="card-body grid gap-4 md:grid-cols-4">
+                <div class="space-y-1">
+                  <label
+                    for="filtroStatusReembolsos"
+                    class="text-sm font-medium text-slate-600"
+                    >Status</label
+                  >
+                  <select
+                    id="filtroStatusReembolsos"
+                    class="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500"
+                  >
+                    <option value="">Todos</option>
+                    <option value="AGUARDANDO PIX">Aguardando PIX</option>
+                    <option value="AGUARDANDO MERCADO">Aguardando Mercado</option>
+                    <option value="AGUARDANDO">Aguardando</option>
+                    <option value="FEITO">Feito</option>
+                    <option value="FEITO PIX">Feito PIX</option>
+                    <option value="FEITO MERCADO">Feito Mercado</option>
+                    <option value="CANCELADO">Cancelado</option>
+                  </select>
+                </div>
+                <div class="space-y-1 md:col-span-2">
+                  <label for="buscaReembolsos" class="text-sm font-medium text-slate-600"
+                    >Buscar</label
+                  >
+                  <input
+                    type="text"
+                    id="buscaReembolsos"
+                    placeholder="Filtrar por apelido, pedido, loja, PIX..."
+                    class="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500"
+                  />
+                </div>
+                <div class="flex items-end">
+                  <span
+                    id="statusReembolsos"
+                    class="text-xs text-slate-500 px-3 py-1 rounded-full bg-slate-100"
+                    >Carregando dados...</span
+                  >
+                </div>
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="card-body overflow-x-auto">
+                <table class="min-w-full divide-y divide-slate-200 text-sm">
+                  <thead class="bg-slate-100 text-slate-600">
+                    <tr>
+                      <th class="px-4 py-3 text-left">Vendedor</th>
+                      <th class="px-4 py-3">Data</th>
+                      <th class="px-4 py-3">Número</th>
+                      <th class="px-4 py-3">Apelido</th>
+                      <th class="px-4 py-3">NF</th>
+                      <th class="px-4 py-3">Loja</th>
+                      <th class="px-4 py-3 text-right">Valor</th>
+                      <th class="px-4 py-3">PIX</th>
+                      <th class="px-4 py-3">Problema</th>
+                      <th class="px-4 py-3">Status</th>
+                      <th class="px-4 py-3 text-right">Ações</th>
+                    </tr>
+                  </thead>
+                  <tbody id="reembolsosTableBody" class="divide-y divide-slate-100"></tbody>
+                </table>
+                <p
+                  id="reembolsosEmpty"
+                  class="text-sm text-slate-500 text-center py-6 hidden"
+                >
+                  Nenhum reembolso encontrado com os filtros selecionados.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section id="tab-pecas" class="tab-panel space-y-4 hidden">
+            <div class="card">
+              <div class="card-body grid gap-4 md:grid-cols-4">
+                <div class="space-y-1">
+                  <label for="filtroStatusPecas" class="text-sm font-medium text-slate-600"
+                    >Status</label
+                  >
+                  <select
+                    id="filtroStatusPecas"
+                    class="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500"
+                  >
+                    <option value="">Todos</option>
+                    <option value="NÃO FEITO">Não feito</option>
+                    <option value="EM ANDAMENTO">Em andamento</option>
+                    <option value="RESOLVIDO">Resolvido</option>
+                  </select>
+                </div>
+                <div class="space-y-1 md:col-span-2">
+                  <label for="buscaPecas" class="text-sm font-medium text-slate-600"
+                    >Buscar</label
+                  >
+                  <input
+                    type="text"
+                    id="buscaPecas"
+                    placeholder="Filtrar por cliente, pedido, loja, peça..."
+                    class="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-violet-500 focus:ring-violet-500"
+                  />
+                </div>
+                <div class="flex items-end">
+                  <span
+                    id="statusPecas"
+                    class="text-xs text-slate-500 px-3 py-1 rounded-full bg-slate-100"
+                    >Carregando dados...</span
+                  >
+                </div>
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="card-body overflow-x-auto">
+                <table class="min-w-full divide-y divide-slate-200 text-sm">
+                  <thead class="bg-slate-100 text-slate-600">
+                    <tr>
+                      <th class="px-4 py-3 text-left">Vendedor</th>
+                      <th class="px-4 py-3">Data</th>
+                      <th class="px-4 py-3">Cliente</th>
+                      <th class="px-4 py-3">Apelido</th>
+                      <th class="px-4 py-3">Pedido</th>
+                      <th class="px-4 py-3">Loja</th>
+                      <th class="px-4 py-3">Peça</th>
+                      <th class="px-4 py-3">Informações</th>
+                      <th class="px-4 py-3 text-right">Valor gasto</th>
+                      <th class="px-4 py-3">Status</th>
+                      <th class="px-4 py-3 text-right">Ações</th>
+                    </tr>
+                  </thead>
+                  <tbody id="pecasTableBody" class="divide-y divide-slate-100"></tbody>
+                </table>
+                <p
+                  id="pecasEmpty"
+                  class="text-sm text-slate-500 text-center py-6 hidden"
+                >
+                  Nenhuma peça faltante encontrada com os filtros selecionados.
+                </p>
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+
+    <script type="module" src="firebase-config.js"></script>
+    <script type="module" src="problemas-vendedores.js"></script>
+    <script>
+      window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';
+      window.CUSTOM_NAVBAR_PATH = '/partials/navbar.html';
+    </script>
+    <script src="shared.js"></script>
+  </body>
+</html>

--- a/problemas-vendedores.js
+++ b/problemas-vendedores.js
@@ -1,0 +1,737 @@
+import {
+  initializeApp,
+  getApps,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import {
+  getFirestore,
+  collection,
+  doc,
+  getDocs,
+  deleteDoc,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import {
+  getAuth,
+  onAuthStateChanged,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { firebaseConfig } from './firebase-config.js';
+import { setDocWithCopy } from './secure-firestore.js';
+import { carregarUsuariosPosVendas } from './responsavel-posvendas.js';
+
+const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+const db = getFirestore(app);
+const auth = getAuth(app);
+
+const elementos = {
+  filtroVendedor: document.getElementById('filtroVendedor'),
+  buscaGlobal: document.getElementById('buscaGlobal'),
+  buscaReembolsos: document.getElementById('buscaReembolsos'),
+  buscaPecas: document.getElementById('buscaPecas'),
+  filtroStatusReembolsos: document.getElementById('filtroStatusReembolsos'),
+  filtroStatusPecas: document.getElementById('filtroStatusPecas'),
+  resumoVendedores: document.getElementById('resumoVendedores'),
+  statusReembolsos: document.getElementById('statusReembolsos'),
+  statusPecas: document.getElementById('statusPecas'),
+  reembolsosTableBody: document.getElementById('reembolsosTableBody'),
+  pecasTableBody: document.getElementById('pecasTableBody'),
+  reembolsosEmpty: document.getElementById('reembolsosEmpty'),
+  pecasEmpty: document.getElementById('pecasEmpty'),
+};
+
+const state = {
+  currentUser: null,
+  vendedores: [],
+  reembolsos: [],
+  pecas: [],
+  filtros: {
+    vendedor: '',
+    buscaGlobal: '',
+    buscaReembolsos: '',
+    buscaPecas: '',
+    statusReembolsos: '',
+    statusPecas: '',
+  },
+};
+
+const REEMBOLSO_STATUS_OPCOES = [
+  { valor: 'AGUARDANDO PIX', texto: 'Aguardando PIX' },
+  { valor: 'AGUARDANDO MERCADO', texto: 'Aguardando Mercado' },
+  { valor: 'AGUARDANDO', texto: 'Aguardando' },
+  { valor: 'FEITO', texto: 'Feito' },
+  { valor: 'FEITO PIX', texto: 'Feito PIX' },
+  { valor: 'FEITO MERCADO', texto: 'Feito Mercado' },
+  { valor: 'CANCELADO', texto: 'Cancelado' },
+];
+
+function initTabs() {
+  const tabButtons = Array.from(document.querySelectorAll('.tab-btn'));
+  const tabPanels = Array.from(document.querySelectorAll('.tab-panel'));
+  if (!tabButtons.length) return;
+  tabButtons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      tabButtons.forEach((b) => {
+        b.classList.toggle('border-violet-600', b === btn);
+        b.classList.toggle('text-violet-600', b === btn);
+        b.classList.toggle('border-transparent', b !== btn);
+        b.classList.toggle('text-slate-500', b !== btn);
+      });
+      tabPanels.forEach((panel) => {
+        panel.classList.toggle('hidden', panel.id !== btn.dataset.tab);
+      });
+    });
+  });
+}
+
+initTabs();
+registrarEventos();
+
+onAuthStateChanged(auth, async (user) => {
+  if (!user) {
+    window.location.href = 'index.html?login=1';
+    return;
+  }
+  state.currentUser = user;
+  window.responsavelPosVendas = { uid: user.uid, email: user.email };
+  atualizarResumo('Buscando vendedores vinculados...', false);
+  try {
+    const { usuarios } = await carregarUsuariosPosVendas(db, user);
+    state.vendedores = usuarios;
+    preencherSelectVendedores();
+    atualizarResumo(
+      usuarios.length
+        ? `Visualizando problemas de ${usuarios.length} vendedor(es).`
+        : 'Nenhum vendedor vinculado foi encontrado.',
+      !usuarios.length,
+    );
+  } catch (err) {
+    console.error('Erro ao carregar vendedores vinculados:', err);
+    atualizarResumo(
+      'Não foi possível carregar os vendedores vinculados.',
+      true,
+    );
+    state.vendedores = [];
+  }
+  await carregarDados();
+});
+
+function registrarEventos() {
+  elementos.filtroVendedor?.addEventListener('change', () => {
+    state.filtros.vendedor = elementos.filtroVendedor.value;
+    renderReembolsos();
+    renderPecas();
+  });
+
+  elementos.buscaGlobal?.addEventListener('input', () => {
+    state.filtros.buscaGlobal = elementos.buscaGlobal.value.toLowerCase();
+    renderReembolsos();
+    renderPecas();
+  });
+
+  elementos.buscaReembolsos?.addEventListener('input', () => {
+    state.filtros.buscaReembolsos =
+      elementos.buscaReembolsos.value.toLowerCase();
+    renderReembolsos();
+  });
+
+  elementos.buscaPecas?.addEventListener('input', () => {
+    state.filtros.buscaPecas = elementos.buscaPecas.value.toLowerCase();
+    renderPecas();
+  });
+
+  elementos.filtroStatusReembolsos?.addEventListener('change', () => {
+    state.filtros.statusReembolsos = elementos.filtroStatusReembolsos.value;
+    renderReembolsos();
+  });
+
+  elementos.filtroStatusPecas?.addEventListener('change', () => {
+    state.filtros.statusPecas = elementos.filtroStatusPecas.value;
+    renderPecas();
+  });
+}
+
+function atualizarResumo(texto, isError) {
+  if (!elementos.resumoVendedores) return;
+  elementos.resumoVendedores.textContent = texto;
+  elementos.resumoVendedores.classList.toggle(
+    'text-rose-600',
+    Boolean(isError),
+  );
+}
+
+async function carregarDados() {
+  if (!state.currentUser) return;
+  await Promise.all([carregarReembolsos(), carregarPecas()]);
+}
+
+async function carregarReembolsos() {
+  if (!elementos.statusReembolsos) return;
+  elementos.statusReembolsos.textContent = 'Carregando dados...';
+  try {
+    const resultados = (
+      await Promise.all(
+        state.vendedores.map((v) => carregarColecao(v, 'reembolsos')),
+      )
+    ).flat();
+    state.reembolsos = resultados.sort((a, b) =>
+      (a.data || '').localeCompare(b.data || ''),
+    );
+    elementos.statusReembolsos.textContent = `${resultados.length} registro(s) encontrados.`;
+  } catch (err) {
+    console.error('Erro ao carregar reembolsos:', err);
+    elementos.statusReembolsos.textContent = 'Erro ao carregar reembolsos.';
+    state.reembolsos = [];
+  }
+  renderReembolsos();
+}
+
+async function carregarPecas() {
+  if (!elementos.statusPecas) return;
+  elementos.statusPecas.textContent = 'Carregando dados...';
+  try {
+    const resultados = (
+      await Promise.all(
+        state.vendedores.map((v) => carregarColecao(v, 'pecas')),
+      )
+    ).flat();
+    state.pecas = resultados.sort((a, b) =>
+      (a.data || '').localeCompare(b.data || ''),
+    );
+    elementos.statusPecas.textContent = `${resultados.length} registro(s) encontrados.`;
+  } catch (err) {
+    console.error('Erro ao carregar peças faltantes:', err);
+    elementos.statusPecas.textContent = 'Erro ao carregar peças faltantes.';
+    state.pecas = [];
+  }
+  renderPecas();
+}
+
+async function carregarColecao(vendedor, tipo) {
+  if (!vendedor?.uid || !state.currentUser?.uid) return [];
+  const caminhos = [
+    doc(
+      db,
+      'uid',
+      state.currentUser.uid,
+      'uid',
+      vendedor.uid,
+      'problemas',
+      tipo,
+    ),
+    doc(db, 'uid', vendedor.uid, 'problemas', tipo),
+  ];
+  for (const baseDoc of caminhos) {
+    try {
+      const itensRef = collection(baseDoc, 'itens');
+      const snap = await getDocs(itensRef);
+      if (!snap.empty) {
+        return snap.docs.map((docSnap) => ({
+          id: docSnap.id,
+          ...docSnap.data(),
+          ownerUid: vendedor.uid,
+          ownerNome: vendedor.nome || vendedor.email || vendedor.uid,
+          ownerEmail: vendedor.email || '',
+          tipo,
+        }));
+      }
+    } catch (err) {
+      console.warn(`Falha ao carregar ${tipo} para ${vendedor.uid}:`, err);
+    }
+  }
+  return [];
+}
+
+function preencherSelectVendedores() {
+  if (!elementos.filtroVendedor) return;
+  elementos.filtroVendedor.innerHTML =
+    '<option value="">Todos os vendedores vinculados</option>';
+  state.vendedores.forEach((v) => {
+    const opt = document.createElement('option');
+    opt.value = v.uid;
+    opt.textContent = v.nome || v.email || v.uid;
+    elementos.filtroVendedor.appendChild(opt);
+  });
+}
+
+function filtrarDados(lista, tipo) {
+  const { vendedor, buscaGlobal } = state.filtros;
+  const buscaEspecifica =
+    tipo === 'reembolsos'
+      ? state.filtros.buscaReembolsos
+      : state.filtros.buscaPecas;
+  const statusFiltro =
+    tipo === 'reembolsos'
+      ? state.filtros.statusReembolsos
+      : state.filtros.statusPecas;
+
+  return lista.filter((item) => {
+    if (vendedor && item.ownerUid !== vendedor) return false;
+    if (statusFiltro) {
+      const statusItem = normalizarTexto(item.status);
+      if (normalizarTexto(statusFiltro) !== statusItem) return false;
+    }
+    if (buscaGlobal) {
+      const campos = Object.values(item).map((valor) =>
+        String(valor || '').toLowerCase(),
+      );
+      if (!campos.some((valor) => valor.includes(buscaGlobal))) return false;
+    }
+    if (buscaEspecifica) {
+      const campos =
+        tipo === 'reembolsos'
+          ? [
+              item.apelido,
+              item.numero,
+              item.loja,
+              item.nf,
+              item.pix,
+              item.problema,
+              item.ownerNome,
+              item.ownerEmail,
+            ]
+          : [
+              item.nomeCliente,
+              item.apelido,
+              item.numero,
+              item.loja,
+              item.peca,
+              item.informacoes,
+              item.ownerNome,
+              item.ownerEmail,
+            ];
+      const contem = campos.some((valor) =>
+        String(valor || '')
+          .toLowerCase()
+          .includes(buscaEspecifica),
+      );
+      if (!contem) return false;
+    }
+    return true;
+  });
+}
+
+function renderReembolsos() {
+  if (!elementos.reembolsosTableBody) return;
+  elementos.reembolsosTableBody.innerHTML = '';
+  const dados = filtrarDados(state.reembolsos, 'reembolsos');
+  elementos.reembolsosEmpty?.classList.toggle('hidden', Boolean(dados.length));
+  if (!dados.length) return;
+  dados.forEach((dado) => {
+    const tr = document.createElement('tr');
+    tr.className = 'odd:bg-white even:bg-slate-50 hover:bg-slate-100';
+
+    tr.appendChild(criarCelulaTextoVendedor(dado));
+    tr.appendChild(
+      criarCelulaInput({
+        tipo: 'date',
+        valor: dado.data || '',
+        onChange: (valor) => atualizarReembolso(dado, { data: valor }),
+      }),
+    );
+    tr.appendChild(
+      criarCelulaInput({
+        tipo: 'text',
+        valor: dado.numero || '',
+        onChange: (valor) => atualizarReembolso(dado, { numero: valor.trim() }),
+      }),
+    );
+    tr.appendChild(
+      criarCelulaInput({
+        tipo: 'text',
+        valor: dado.apelido || '',
+        onChange: (valor) =>
+          atualizarReembolso(dado, { apelido: valor.trim() }),
+      }),
+    );
+    tr.appendChild(
+      criarCelulaInput({
+        tipo: 'text',
+        valor: dado.nf || '',
+        onChange: (valor) => atualizarReembolso(dado, { nf: valor.trim() }),
+      }),
+    );
+    tr.appendChild(
+      criarCelulaInput({
+        tipo: 'text',
+        valor: dado.loja || '',
+        onChange: (valor) => atualizarReembolso(dado, { loja: valor.trim() }),
+      }),
+    );
+
+    const valorTd = document.createElement('td');
+    valorTd.className = 'p-2 align-middle';
+    const valorWrapper = document.createElement('div');
+    valorWrapper.className = 'flex items-center justify-end gap-1';
+    const prefixo = document.createElement('span');
+    prefixo.textContent = 'R$';
+    prefixo.className = 'text-slate-500';
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.step = '0.01';
+    input.value = formatarNumero(dado.valor);
+    input.className =
+      'w-28 rounded-xl border border-slate-300 p-1 text-right focus:border-violet-500 focus:ring-violet-500';
+    input.addEventListener('change', async (ev) => {
+      const novoValor = Number.parseFloat(ev.target.value);
+      const valorConvertido = Number.isFinite(novoValor) ? novoValor : 0;
+      await atualizarReembolso(dado, { valor: valorConvertido });
+      ev.target.value = formatarNumero(valorConvertido);
+    });
+    valorWrapper.appendChild(prefixo);
+    valorWrapper.appendChild(input);
+    valorTd.appendChild(valorWrapper);
+    tr.appendChild(valorTd);
+
+    tr.appendChild(
+      criarCelulaInput({
+        tipo: 'text',
+        valor: dado.pix || '',
+        onChange: (valor) => atualizarReembolso(dado, { pix: valor.trim() }),
+      }),
+    );
+    tr.appendChild(
+      criarCelulaTextarea({
+        valor: dado.problema || '',
+        onChange: (valor) =>
+          atualizarReembolso(dado, { problema: valor.trim() }),
+      }),
+    );
+    tr.appendChild(
+      criarCelulaSelect({
+        valor: dado.status || 'AGUARDANDO',
+        opcoes: REEMBOLSO_STATUS_OPCOES,
+        onChange: (valor) => atualizarReembolso(dado, { status: valor }),
+      }),
+    );
+    tr.appendChild(criarCelulaAcoes(() => excluirReembolso(dado)));
+
+    elementos.reembolsosTableBody.appendChild(tr);
+  });
+}
+
+function renderPecas() {
+  if (!elementos.pecasTableBody) return;
+  elementos.pecasTableBody.innerHTML = '';
+  const dados = filtrarDados(state.pecas, 'pecas');
+  elementos.pecasEmpty?.classList.toggle('hidden', Boolean(dados.length));
+  if (!dados.length) return;
+  dados.forEach((dado) => {
+    const tr = document.createElement('tr');
+    tr.className = 'odd:bg-white even:bg-slate-50 hover:bg-slate-100';
+
+    tr.appendChild(criarCelulaTextoVendedor(dado));
+    tr.appendChild(
+      criarCelulaInput({
+        tipo: 'date',
+        valor: dado.data || '',
+        onChange: (valor) => atualizarPeca(dado, { data: valor }),
+      }),
+    );
+    tr.appendChild(
+      criarCelulaInput({
+        tipo: 'text',
+        valor: dado.nomeCliente || '',
+        onChange: (valor) => atualizarPeca(dado, { nomeCliente: valor.trim() }),
+      }),
+    );
+    tr.appendChild(
+      criarCelulaInput({
+        tipo: 'text',
+        valor: dado.apelido || '',
+        onChange: (valor) => atualizarPeca(dado, { apelido: valor.trim() }),
+      }),
+    );
+    tr.appendChild(
+      criarCelulaInput({
+        tipo: 'text',
+        valor: dado.numero || '',
+        onChange: (valor) => atualizarPeca(dado, { numero: valor.trim() }),
+      }),
+    );
+    tr.appendChild(
+      criarCelulaInput({
+        tipo: 'text',
+        valor: dado.loja || '',
+        onChange: (valor) => atualizarPeca(dado, { loja: valor.trim() }),
+      }),
+    );
+    tr.appendChild(
+      criarCelulaInput({
+        tipo: 'text',
+        valor: dado.peca || '',
+        onChange: (valor) => atualizarPeca(dado, { peca: valor.trim() }),
+      }),
+    );
+    tr.appendChild(
+      criarCelulaTextarea({
+        valor: dado.informacoes || '',
+        onChange: (valor) => atualizarPeca(dado, { informacoes: valor.trim() }),
+      }),
+    );
+
+    const valorTd = document.createElement('td');
+    valorTd.className = 'p-2 align-middle';
+    const wrapper = document.createElement('div');
+    wrapper.className = 'flex items-center justify-end gap-1';
+    const prefixo = document.createElement('span');
+    prefixo.textContent = 'R$';
+    prefixo.className = 'text-slate-500';
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.step = '0.01';
+    input.value = formatarNumero(dado.valorGasto);
+    input.className =
+      'w-28 rounded-xl border border-slate-300 p-1 text-right focus:border-violet-500 focus:ring-violet-500';
+    input.addEventListener('change', async (ev) => {
+      const novoValor = Number.parseFloat(ev.target.value);
+      const valorConvertido = Number.isFinite(novoValor) ? novoValor : 0;
+      await atualizarPeca(dado, { valorGasto: valorConvertido });
+      ev.target.value = formatarNumero(valorConvertido);
+    });
+    wrapper.appendChild(prefixo);
+    wrapper.appendChild(input);
+    valorTd.appendChild(wrapper);
+    tr.appendChild(valorTd);
+
+    tr.appendChild(
+      criarCelulaSelect({
+        valor: dado.status || 'NÃO FEITO',
+        opcoes: [
+          { valor: 'NÃO FEITO', texto: 'Não feito' },
+          { valor: 'EM ANDAMENTO', texto: 'Em andamento' },
+          { valor: 'RESOLVIDO', texto: 'Resolvido' },
+        ],
+        onChange: (valor) => atualizarPeca(dado, { status: valor }),
+        aplicarClasse: (select, status) => aplicarCorStatus(select, status),
+      }),
+    );
+
+    tr.appendChild(criarCelulaAcoes(() => excluirPeca(dado)));
+
+    elementos.pecasTableBody.appendChild(tr);
+  });
+}
+
+function criarCelulaTextoVendedor(dado) {
+  const td = document.createElement('td');
+  td.className = 'p-2 align-middle';
+  const nome = document.createElement('p');
+  nome.className = 'font-medium text-slate-700';
+  nome.textContent = dado.ownerNome || dado.ownerUid;
+  const email = document.createElement('p');
+  email.className = 'text-xs text-slate-500';
+  email.textContent = dado.ownerEmail || '';
+  td.appendChild(nome);
+  if (email.textContent) td.appendChild(email);
+  return td;
+}
+
+function criarCelulaInput({ tipo, valor, onChange }) {
+  const td = document.createElement('td');
+  td.className = 'p-2 align-middle';
+  const input = document.createElement('input');
+  input.type = tipo;
+  input.value = valor ?? '';
+  input.className =
+    'w-full rounded-xl border border-slate-300 px-2 py-1 text-sm focus:border-violet-500 focus:ring-violet-500';
+  input.addEventListener('change', async (ev) => {
+    await onChange(ev.target.value);
+  });
+  td.appendChild(input);
+  return td;
+}
+
+function criarCelulaTextarea({ valor, onChange }) {
+  const td = document.createElement('td');
+  td.className = 'p-2 align-middle';
+  const textarea = document.createElement('textarea');
+  textarea.value = valor ?? '';
+  textarea.rows = 2;
+  textarea.className =
+    'w-full rounded-xl border border-slate-300 px-2 py-1 text-sm focus:border-violet-500 focus:ring-violet-500 resize-y min-h-[36px]';
+  textarea.addEventListener('change', async (ev) => {
+    await onChange(ev.target.value);
+  });
+  td.appendChild(textarea);
+  return td;
+}
+
+function criarCelulaSelect({ valor, opcoes, onChange, aplicarClasse }) {
+  const td = document.createElement('td');
+  td.className = 'p-2 align-middle';
+  const select = document.createElement('select');
+  select.className =
+    'w-full rounded-xl border border-slate-300 px-2 py-1 text-sm focus:border-violet-500 focus:ring-violet-500';
+  opcoes.forEach((opcao) => {
+    const option = document.createElement('option');
+    option.value = opcao.valor;
+    option.textContent = opcao.texto;
+    if (opcao.valor === valor) option.selected = true;
+    select.appendChild(option);
+  });
+  if (aplicarClasse) aplicarClasse(select, valor);
+  select.addEventListener('change', async (ev) => {
+    await onChange(ev.target.value);
+    if (aplicarClasse) aplicarClasse(select, ev.target.value);
+  });
+  td.appendChild(select);
+  return td;
+}
+
+function criarCelulaAcoes(onDelete) {
+  const td = document.createElement('td');
+  td.className = 'p-2 align-middle text-right';
+  const botao = document.createElement('button');
+  botao.type = 'button';
+  botao.textContent = 'Excluir';
+  botao.className =
+    'inline-flex items-center rounded-xl border border-rose-200 px-3 py-1 text-sm font-medium text-rose-600 hover:bg-rose-50';
+  botao.addEventListener('click', onDelete);
+  td.appendChild(botao);
+  return td;
+}
+
+function aplicarCorStatus(el, status) {
+  el.classList.remove(
+    'bg-amber-50',
+    'text-amber-700',
+    'border-amber-200',
+    'bg-blue-50',
+    'text-blue-700',
+    'border-blue-200',
+    'bg-emerald-50',
+    'text-emerald-700',
+    'border-emerald-200',
+  );
+  const baseClasses = ['border'];
+  if (status === 'RESOLVIDO') {
+    el.classList.add(
+      'bg-emerald-50',
+      'text-emerald-700',
+      'border-emerald-200',
+      ...baseClasses,
+    );
+  } else if (status === 'EM ANDAMENTO') {
+    el.classList.add(
+      'bg-blue-50',
+      'text-blue-700',
+      'border-blue-200',
+      ...baseClasses,
+    );
+  } else {
+    el.classList.add(
+      'bg-amber-50',
+      'text-amber-700',
+      'border-amber-200',
+      ...baseClasses,
+    );
+  }
+}
+
+function formatarNumero(valor) {
+  return (Number(valor) || 0).toFixed(2);
+}
+
+function normalizarTexto(valor) {
+  return String(valor || '')
+    .normalize('NFD')
+    .replace(/[^\w\s]/g, '')
+    .toUpperCase()
+    .trim();
+}
+
+function extrairPayload(dado) {
+  const { id, ownerUid, ownerNome, ownerEmail, tipo, ...restante } = dado;
+  return restante;
+}
+
+async function atualizarReembolso(dado, atualizacoes) {
+  const ref = doc(
+    db,
+    'uid',
+    dado.ownerUid,
+    'problemas',
+    'reembolsos',
+    'itens',
+    dado.id,
+  );
+  const payload = { ...extrairPayload(dado), ...atualizacoes };
+  await setDocWithCopy(ref, payload, dado.ownerUid, undefined, {
+    posVendasUid: state.currentUser?.uid,
+  });
+  Object.assign(dado, atualizacoes);
+}
+
+async function atualizarPeca(dado, atualizacoes) {
+  const ref = doc(
+    db,
+    'uid',
+    dado.ownerUid,
+    'problemas',
+    'pecas',
+    'itens',
+    dado.id,
+  );
+  const payload = { ...extrairPayload(dado), ...atualizacoes };
+  await setDocWithCopy(ref, payload, dado.ownerUid, undefined, {
+    posVendasUid: state.currentUser?.uid,
+  });
+  Object.assign(dado, atualizacoes);
+}
+
+async function excluirReembolso(dado) {
+  if (!window.confirm('Deseja excluir este reembolso?')) return;
+  const ref = doc(
+    db,
+    'uid',
+    dado.ownerUid,
+    'problemas',
+    'reembolsos',
+    'itens',
+    dado.id,
+  );
+  await deleteDoc(ref);
+  await removerCopias(ref, dado.ownerUid);
+  state.reembolsos = state.reembolsos.filter((item) => item.id !== dado.id);
+  renderReembolsos();
+}
+
+async function excluirPeca(dado) {
+  if (!window.confirm('Deseja excluir esta peça faltante?')) return;
+  const ref = doc(
+    db,
+    'uid',
+    dado.ownerUid,
+    'problemas',
+    'pecas',
+    'itens',
+    dado.id,
+  );
+  await deleteDoc(ref);
+  await removerCopias(ref, dado.ownerUid);
+  state.pecas = state.pecas.filter((item) => item.id !== dado.id);
+  renderPecas();
+}
+
+async function removerCopias(ref, ownerUid) {
+  const destinatarios = new Set();
+  if (window.responsavelFinanceiro?.uid) {
+    destinatarios.add(window.responsavelFinanceiro.uid);
+  }
+  if (window.responsavelPosVendas?.uid) {
+    destinatarios.add(window.responsavelPosVendas.uid);
+  }
+  destinatarios.delete(ownerUid);
+  if (!destinatarios.size) return;
+  const segmentos = ref.path.split('/');
+  const relativo = segmentos.slice(2).join('/');
+  for (const responsavelUid of destinatarios) {
+    const copiaRef = doc(
+      ref.firestore,
+      `uid/${responsavelUid}/uid/${ownerUid}/${relativo}`,
+    );
+    try {
+      await deleteDoc(copiaRef);
+    } catch (err) {
+      console.warn('Não foi possível remover cópia do documento:', err);
+    }
+  }
+}

--- a/responsavel-posvendas.js
+++ b/responsavel-posvendas.js
@@ -1,0 +1,160 @@
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  doc,
+  getDoc,
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+
+async function fetchUsuariosPorEmail(db, email) {
+  if (!email) return [];
+  const [snapUsuarios, snapUid] = await Promise.all([
+    getDocs(
+      query(
+        collection(db, 'usuarios'),
+        where('responsavelPosVendasEmail', '==', email),
+      ),
+    ),
+    getDocs(
+      query(
+        collection(db, 'uid'),
+        where('responsavelPosVendasEmail', '==', email),
+      ),
+    ),
+  ]);
+  const ids = new Set();
+  const resultado = [];
+  for (const docSnap of [...snapUsuarios.docs, ...snapUid.docs]) {
+    if (ids.has(docSnap.id)) continue;
+    ids.add(docSnap.id);
+    const dados = docSnap.data() || {};
+    resultado.push({
+      uid: docSnap.id,
+      nome:
+        dados.nome ||
+        dados.razaoSocial ||
+        dados.apelido ||
+        dados.displayName ||
+        dados.usuario ||
+        dados.email ||
+        docSnap.id,
+      email: dados.email || dados.login || '',
+    });
+  }
+  return resultado;
+}
+
+async function fetchUsuariosDeCopias(db, posUid) {
+  if (!posUid) return [];
+  const ref = collection(db, 'uid', posUid, 'uid');
+  const snap = await getDocs(ref);
+  const ids = new Set();
+  const resultado = [];
+  for (const docSnap of snap.docs) {
+    if (ids.has(docSnap.id)) continue;
+    ids.add(docSnap.id);
+    const dados = docSnap.data() || {};
+    resultado.push({
+      uid: docSnap.id,
+      nome:
+        dados.nome ||
+        dados.razaoSocial ||
+        dados.apelido ||
+        dados.usuarioNome ||
+        dados.usuarioEmail ||
+        docSnap.id,
+      email: dados.email || dados.usuarioEmail || '',
+    });
+  }
+  return resultado;
+}
+
+async function carregarInformacoesUsuario(db, uid) {
+  if (!uid) return null;
+  const prioridades = [
+    async () => {
+      const ref = doc(db, 'usuarios', uid);
+      const snap = await getDoc(ref);
+      if (!snap.exists()) return null;
+      const dados = snap.data() || {};
+      return {
+        uid,
+        nome:
+          dados.nome ||
+          dados.displayName ||
+          dados.razaoSocial ||
+          dados.apelido ||
+          dados.email ||
+          uid,
+        email: dados.email || '',
+      };
+    },
+    async () => {
+      const ref = doc(db, 'uid', uid);
+      const snap = await getDoc(ref);
+      if (!snap.exists()) return null;
+      const dados = snap.data() || {};
+      return {
+        uid,
+        nome:
+          dados.nome ||
+          dados.razaoSocial ||
+          dados.apelido ||
+          dados.usuarioNome ||
+          dados.usuarioEmail ||
+          dados.email ||
+          uid,
+        email: dados.email || dados.usuarioEmail || dados.login || '',
+      };
+    },
+  ];
+
+  for (const resolver of prioridades) {
+    try {
+      const info = await resolver();
+      if (info) return info;
+    } catch (_) {
+      /* ignore */
+    }
+  }
+
+  return { uid, nome: uid, email: '' };
+}
+
+export async function carregarUsuariosPosVendas(db, user) {
+  if (!db || !user) {
+    return { usuarios: [] };
+  }
+
+  const candidatos = new Map();
+
+  const extrasEmail = await fetchUsuariosPorEmail(db, user.email || '');
+  extrasEmail.forEach((item) => {
+    if (!candidatos.has(item.uid)) candidatos.set(item.uid, item);
+  });
+
+  const extrasCopias = await fetchUsuariosDeCopias(db, user.uid);
+  extrasCopias.forEach((item) => {
+    if (!candidatos.has(item.uid)) candidatos.set(item.uid, item);
+  });
+
+  // Inclui o próprio usuário para permitir visualizar registros pessoais
+  if (user.uid && !candidatos.has(user.uid)) {
+    candidatos.set(user.uid, {
+      uid: user.uid,
+      nome: user.displayName || user.email || user.uid,
+      email: user.email || '',
+    });
+  }
+
+  const usuarios = await Promise.all(
+    Array.from(candidatos.keys()).map((uid) =>
+      carregarInformacoesUsuario(db, uid),
+    ),
+  );
+
+  usuarios.sort((a, b) => a.nome.localeCompare(b.nome));
+
+  return { usuarios };
+}


### PR DESCRIPTION
## Summary
- add a dedicated "Problemas Vendedores" page so perfis de pós-vendas can revisar e editar reembolsos e peças faltantes de todos os vendedores vinculados
- criar utilitário para carregar vendedores associados ao pós-vendas e alimentar a nova interface com filtros e edição inline
- incluir o novo atalho no sidebar disponível para o perfil de pós-vendas

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_6901f920e420832a9a7a43b69417dc52