### PR TITLE
Adicionar geração de relatórios em PDF no resumo da equipe

### DIFF
--- a/resumo-equipe.html
+++ b/resumo-equipe.html
@@ -499,6 +499,7 @@
         window.CUSTOM_SIDEBAR_PATH = '/partials/sidebar.html';
         window.CUSTOM_NAVBAR_PATH = '/partials/navbar.html';
       </script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
       <script src="shared.js"></script>
       <script type="module" src="firebase-config.js"></script>
       <script type="module" src="resumo-equipe.js"></script>


### PR DESCRIPTION
## Summary
- carregar a biblioteca jsPDF na página de resumo da equipe para permitir exportação em PDF
- gerar os relatórios semanais e mensais do resumo da equipe em PDF com cabeçalho destacado
- exibir feedback apropriado após a tentativa de gerar cada relatório

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690376fc632c832a8a95bdb3352ac53a