### PR TITLE
Refine catálogo card layout and print styling

### DIFF
--- a/catalogo.js
+++ b/catalogo.js
@@ -1747,16 +1747,17 @@ function renderCardView(displayItems) {
   ) => {
     const wrapper = document.createElement('div');
     wrapper.className =
-      'flex flex-col gap-1 rounded-lg bg-white px-3 py-2 shadow-inner ' +
+      'catalog-card__info-cell flex flex-col gap-1 rounded-md border border-gray-200 bg-white px-3 py-2 ' +
       containerClass;
     const labelEl = document.createElement('span');
     labelEl.className =
-      'text-xs font-semibold uppercase tracking-wide text-gray-600 ' +
+      'catalog-card__info-label text-[11px] font-medium uppercase tracking-wide text-gray-500 ' +
       labelClass;
     labelEl.textContent = label;
     const valueEl = document.createElement('span');
     valueEl.className =
-      'text-sm font-semibold text-gray-900 whitespace-pre-wrap ' + valueClass;
+      'catalog-card__info-value text-sm font-semibold text-gray-900 whitespace-pre-wrap ' +
+      valueClass;
     const resolvedValue =
       typeof value === 'string'
         ? value.trim() || '--'
@@ -1772,13 +1773,13 @@ function renderCardView(displayItems) {
     if (!produto) return;
     const card = document.createElement('article');
     card.className =
-      'relative flex h-full flex-col overflow-hidden rounded-2xl border-2 border-gray-200 bg-white shadow-md transition hover:shadow-lg';
+      'catalog-card relative flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition hover:shadow-md';
     card.dataset.productId = produto.id || '';
     card.dataset.viewType = 'card';
 
     const selectionWrapper = document.createElement('label');
     selectionWrapper.className =
-      'catalog-select-toggle absolute left-4 top-4 z-10 inline-flex items-center gap-2 rounded-full bg-white/90 px-3 py-1 text-xs font-semibold text-gray-700 shadow';
+      'catalog-card__selection catalog-select-toggle absolute left-4 top-4 z-10 inline-flex items-center gap-2 rounded-full bg-white/90 px-2.5 py-1 text-[11px] font-medium text-gray-700 shadow';
     selectionWrapper.title = 'Selecionar produto';
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
@@ -1795,20 +1796,21 @@ function renderCardView(displayItems) {
     card.appendChild(selectionWrapper);
 
     const header = document.createElement('div');
-    header.className = 'bg-yellow-300 px-4 py-3 text-center';
+    header.className =
+      'catalog-card__header flex flex-col gap-1 border-b border-yellow-200 bg-yellow-50 px-4 py-3 text-left';
     const headerTitle = document.createElement('h3');
     headerTitle.className =
-      'text-base font-bold uppercase tracking-wide text-gray-900';
+      'catalog-card__title text-lg font-semibold leading-snug text-gray-900';
     headerTitle.textContent = produto.nome || 'Produto sem nome';
     header.appendChild(headerTitle);
     card.appendChild(header);
 
     const imageSection = document.createElement('div');
     imageSection.className =
-      'relative flex flex-col items-center border-b border-gray-200 bg-white px-6 pt-5 pb-10';
+      'catalog-card__media relative flex flex-col items-center border-b border-gray-200 bg-white px-4 pt-4 pb-6';
     const imageFrame = document.createElement('div');
     imageFrame.className =
-      'relative flex h-48 w-full max-w-sm items-center justify-center overflow-hidden rounded-xl border-4 border-yellow-200 bg-gray-100 shadow-inner';
+      'catalog-card__media-frame relative flex h-44 w-full max-w-sm items-center justify-center overflow-hidden rounded-lg border border-yellow-200 bg-gray-100';
     const fotos = Array.isArray(produto.fotos) ? produto.fotos : [];
     const primeiraFoto = fotos.find((foto) => foto?.url);
     if (primeiraFoto) {
@@ -1825,65 +1827,70 @@ function renderCardView(displayItems) {
       imageFrame.appendChild(placeholder);
     }
 
-    const imageOverlay = document.createElement('div');
-    imageOverlay.className =
-      'pointer-events-none absolute inset-x-0 bottom-0 flex justify-between px-4 py-2 text-xs font-bold uppercase tracking-wide text-gray-900';
-    const skuBadge = document.createElement('span');
-    skuBadge.className = 'rounded-md bg-white/90 px-3 py-1 shadow-md';
-    skuBadge.textContent = `SKU = ${produto.sku || '--'}`;
-    const categoriaBadge = document.createElement('span');
-    categoriaBadge.className = 'rounded-md bg-white/90 px-3 py-1 shadow-md';
-    const categoriaTexto = produto.categoria
-      ? produto.categoria.toString().trim().toUpperCase()
-      : 'SEM CATEGORIA';
-    categoriaBadge.textContent = categoriaTexto || 'SEM CATEGORIA';
-    imageOverlay.append(skuBadge, categoriaBadge);
-    imageFrame.appendChild(imageOverlay);
-
     imageSection.appendChild(imageFrame);
     card.appendChild(imageSection);
 
     const content = document.createElement('div');
-    content.className = 'flex flex-1 flex-col gap-4 px-5 py-4';
+    content.className =
+      'catalog-card__content flex flex-1 flex-col gap-4 px-4 py-4';
+
+    const badgesRow = document.createElement('div');
+    badgesRow.className =
+      'catalog-card__badges flex flex-wrap items-center gap-2 text-xs font-medium text-gray-700';
+    const skuBadge = document.createElement('span');
+    skuBadge.className =
+      'catalog-card__badge rounded-full bg-gray-100 px-3 py-1 text-gray-700';
+    skuBadge.textContent = `SKU: ${produto.sku || '--'}`;
+    const categoriaBadge = document.createElement('span');
+    categoriaBadge.className =
+      'catalog-card__badge rounded-full bg-gray-100 px-3 py-1 text-gray-700';
+    const categoriaTexto = produto.categoria
+      ? produto.categoria.toString().trim()
+      : 'Sem categoria';
+    categoriaBadge.textContent = categoriaTexto || 'Sem categoria';
+    badgesRow.append(skuBadge, categoriaBadge);
+    content.appendChild(badgesRow);
 
     const measuresSection = document.createElement('div');
     measuresSection.className =
-      'rounded-2xl border-2 border-gray-200 bg-gray-100 px-4 py-4';
+      'catalog-card__block rounded-lg border border-gray-200 bg-gray-50 px-3 py-3';
     const measuresHeading = document.createElement('p');
     measuresHeading.className =
-      'text-center text-xs font-semibold uppercase tracking-wide text-gray-700';
+      'catalog-card__block-title text-center text-xs font-semibold uppercase tracking-wide text-gray-600';
     measuresHeading.textContent = 'Medidas do produto / Medidas da embalagem';
     measuresSection.appendChild(measuresHeading);
 
     const measuresGrid = document.createElement('div');
-    measuresGrid.className = 'mt-3 grid gap-3 sm:grid-cols-2';
+    measuresGrid.className =
+      'catalog-card__info-grid mt-3 grid gap-3 sm:grid-cols-2';
     measuresGrid.appendChild(
       createInfoCell('Produto', produto.medidas || '--', {
-        containerClass: 'border border-gray-300',
+        containerClass: 'border-gray-200',
       }),
     );
     measuresGrid.appendChild(
       createInfoCell('Embalagem', produto.tamanhoEmbalagem || '--', {
-        containerClass: 'border border-gray-300',
+        containerClass: 'border-gray-200',
       }),
     );
     measuresSection.appendChild(measuresGrid);
     content.appendChild(measuresSection);
 
     const infoRow = document.createElement('div');
-    infoRow.className = 'flex flex-col gap-4 lg:flex-row';
+    infoRow.className = 'catalog-card__info-row grid gap-4 md:grid-cols-2';
 
     const componentsSection = document.createElement('div');
     componentsSection.className =
-      'flex-1 rounded-2xl border-2 border-gray-200 bg-gray-100 px-4 py-4';
+      'catalog-card__block flex-1 rounded-lg border border-gray-200 bg-gray-50 px-3 py-3';
     const componentsTitle = document.createElement('p');
     componentsTitle.className =
-      'text-sm font-semibold uppercase tracking-wide text-gray-700';
+      'catalog-card__block-title text-xs font-semibold uppercase tracking-wide text-gray-600';
     componentsTitle.textContent = 'Componentes';
     componentsSection.appendChild(componentsTitle);
 
     const componentsGrid = document.createElement('div');
-    componentsGrid.className = 'mt-3 grid grid-cols-2 gap-3';
+    componentsGrid.className =
+      'catalog-card__info-grid mt-3 grid grid-cols-2 gap-3';
     const componentes =
       produto && typeof produto.componentes === 'object'
         ? produto.componentes
@@ -1899,26 +1906,26 @@ function renderCardView(displayItems) {
         'Parafusos',
         formatComponentQuantityForDisplay(parafusosQuantidade),
         {
-          containerClass: 'border border-yellow-300 bg-yellow-50',
+          containerClass: 'border-yellow-200 bg-white',
           valueClass: 'text-sm font-semibold text-gray-800',
         },
       ),
     );
     componentsGrid.appendChild(
       createInfoCell('Puxador', puxadorDisplay, {
-        containerClass: 'border border-yellow-300 bg-yellow-50',
+        containerClass: 'border-yellow-200 bg-white',
         valueClass: 'text-sm font-semibold text-gray-800',
       }),
     );
     componentsGrid.appendChild(
       createInfoCell('Outros', outrosDisplays[0] || '--', {
-        containerClass: 'border border-yellow-300 bg-yellow-50',
+        containerClass: 'border-yellow-200 bg-white',
         valueClass: 'text-sm font-semibold text-gray-800',
       }),
     );
     componentsGrid.appendChild(
       createInfoCell('Outros', outrosDisplays[1] || '--', {
-        containerClass: 'border border-yellow-300 bg-yellow-50',
+        containerClass: 'border-yellow-200 bg-white',
         valueClass: 'text-sm font-semibold text-gray-800',
       }),
     );
@@ -1927,20 +1934,20 @@ function renderCardView(displayItems) {
 
     const financeSection = document.createElement('div');
     financeSection.className =
-      'flex w-full flex-col rounded-2xl border-2 border-green-300 bg-green-100 px-4 py-4 text-gray-900 lg:w-64';
+      'catalog-card__block catalog-card__block--finance flex w-full flex-col gap-3 rounded-lg border border-green-200 bg-white px-3 py-3 text-gray-900';
     const financeTitle = document.createElement('p');
     financeTitle.className =
-      'text-sm font-semibold uppercase tracking-wide text-green-900';
+      'catalog-card__block-title text-xs font-semibold uppercase tracking-wide text-green-700';
     financeTitle.textContent = 'Custo / Preço sugerido';
     financeSection.appendChild(financeTitle);
 
     const financeValues = document.createElement('div');
-    financeValues.className = 'mt-3 flex flex-col gap-3';
+    financeValues.className = 'mt-1 flex flex-col gap-2';
     financeValues.appendChild(
       createInfoCell('Custo', formatCurrency(getProductCost(produto)), {
-        containerClass: 'border border-green-300 bg-white',
+        containerClass: 'border-green-200 bg-green-50',
         labelClass: 'text-green-700',
-        valueClass: 'text-base font-bold text-green-900',
+        valueClass: 'text-base font-semibold text-green-900',
       }),
     );
     financeValues.appendChild(
@@ -1948,9 +1955,9 @@ function renderCardView(displayItems) {
         'Preço sugerido',
         formatCurrency(getProductPrice(produto)),
         {
-          containerClass: 'border border-green-300 bg-white',
+          containerClass: 'border-green-200 bg-green-50',
           labelClass: 'text-green-700',
-          valueClass: 'text-base font-bold text-green-900',
+          valueClass: 'text-base font-semibold text-green-900',
         },
       ),
     );
@@ -1961,12 +1968,12 @@ function renderCardView(displayItems) {
 
     const actions = document.createElement('div');
     actions.className =
-      'mt-auto flex flex-wrap items-center justify-end gap-2 pt-2';
+      'catalog-card__actions mt-auto flex flex-wrap items-center justify-end gap-2 pt-2';
 
     const detailsBtn = document.createElement('button');
     detailsBtn.type = 'button';
     detailsBtn.className =
-      'inline-flex items-center gap-2 rounded-lg bg-blue-600 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-white shadow transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400';
+      'catalog-card__action-btn inline-flex items-center gap-2 rounded-md bg-blue-600 px-3 py-2 text-xs font-semibold text-white shadow transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400';
     detailsBtn.innerHTML =
       '<i class="fa-solid fa-circle-info"></i><span>Detalhes</span>';
     detailsBtn.addEventListener('click', () => openModal(produto));
@@ -1976,7 +1983,7 @@ function renderCardView(displayItems) {
       const editBtn = document.createElement('button');
       editBtn.type = 'button';
       editBtn.className =
-        'inline-flex items-center gap-2 rounded-lg bg-purple-600 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-white shadow transition hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400';
+        'catalog-card__action-btn inline-flex items-center gap-2 rounded-md bg-purple-600 px-3 py-2 text-xs font-semibold text-white shadow transition hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400';
       editBtn.innerHTML =
         '<i class="fa-solid fa-pen-to-square"></i><span>Editar</span>';
       editBtn.addEventListener('click', () => startEditingProduct(produto));
@@ -1985,7 +1992,7 @@ function renderCardView(displayItems) {
       const deleteBtn = document.createElement('button');
       deleteBtn.type = 'button';
       deleteBtn.className =
-        'inline-flex items-center gap-2 rounded-lg bg-red-600 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-white shadow transition hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-400';
+        'catalog-card__action-btn inline-flex items-center gap-2 rounded-md bg-red-600 px-3 py-2 text-xs font-semibold text-white shadow transition hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-400';
       deleteBtn.innerHTML =
         '<i class="fa-solid fa-trash-can"></i><span>Excluir</span>';
       deleteBtn.addEventListener('click', () =>
@@ -2000,21 +2007,22 @@ function renderCardView(displayItems) {
     const cardDriveLink =
       produto.driveFolderLink || produto.driveLink || produto.linkDrive;
     const footer = document.createElement('div');
-    footer.className = 'bg-yellow-300 px-4 py-3';
+    footer.className =
+      'catalog-card__footer border-t border-yellow-100 bg-yellow-50 px-4 py-3';
     if (cardDriveLink) {
       const driveBtn = document.createElement('a');
       driveBtn.href = cardDriveLink;
       driveBtn.target = '_blank';
       driveBtn.rel = 'noopener noreferrer';
       driveBtn.className =
-        'inline-flex w-full items-center justify-center gap-2 text-sm font-bold uppercase tracking-wide text-gray-900 transition hover:text-gray-800';
+        'inline-flex w-full items-center justify-center gap-2 text-sm font-semibold text-gray-800 transition hover:text-gray-900';
       driveBtn.innerHTML =
         '<i class="fa-solid fa-folder-open"></i><span>Abrir pasta de fotos (Abrir pasta Driver)</span>';
       footer.appendChild(driveBtn);
     } else {
       const drivePlaceholder = document.createElement('div');
       drivePlaceholder.className =
-        'inline-flex w-full items-center justify-center gap-2 text-sm font-semibold uppercase tracking-wide text-gray-600';
+        'inline-flex w-full items-center justify-center gap-2 text-sm font-medium text-gray-600';
       drivePlaceholder.innerHTML =
         '<i class="fa-solid fa-folder-open"></i><span>Pasta de fotos não cadastrada</span>';
       footer.appendChild(drivePlaceholder);

--- a/css/styles.css
+++ b/css/styles.css
@@ -198,6 +198,161 @@ h4 {
   font-size: 1.1rem;
 }
 
+/* === Catálogo de produtos === */
+.catalog-card {
+  border-radius: 0.85rem;
+  border-color: #e5e7eb;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.18s ease;
+  background-color: #ffffff;
+}
+
+.catalog-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.1);
+}
+
+.catalog-card__header {
+  background: #fef3c7;
+  border-bottom: 1px solid #fcd34d;
+  padding: 0.9rem 1.1rem;
+}
+
+.catalog-card__title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.catalog-card__media {
+  padding: 1rem 1.1rem 1.25rem;
+}
+
+.catalog-card__media-frame {
+  height: 11rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, #f3f4f6, #e5e7eb);
+}
+
+.catalog-card__media-frame img {
+  object-fit: cover;
+}
+
+.catalog-card__badges {
+  gap: 0.5rem;
+}
+
+.catalog-card__badge {
+  background-color: #f3f4f6;
+  color: #374151;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.catalog-card__block {
+  border-color: #e5e7eb;
+  background-color: #f9fafb;
+}
+
+.catalog-card__block-title {
+  color: #4b5563;
+  letter-spacing: 0.08em;
+}
+
+.catalog-card__info-grid {
+  gap: 0.75rem;
+}
+
+.catalog-card__info-cell {
+  border-color: #e5e7eb;
+  background-color: #ffffff;
+  gap: 0.35rem;
+}
+
+.catalog-card__info-label {
+  font-size: 0.68rem;
+  color: #6b7280;
+  letter-spacing: 0.1em;
+}
+
+.catalog-card__info-value {
+  font-size: 0.875rem;
+  color: #1f2937;
+}
+
+.catalog-card__block--finance {
+  border-color: rgba(16, 185, 129, 0.35);
+  background-color: #ecfdf5;
+}
+
+.catalog-card__block--finance .catalog-card__info-cell {
+  background-color: #d1fae5;
+  border-color: rgba(16, 185, 129, 0.35);
+}
+
+.catalog-card__actions {
+  padding-top: 0.5rem;
+}
+
+.catalog-card__action-btn {
+  font-size: 0.7rem;
+  text-transform: none;
+  border-radius: 0.55rem;
+}
+
+.catalog-card__footer {
+  background: #fef3c7;
+  border-top: 1px solid #fcd34d;
+}
+
+.catalog-card__footer a,
+.catalog-card__footer div {
+  font-weight: 600;
+}
+
+.catalog-card__selection {
+  background-color: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.1);
+}
+
+.catalog-card__selection input {
+  margin-top: 1px;
+}
+
+/* Print adjustments to keep the same layout when exporting */
+@media print {
+  body {
+    background: #ffffff !important;
+  }
+
+  #catalogCards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1rem;
+  }
+
+  .catalog-card {
+    break-inside: avoid;
+    box-shadow: none;
+    border-color: #d1d5db;
+    transform: none !important;
+  }
+
+  .catalog-card,
+  .catalog-card__header,
+  .catalog-card__footer,
+  .catalog-card__badge,
+  .catalog-card__info-cell,
+  .catalog-card__block--finance {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+}
+
 .result {
   background: #f8f9fa;
   padding: 20px;


### PR DESCRIPTION
## Summary
- create dedicated catalog card classes in the renderer to tighten spacing, reorganize badges, and standardize actions
- add catalog card styling rules that shrink imagery, improve typography, and include finance highlighting
- ensure print/export keeps the new grid layout and colors so PDF exports match the on-screen cards

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690df35a3074832a8b1fe793656af33d)