### PR TITLE
Add report download actions to resumo equipe tabs

### DIFF
--- a/resumo-equipe.html
+++ b/resumo-equipe.html
@@ -134,7 +134,29 @@
           </div>
 
           <div id="tab-diario" class="space-y-4">
-            <p id="diarioStatus" class="text-sm text-gray-500"></p>
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <p id="diarioStatus" class="text-sm text-gray-500"></p>
+              <div class="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-2 rounded-lg border border-indigo-100 bg-indigo-50 px-4 py-2 text-sm font-medium text-indigo-600 transition hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                  data-relatorio-tab="diario"
+                  data-relatorio-periodo="semana"
+                >
+                  <i class="fa fa-file-alt"></i>
+                  Relatório semanal
+                </button>
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-2 rounded-lg border border-indigo-100 bg-white px-4 py-2 text-sm font-medium text-indigo-600 transition hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                  data-relatorio-tab="diario"
+                  data-relatorio-periodo="mes"
+                >
+                  <i class="fa fa-calendar"></i>
+                  Relatório mensal
+                </button>
+              </div>
+            </div>
             <div id="diarioTotais" class="space-y-4"></div>
             <div
               class="overflow-x-auto rounded-xl border border-gray-200 shadow"
@@ -167,7 +189,29 @@
           </div>
 
           <div id="tab-vendas" class="space-y-4 hidden">
-            <p id="vendasStatus" class="text-sm text-gray-500"></p>
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <p id="vendasStatus" class="text-sm text-gray-500"></p>
+              <div class="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-2 rounded-lg border border-indigo-100 bg-indigo-50 px-4 py-2 text-sm font-medium text-indigo-600 transition hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                  data-relatorio-tab="vendas"
+                  data-relatorio-periodo="semana"
+                >
+                  <i class="fa fa-file-alt"></i>
+                  Relatório semanal
+                </button>
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-2 rounded-lg border border-indigo-100 bg-white px-4 py-2 text-sm font-medium text-indigo-600 transition hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                  data-relatorio-tab="vendas"
+                  data-relatorio-periodo="mes"
+                >
+                  <i class="fa fa-calendar"></i>
+                  Relatório mensal
+                </button>
+              </div>
+            </div>
             <div
               id="vendasTotais"
               class="grid gap-4 md:grid-cols-2 xl:grid-cols-4"
@@ -219,11 +263,33 @@
           </div>
 
           <div id="tab-problemas" class="space-y-4 hidden">
-            <p class="text-sm text-gray-500">
-              A visualização abaixo reutiliza a ferramenta completa de
-              acompanhamento de problemas para facilitar o acesso rápido do
-              gestor financeiro.
-            </p>
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <p id="problemasStatus" class="text-sm text-gray-500">
+                A visualização abaixo reutiliza a ferramenta completa de
+                acompanhamento de problemas para facilitar o acesso rápido do
+                gestor financeiro.
+              </p>
+              <div class="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-2 rounded-lg border border-indigo-100 bg-indigo-50 px-4 py-2 text-sm font-medium text-indigo-600 transition hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                  data-relatorio-tab="problemas"
+                  data-relatorio-periodo="semana"
+                >
+                  <i class="fa fa-file-alt"></i>
+                  Relatório semanal
+                </button>
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-2 rounded-lg border border-indigo-100 bg-white px-4 py-2 text-sm font-medium text-indigo-600 transition hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                  data-relatorio-tab="problemas"
+                  data-relatorio-periodo="mes"
+                >
+                  <i class="fa fa-calendar"></i>
+                  Relatório mensal
+                </button>
+              </div>
+            </div>
             <div
               class="overflow-hidden rounded-xl border border-gray-200 shadow"
             >
@@ -238,7 +304,29 @@
           </div>
 
           <div id="tab-cadastro" class="space-y-4 hidden">
-            <div class="rounded-xl border border-indigo-100 bg-white p-4 shadow">
+            <div class="flex flex-wrap items-center justify-end gap-2">
+              <button
+                type="button"
+                class="inline-flex items-center gap-2 rounded-lg border border-indigo-100 bg-indigo-50 px-4 py-2 text-sm font-medium text-indigo-600 transition hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                data-relatorio-tab="cadastro"
+                data-relatorio-periodo="semana"
+              >
+                <i class="fa fa-file-alt"></i>
+                Relatório semanal
+              </button>
+              <button
+                type="button"
+                class="inline-flex items-center gap-2 rounded-lg border border-indigo-100 bg-white px-4 py-2 text-sm font-medium text-indigo-600 transition hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                data-relatorio-tab="cadastro"
+                data-relatorio-periodo="mes"
+              >
+                <i class="fa fa-calendar"></i>
+                Relatório mensal
+              </button>
+            </div>
+            <div
+              class="rounded-xl border border-indigo-100 bg-white p-4 shadow"
+            >
               <h3 class="text-lg font-semibold text-gray-700">
                 Limites de integrantes por cargo
               </h3>
