### PR TITLE
Ajusta exportação em PDF do catálogo para usar layout dos cards

### DIFF
--- a/catalogo.html
+++ b/catalogo.html
@@ -738,6 +738,7 @@
 
       <script src="shared.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.25/jspdf.plugin.autotable.min.js"></script>
       <script type="module" src="firebase-config.js"></script>


### PR DESCRIPTION
## Resumo
- adiciona o html2canvas à página do catálogo para permitir a captura dos cards
- refatora a construção dos cards para reutilizar o mesmo markup no DOM e na exportação
- gera o PDF capturando os cards renderizados, garantindo o mesmo layout exibido na página

## Testes
- npx prettier --write catalogo.js catalogo.html

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dfcade6d4832a8edd14bd7fc6d451)