### PR TITLE
Adicionar geração de relatório completo para acompanhamento de problemas

### DIFF
--- a/acompanhamento-problemas.html
+++ b/acompanhamento-problemas.html
@@ -57,12 +57,20 @@
                 Problemas.
               </p>
             </div>
-            <div class="lg:justify-self-end">
+            <div class="lg:justify-self-end flex flex-col items-end gap-2">
               <span
                 id="globalStatus"
                 class="text-xs text-gray-500 px-3 py-1 rounded-full bg-gray-100"
                 >Sincronizando dados...</span
               >
+              <button
+                id="gerarRelatorioProblemas"
+                type="button"
+                class="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+              >
+                <i class="fa-solid fa-chart-line"></i>
+                Gerar relatório completo
+              </button>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- adiciona botão de "Gerar relatório completo" na tela de acompanhamento de problemas
- consolida dados filtrados de peças faltantes e reembolsos em um relatório com tabelas, resumos financeiros e indicadores principais
- gera uma nova janela com visualizações em Chart.js e métricas agregadas, incluindo evolução temporal e maiores gastos

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690a84be5468832ab85c723d5c58a178