### PR TITLE
Add wiring component fields to SKU associado form

### DIFF
--- a/sku-associado.html
+++ b/sku-associado.html
@@ -66,6 +66,53 @@
                   placeholder="Informe a quantidade por SKU"
                 />
               </div>
+              <div>
+                <label for="fiacao" class="block text-sm font-medium mb-1"
+                  >Fiação</label
+                >
+                <input
+                  id="fiacao"
+                  class="w-full p-2 border rounded"
+                  placeholder="Tipo de fiação"
+                />
+              </div>
+              <div>
+                <label for="quantidadeFiacao" class="block text-sm font-medium mb-1"
+                  >Quantidade de Fiação</label
+                >
+                <input
+                  id="quantidadeFiacao"
+                  type="number"
+                  min="0"
+                  step="1"
+                  class="w-full p-2 border rounded"
+                  placeholder="Informe a quantidade de fiação"
+                />
+              </div>
+              <div>
+                <label for="quantidadeBocais" class="block text-sm font-medium mb-1"
+                  >Quantidade de Bocais</label
+                >
+                <input
+                  id="quantidadeBocais"
+                  type="number"
+                  min="0"
+                  step="1"
+                  class="w-full p-2 border rounded"
+                  placeholder="Informe a quantidade de bocais"
+                />
+              </div>
+              <div class="md:col-span-2">
+                <label for="outrosComponentes" class="block text-sm font-medium mb-1"
+                  >Outros Componentes</label
+                >
+                <textarea
+                  id="outrosComponentes"
+                  class="w-full p-2 border rounded"
+                  rows="3"
+                  placeholder="Descreva outros componentes relevantes"
+                ></textarea>
+              </div>
               <div class="md:col-span-2">
                 <label
                   for="skusPrincipaisVinculados"
@@ -98,6 +145,10 @@
                   <th class="px-2 py-1">SKU Principal</th>
                   <th class="px-2 py-1">Associados</th>
                   <th class="px-2 py-1">Parafusos por SKU</th>
+                  <th class="px-2 py-1">Fiação</th>
+                  <th class="px-2 py-1">Qtd. Fiação</th>
+                  <th class="px-2 py-1">Bocais</th>
+                  <th class="px-2 py-1">Outros Componentes</th>
                   <th class="px-2 py-1">Principais Vinculados</th>
                   <th class="px-2 py-1">Ações</th>
                 </tr>


### PR DESCRIPTION
## Summary
- add wiring, quantity, socket, and other component inputs to the SKU associado form and listing table
- persist new component details alongside existing SKU metadata and display them in the grid
- centralize numeric sanitization/formatting helpers for reuse across the new fields

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690aa4b2114c832abad14fbcb6af6059