@@ -247,21 +335,39 @@
                 para cada cargo.
               </p>
               <ul class="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-                <li class="rounded-lg bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700">
+                <li
+                  class="rounded-lg bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700"
+                >
                   Vendedores:
-                  <span data-cargo-count="vendedor" class="font-semibold">0/10</span>
+                  <span data-cargo-count="vendedor" class="font-semibold"
+                    >0/10</span
+                  >
                 </li>
-                <li class="rounded-lg bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700">
+                <li
+                  class="rounded-lg bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700"
+                >
                   Gestores de expedição:
-                  <span data-cargo-count="gestor_expedicao" class="font-semibold">0/2</span>
+                  <span
+                    data-cargo-count="gestor_expedicao"
+                    class="font-semibold"
+                    >0/2</span
+                  >
                 </li>
-                <li class="rounded-lg bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700">
+                <li
+                  class="rounded-lg bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700"
+                >
                   Pós-vendas:
-                  <span data-cargo-count="posvendas" class="font-semibold">0/3</span>
+                  <span data-cargo-count="posvendas" class="font-semibold"
+                    >0/3</span
+                  >
                 </li>
-                <li class="rounded-lg bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700">
+                <li
+                  class="rounded-lg bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700"
+                >
                   Usuários:
-                  <span data-cargo-count="usuario" class="font-semibold">0/5</span>
+                  <span data-cargo-count="usuario" class="font-semibold"
+                    >0/5</span
+                  >
                 </li>
               </ul>
             </div>
@@ -290,7 +396,9 @@
                     required
                   >
                     <option value="vendedor">Vendedor</option>
-                    <option value="gestor_expedicao">Gestor de expedição</option>
+                    <option value="gestor_expedicao">
+                      Gestor de expedição
+                    </option>
                     <option value="posvendas">Pós-vendas</option>
                     <option value="usuario">Usuário</option>
                   </select>
@@ -331,12 +439,15 @@
                 </label>
                 <p class="mt-1 text-xs text-gray-500">
                   Informe o e-mail do gestor de expedição responsável pelo
-                  integrante. Para gestores de expedição deixe em branco para usar
-                  o próprio e-mail cadastrado.
+                  integrante. Para gestores de expedição deixe em branco para
+                  usar o próprio e-mail cadastrado.
                 </p>
               </div>
               <div class="md:col-span-2 flex items-center justify-end gap-3">
-                <span id="cadastroEquipeStatus" class="text-sm text-gray-500"></span>
+                <span
+                  id="cadastroEquipeStatus"
+                  class="text-sm text-gray-500"
+                ></span>
                 <button
                   type="submit"
                   class="inline-flex items-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-400"
@@ -358,7 +469,9 @@
                 class="mt-3 overflow-x-auto rounded-lg border border-gray-100"
               >
                 <table class="min-w-full divide-y divide-gray-200 text-sm">
-                  <thead class="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+                  <thead
+                    class="bg-gray-50 text-xs uppercase tracking-wide text-gray-500"
+                  >
                     <tr>
                       <th class="px-4 py-2 text-left">Nome</th>
                       <th class="px-4 py-2 text-left">Cargo</th>
@@ -366,10 +479,16 @@
                       <th class="px-4 py-2 text-left">Resp. expedição</th>
                     </tr>
                   </thead>
-                  <tbody id="cadastroEquipeTabela" class="divide-y divide-gray-100"></tbody>
+                  <tbody
+                    id="cadastroEquipeTabela"
+                    class="divide-y divide-gray-100"
+                  ></tbody>
                 </table>
               </div>
-              <p id="cadastroEquipeVazio" class="mt-3 text-sm text-gray-500 hidden">
+              <p
+                id="cadastroEquipeVazio"
+                class="mt-3 text-sm text-gray-500 hidden"
+              >
                 Nenhum integrante cadastrado até o momento.
               </p>
             </div>


### PR DESCRIPTION
## Summary
- add weekly and monthly report buttons to each subtab in Resumo da Equipe
- capture tab metrics and build downloadable text reports for the selected period
- wire the new actions into existing status messaging and initialization flow

## Testing
- No automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690347b7e8f0832abca1dbeef2b92507