### PR TITLE
Add navbar alerts for cronograma daily schedule

### DIFF
--- a/acompanhamento-problemas.js
+++ b/acompanhamento-problemas.js
@@ -50,7 +50,9 @@ const reembolsosExportExcelBtn = document.getElementById(
 );
 const reembolsosExportPdfBtn = document.getElementById('reembolsosExportPdf');
 const reembolsosStatusFiltroEl = document.getElementById('reembolsosStatus');
-const reembolsosModeloExcelBtn = document.getElementById('reembolsosModeloExcel');
+const reembolsosModeloExcelBtn = document.getElementById(
+  'reembolsosModeloExcel',
+);
 const reembolsosImportInput = document.getElementById('reembolsosImportarXlsx');
 
 const REEMBOLSO_STATUS_MAPA = {
@@ -205,7 +207,10 @@ function registrarEventos() {
   pecasImportInput?.addEventListener('change', importarPecasMassa);
   reembolsosExportExcelBtn?.addEventListener('click', exportarReembolsosExcel);
   reembolsosExportPdfBtn?.addEventListener('click', exportarReembolsosPdf);
-  reembolsosModeloExcelBtn?.addEventListener('click', baixarModeloReembolsosExcel);
+  reembolsosModeloExcelBtn?.addEventListener(
+    'click',
+    baixarModeloReembolsosExcel,
+  );
   reembolsosImportInput?.addEventListener('change', importarReembolsosMassa);
   gerarRelatorioBtn?.addEventListener('click', gerarRelatorioCompleto);
 }
@@ -892,8 +897,14 @@ function gerarRelatorioCompleto() {
 
   // Principais problemas (por valor) e problemas mais recorrentes (por quantidade)
   const todosProblemas = [
-    ...pecas.map((p) => ({ problema: p.problema || 'Não informado', valor: Number(p.valorGasto) || 0 })),
-    ...reembolsos.map((r) => ({ problema: r.problema || r.motivo || 'Não informado', valor: Number(r.valor) || 0 })),
+    ...pecas.map((p) => ({
+      problema: p.problema || 'Não informado',
+      valor: Number(p.valorGasto) || 0,
+    })),
+    ...reembolsos.map((r) => ({
+      problema: r.problema || r.motivo || 'Não informado',
+      valor: Number(r.valor) || 0,
+    })),
   ];
   const agrupadosProblemas = agruparMetricas(
     todosProblemas,
@@ -901,8 +912,12 @@ function gerarRelatorioCompleto() {
     (i) => i.valor,
   );
   const principaisProblemas = agrupadosProblemas.slice(0, 5);
-  const problemasRecorrentes = [...agrupadosProblemas].sort((a, b) => b.quantidade - a.quantidade).slice(0, 5);
-  const problemasMaiorGasto = [...agrupadosProblemas].sort((a, b) => b.valor - a.valor).slice(0, 5);
+  const problemasRecorrentes = [...agrupadosProblemas]
+    .sort((a, b) => b.quantidade - a.quantidade)
+    .slice(0, 5);
+  const problemasMaiorGasto = [...agrupadosProblemas]
+    .sort((a, b) => b.valor - a.valor)
+    .slice(0, 5);
 
   const principaisLojas = agruparMetricas(
     pecas,
@@ -920,7 +935,8 @@ function gerarRelatorioCompleto() {
   const maioresGastos = [
     ...pecas.map((item) => ({
       tipo: 'Peça faltante',
-      descricao: item.peca || item.numero || item.nomeCliente || 'Não informado',
+      descricao:
+        item.peca || item.numero || item.nomeCliente || 'Não informado',
       responsavel: item.usuarioNome || '-',
       data: item.data || '',
       loja: item.loja || '-',
@@ -958,7 +974,9 @@ function gerarRelatorioCompleto() {
       valores: principaisPecas.map((item) => item.quantidade),
     },
     topGastos: {
-      labels: maioresGastos.map((item) => limitarTexto(`${item.tipo}: ${item.descricao}`, 40)),
+      labels: maioresGastos.map((item) =>
+        limitarTexto(`${item.tipo}: ${item.descricao}`, 40),
+      ),
       valores: maioresGastos.map((item) => Number(item.valor.toFixed(2))),
     },
   };
@@ -1037,7 +1055,12 @@ function baixarModeloPecasExcel() {
     'NÃO FEITO',
     25.5,
   ];
-  exportarExcel(gerarNomeArquivo('modelo_pecas_faltantes', 'xlsx'), 'Modelo', headers, [exemplo]);
+  exportarExcel(
+    gerarNomeArquivo('modelo_pecas_faltantes', 'xlsx'),
+    'Modelo',
+    headers,
+    [exemplo],
+  );
 }
 
 function baixarModeloReembolsosExcel() {
@@ -1067,7 +1090,12 @@ function baixarModeloReembolsosExcel() {
     'chave-pix-aqui',
     'AGUARDANDO',
   ];
-  exportarExcel(gerarNomeArquivo('modelo_reembolsos', 'xlsx'), 'Modelo', headers, [exemplo]);
+  exportarExcel(
+    gerarNomeArquivo('modelo_reembolsos', 'xlsx'),
+    'Modelo',
+    headers,
+    [exemplo],
+  );
 }
 
 async function importarPecasMassa(event) {
@@ -1080,7 +1108,10 @@ async function importarPecasMassa(event) {
       alert('Nenhuma linha encontrada na planilha.');
       return;
     }
-    const itensRef = collection(doc(db, 'uid', currentUser.uid, 'problemas', 'pecasfaltando'), 'itens');
+    const itensRef = collection(
+      doc(db, 'uid', currentUser.uid, 'problemas', 'pecasfaltando'),
+      'itens',
+    );
     let inseridos = 0;
     for (const r of rows) {
       const registro = normalizarLinhaPeca(r);
@@ -1105,7 +1136,10 @@ async function importarReembolsosMassa(event) {
       alert('Nenhuma linha encontrada na planilha.');
       return;
     }
-    const itensRef = collection(doc(db, 'uid', currentUser.uid, 'problemas', 'reembolsos'), 'itens');
+    const itensRef = collection(
+      doc(db, 'uid', currentUser.uid, 'problemas', 'reembolsos'),
+      'itens',
+    );
     let inseridos = 0;
     for (const r of rows) {
       const registro = normalizarLinhaReembolso(r);
@@ -1162,7 +1196,8 @@ function normalizarLinhaPeca(r) {
     peca: r.peca || r['peca'] || '',
     problema: r.problema || r['problema'] || '',
     status: (r.status || r['status'] || '').toString().toUpperCase(),
-    valorGasto: Number(r['valor_gasto (R$)'] || r.valor_gasto || r['valor']) || 0,
+    valorGasto:
+      Number(r['valor_gasto (R$)'] || r.valor_gasto || r['valor']) || 0,
   };
 }
 
@@ -1216,21 +1251,19 @@ function exportarPDF(titulo, headers, linhas, nomeArquivo) {
 function obterPeriodoSelecionado() {
   const pecasInicio = document.getElementById('pecasInicio')?.value || '';
   const pecasFim = document.getElementById('pecasFim')?.value || '';
-  const reembolsosInicio = document.getElementById('reembolsosInicio')?.value || '';
+  const reembolsosInicio =
+    document.getElementById('reembolsosInicio')?.value || '';
   const reembolsosFim = document.getElementById('reembolsosFim')?.value || '';
 
-  const datasInicio = [pecasInicio, reembolsosInicio]
-    .filter(Boolean)
-    .sort();
-  const datasFim = [pecasFim, reembolsosFim]
-    .filter(Boolean)
-    .sort();
+  const datasInicio = [pecasInicio, reembolsosInicio].filter(Boolean).sort();
+  const datasFim = [pecasFim, reembolsosFim].filter(Boolean).sort();
 
   const inicio = datasInicio[0] || '';
   const fim = datasFim.length ? datasFim[datasFim.length - 1] : '';
 
   let texto = 'Período completo';
-  if (inicio && fim) texto = `De ${formatarData(inicio)} até ${formatarData(fim)}`;
+  if (inicio && fim)
+    texto = `De ${formatarData(inicio)} até ${formatarData(fim)}`;
   else if (inicio) texto = `A partir de ${formatarData(inicio)}`;
   else if (fim) texto = `Até ${formatarData(fim)}`;
 
@@ -1253,7 +1286,8 @@ function agruparMetricas(lista, chaveFn, valorFn, rotuloFn) {
   const valorFnNormalizado = typeof valorFn === 'function' ? valorFn : () => 0;
 
   lista.forEach((item) => {
-    const chaveOriginal = typeof chaveFn === 'function' ? chaveFn(item) : undefined;
+    const chaveOriginal =
+      typeof chaveFn === 'function' ? chaveFn(item) : undefined;
     const chaveBase = (chaveOriginal ?? 'Não informado').toString().trim();
     const chaveNormalizada = chaveBase || 'Não informado';
     const valor = Number(valorFnNormalizado(item)) || 0;
@@ -1312,7 +1346,8 @@ function gerarHtmlRelatorio(dados) {
   const graficos = dados?.graficos || {};
   const geradoEm = dados?.geradoEm || new Date().toLocaleString('pt-BR');
 
-  const formatarQuantidade = (valor) => Number(valor || 0).toLocaleString('pt-BR');
+  const formatarQuantidade = (valor) =>
+    Number(valor || 0).toLocaleString('pt-BR');
   const formatarMoedaBRL = (valor) => formatarMoeda(Number(valor) || 0);
 
   const criarLinhasTabela = (lista, colunasVazias) => {

--- a/css/styles.css
+++ b/css/styles.css
@@ -1070,12 +1070,63 @@ body.dark-mode .data-table th {
   display: flex;
   align-items: center;
   gap: 20px;
+  justify-content: flex-end;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 .navbar-left {
   display: flex;
   align-items: center;
   gap: 1rem;
   position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.navbar-center {
+  display: flex;
+  justify-content: center;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0 1rem;
+}
+.navbar-center.hidden {
+  display: none;
+}
+.schedule-alert-banner {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.6rem 1.5rem;
+  border-radius: 999px;
+  background: #fee2e2;
+  color: #b91c1c;
+  border: 2px solid #f87171;
+  font-weight: 800;
+  font-size: clamp(1rem, 0.9rem + 0.6vw, 1.4rem);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  box-shadow: 0 12px 24px -18px rgba(185, 28, 28, 0.6);
+  text-align: center;
+  line-height: 1.2;
+}
+.schedule-alert-banner:not(.hidden) {
+  display: inline-flex;
+}
+.schedule-alert-banner .alert-title {
+  font-size: inherit;
+}
+.schedule-alert-banner .alert-details {
+  font-weight: 700;
+  font-size: clamp(0.95rem, 0.9rem + 0.4vw, 1.2rem);
+  text-transform: none;
+  letter-spacing: 0.02em;
+}
+.schedule-alert-banner .alert-extra {
+  font-weight: 600;
+  font-size: clamp(0.85rem, 0.8rem + 0.35vw, 1.05rem);
+  text-transform: none;
+  letter-spacing: 0.01em;
 }
 .navbar-search {
   height: 2.5rem;
@@ -1135,6 +1186,21 @@ body.dark-mode .data-table th {
 .navbar .menu-item.active {
   background-color: var(--nav-hover);
   color: var(--nav-text);
+}
+
+@media (max-width: 768px) {
+  .navbar-center {
+    padding: 0 0.5rem;
+  }
+  .schedule-alert-banner {
+    width: 100%;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .schedule-alert-banner .alert-details,
+  .schedule-alert-banner .alert-extra {
+    font-size: 0.95rem;
+  }
 }
 .user-dropdown {
   display: flex;

--- a/equipes.html
+++ b/equipes.html
@@ -127,6 +127,51 @@
         background: color-mix(in srgb, var(--card-bg, #ffffff) 92%, transparent);
       }
 
+      .alert-section {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        border: 1px solid rgba(239, 68, 68, 0.2);
+        background: rgba(254, 226, 226, 0.35);
+        padding: 16px;
+        border-radius: 12px;
+      }
+
+      .alert-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-weight: 600;
+        cursor: pointer;
+        color: #b91c1c;
+      }
+
+      .alert-toggle input[type='checkbox'] {
+        accent-color: #ef4444;
+      }
+
+      .alert-message {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .alert-message input[type='text'] {
+        width: 100%;
+        border-radius: 10px;
+        border: 1px solid rgba(185, 28, 28, 0.25);
+        padding: 10px 12px;
+        font-size: 0.95rem;
+      }
+
+      .tag.tag-alert {
+        background: rgba(248, 113, 113, 0.2);
+        color: #b91c1c;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+      }
+
       .repeat-toggle {
         display: inline-flex;
         align-items: center;
@@ -1101,6 +1146,23 @@
                 />
                 <p class="form-hint">Opcional: compartilhe um link de vídeo com o passo a passo desta etapa.</p>
               </div>
+              <div class="alert-section">
+                <label for="scheduleAlertToggle" class="alert-toggle">
+                  <input type="checkbox" id="scheduleAlertToggle" name="scheduleAlertToggle" />
+                  Ativar alerta no horário programado
+                </label>
+                <div id="scheduleAlertMessageContainer" class="alert-message" hidden>
+                  <label for="scheduleAlertMessage">Mensagem do alerta</label>
+                  <input
+                    type="text"
+                    id="scheduleAlertMessage"
+                    name="scheduleAlertMessage"
+                    maxlength="160"
+                    placeholder="Ex.: Reunião começa agora!"
+                  />
+                  <p class="form-hint">Se não informar, usaremos o título da etapa como mensagem.</p>
+                </div>
+              </div>
               <div>
                 <label for="scheduleNotes">Detalhes e observações</label>
                 <textarea
@@ -1257,6 +1319,9 @@
       const cancelScheduleFormBtn = document.getElementById('cancelScheduleForm');
       const scheduleRepeatToggle = document.getElementById('scheduleRepeatToggle');
       const scheduleRepeatDaysContainer = document.getElementById('scheduleRepeatDays');
+      const scheduleAlertToggle = document.getElementById('scheduleAlertToggle');
+      const scheduleAlertMessageContainer = document.getElementById('scheduleAlertMessageContainer');
+      const scheduleAlertMessageInput = document.getElementById('scheduleAlertMessage');
 
       const SCHEDULE_STATUS_OPTIONS = [
         { value: 'nao_feito', label: 'Não feito', className: 'status-pending', icon: 'fa-circle' },
@@ -1290,6 +1355,8 @@
         return acc;
       }, {});
       const weekdayIndexToValue = WEEKDAY_OPTIONS.map((option) => option.value);
+      const SCHEDULE_ALERT_WINDOW_MINUTES = 10;
+      const SCHEDULE_ALERT_INTERVAL_MS = 30000;
 
       const updateForm = document.getElementById('updateForm');
       const updateStatus = document.getElementById('updateStatus');
@@ -1298,6 +1365,10 @@
 
       let app;
       let db;
+      let scheduleAlertBannerEl;
+      let scheduleAlertWrapperEl;
+      let scheduleAlertIntervalId = null;
+      let lastRenderedAlertSignature = '';
       let auth;
       let currentUser = null;
       let currentEmail = '';
@@ -1371,6 +1442,15 @@
         scheduleRepeatDaysContainer.hidden = !isActive;
       }
 
+      function updateScheduleAlertVisibility({ reset = false } = {}) {
+        if (!scheduleAlertMessageContainer) return;
+        const isActive = !!scheduleAlertToggle?.checked;
+        scheduleAlertMessageContainer.hidden = !isActive;
+        if (reset && scheduleAlertMessageInput) {
+          scheduleAlertMessageInput.value = '';
+        }
+      }
+
       function openScheduleForm({ focusField = true } = {}) {
         if (!scheduleForm) return;
         scheduleForm.hidden = false;
@@ -1385,6 +1465,7 @@
           }
         }
         updateRepeatDaysVisibility();
+        updateScheduleAlertVisibility();
         if (focusField) {
           const firstField = scheduleForm.querySelector('input, select, textarea');
           firstField?.focus();
@@ -1400,6 +1481,7 @@
             scheduleDateInput.value = scheduleDateFilter.value;
           }
           updateRepeatDaysVisibility();
+          updateScheduleAlertVisibility({ reset: true });
         }
         scheduleForm.hidden = true;
         if (openScheduleFormBtn) {
@@ -1428,6 +1510,174 @@
         } catch (e) {
           return timeString;
         }
+      }
+
+      function getScheduleAlertElements() {
+        if (!scheduleAlertBannerEl || !document.body.contains(scheduleAlertBannerEl)) {
+          scheduleAlertBannerEl = document.getElementById('scheduleAlertBanner');
+        }
+        if (!scheduleAlertWrapperEl || !document.body.contains(scheduleAlertWrapperEl)) {
+          scheduleAlertWrapperEl = document.getElementById('navbarAlertWrapper');
+        }
+        return { banner: scheduleAlertBannerEl, wrapper: scheduleAlertWrapperEl };
+      }
+
+      function isScheduleEntryActiveOnDate(entry, targetDateIso, targetDateObj) {
+        if (!entry || !targetDateIso || !targetDateObj) {
+          return false;
+        }
+        if (entry.scheduledDate === targetDateIso) {
+          return true;
+        }
+        if (!entry.repeatWeekly || !entry.repeatDays?.length) {
+          return false;
+        }
+        const entryDate = parseISODateString(entry.scheduledDate);
+        if (entryDate && entryDate > targetDateObj) {
+          return false;
+        }
+        const weekdayKey = weekdayIndexToValue[targetDateObj.getDay()];
+        if (!weekdayKey) {
+          return false;
+        }
+        return entry.repeatDays.includes(weekdayKey);
+      }
+
+      function computeAlertTiming(entry, now) {
+        if (!entry.startTime) return null;
+        const [hour, minute] = entry.startTime.split(':').map((value) => parseInt(value, 10));
+        if (!Number.isFinite(hour) || !Number.isFinite(minute)) {
+          return null;
+        }
+        const alertStart = new Date(now);
+        alertStart.setHours(hour, minute, 0, 0);
+        const diffMinutes = (now.getTime() - alertStart.getTime()) / 60000;
+        if (diffMinutes < 0 || diffMinutes > SCHEDULE_ALERT_WINDOW_MINUTES) {
+          return null;
+        }
+        return { alertStart, diffMinutes };
+      }
+
+      function collectActiveScheduleAlerts(now, normalizedEmail, currentDateIso, currentDateObj) {
+        const alerts = [];
+        if (!normalizedEmail) return alerts;
+        trackedOwners.forEach((ownerUid) => {
+          const entries = schedulesByOwner.get(ownerUid) || [];
+          entries.forEach((entry) => {
+            if (!entry.alertEnabled) return;
+            if ((entry.status || 'nao_feito') === 'feito') return;
+            const responsible = (entry.responsibleEmail || '').toLowerCase();
+            if (!responsible || responsible !== normalizedEmail) return;
+            if (!isScheduleEntryActiveOnDate(entry, currentDateIso, currentDateObj)) return;
+            const timing = computeAlertTiming(entry, now);
+            if (!timing) return;
+            alerts.push({ ownerUid, entry, ...timing });
+          });
+        });
+        alerts.sort((a, b) => a.alertStart.getTime() - b.alertStart.getTime());
+        return alerts;
+      }
+
+      function hideScheduleAlertBanner() {
+        const { banner, wrapper } = getScheduleAlertElements();
+        if (wrapper) {
+          wrapper.classList.add('hidden');
+        }
+        if (banner) {
+          banner.classList.add('hidden');
+          banner.innerHTML = '';
+          banner.removeAttribute('data-alert-id');
+        }
+        lastRenderedAlertSignature = '';
+      }
+
+      function updateScheduleAlertBanner() {
+        const { banner, wrapper } = getScheduleAlertElements();
+        if (!banner || !wrapper) {
+          return;
+        }
+        const normalizedEmail = (currentEmail || currentUser?.email || '').toLowerCase();
+        if (!normalizedEmail) {
+          hideScheduleAlertBanner();
+          return;
+        }
+        const now = new Date();
+        const currentDateIso = formatDateISO(now);
+        const currentDateObj = parseISODateString(currentDateIso) || new Date(now.getFullYear(), now.getMonth(), now.getDate());
+        const alerts = collectActiveScheduleAlerts(now, normalizedEmail, currentDateIso, currentDateObj);
+        if (!alerts.length) {
+          hideScheduleAlertBanner();
+          return;
+        }
+        const { ownerUid, entry, alertStart } = alerts[0];
+        const signature = [
+          ownerUid,
+          entry.id,
+          alertStart.getTime(),
+          entry.alertMessage || '',
+          entry.title || '',
+          alerts.length
+        ].join('||');
+        if (signature !== lastRenderedAlertSignature) {
+          const timeLabel = formatTime(entry.startTime);
+          const titleLabel = entry.title || 'Etapa do cronograma';
+          const ownerLabel = resolveOwnerLabel(ownerUid);
+          const message = (entry.alertMessage || '').toString().trim();
+
+          banner.innerHTML = '';
+
+          const titleEl = document.createElement('span');
+          titleEl.className = 'alert-title';
+          titleEl.textContent = 'ALERTA DE CRONOGRAMA';
+          banner.appendChild(titleEl);
+
+          const detailsEl = document.createElement('span');
+          detailsEl.className = 'alert-details';
+          const detailsParts = [];
+          if (timeLabel) detailsParts.push(timeLabel);
+          detailsParts.push(titleLabel);
+          detailsEl.textContent = detailsParts.join(' • ');
+          banner.appendChild(detailsEl);
+
+          const extraParts = [ownerLabel];
+          if (message) {
+            extraParts.push(message);
+          }
+          if (extraParts.length) {
+            const extraEl = document.createElement('span');
+            extraEl.className = 'alert-extra';
+            extraEl.textContent = extraParts.join(' — ');
+            banner.appendChild(extraEl);
+          }
+
+          const additionalAlerts = alerts.length - 1;
+          if (additionalAlerts > 0) {
+            const queueEl = document.createElement('span');
+            queueEl.className = 'alert-extra';
+            queueEl.textContent =
+              additionalAlerts === 1
+                ? 'Mais 1 alerta ativo'
+                : `Mais ${additionalAlerts} alertas ativos`;
+            banner.appendChild(queueEl);
+          }
+
+          lastRenderedAlertSignature = signature;
+        }
+
+        wrapper.classList.remove('hidden');
+        banner.classList.remove('hidden');
+        banner.setAttribute('data-alert-id', signature);
+      }
+
+      function ensureScheduleAlertInterval() {
+        if (scheduleAlertIntervalId !== null) {
+          return;
+        }
+        const { banner } = getScheduleAlertElements();
+        if (!banner) {
+          return;
+        }
+        scheduleAlertIntervalId = window.setInterval(updateScheduleAlertBanner, SCHEDULE_ALERT_INTERVAL_MS);
       }
 
       function parseISODateString(value) {
@@ -1775,29 +2025,14 @@
         const targetDateObj = parseISODateString(targetDate);
         if (!owners.length || !targetDate || !targetDateObj) {
           scheduleFlowContainer.innerHTML = '<div class="empty-state">Cadastre etapas para ver o fluxo diário da equipe.</div>';
+          updateScheduleAlertBanner();
           return;
         }
 
         const sections = owners
           .map((ownerUid) => {
             const entries = (schedulesByOwner.get(ownerUid) || [])
-              .filter((entry) => {
-                if (entry.scheduledDate === targetDate) {
-                  return true;
-                }
-                if (!entry.repeatWeekly || !entry.repeatDays?.length) {
-                  return false;
-                }
-                const entryDate = parseISODateString(entry.scheduledDate);
-                if (entryDate && entryDate > targetDateObj) {
-                  return false;
-                }
-                const weekdayKey = weekdayIndexToValue[targetDateObj.getDay()];
-                if (!weekdayKey) {
-                  return false;
-                }
-                return entry.repeatDays.includes(weekdayKey);
-              })
+              .filter((entry) => isScheduleEntryActiveOnDate(entry, targetDate, targetDateObj))
               .sort((a, b) => {
                 const aTime = `${a.startTime || ''}`;
                 const bTime = `${b.startTime || ''}`;
@@ -1828,6 +2063,9 @@
                 const statusPill = statusInfo
                   ? `<span class="flow-status-pill ${statusInfo.className}"><i class="fas ${statusInfo.icon}" aria-hidden="true"></i>${statusInfo.label}</span>`
                   : '';
+                const alertTag = entry.alertEnabled
+                  ? `<div class="tag tag-alert"><i class="fas fa-bell"></i>Alerta</div>`
+                  : '';
                 const repeatTag = entry.repeatWeekly && entry.repeatDays?.length
                   ? `<div class="tag"><i class="fas fa-arrows-rotate"></i>${entry.repeatDays
                       .map((day) => weekdayMap[day]?.shortLabel || weekdayMap[day]?.label || day)
@@ -1854,6 +2092,7 @@
                           <h3>${entry.title || 'Etapa'}</h3>
                           <div class="flow-meta">
                             <div class="tag"><i class="fas fa-user"></i>${responsibleLabel}</div>
+                            ${alertTag}
                             ${repeatTag}
                             ${statusPill}
                           </div>
@@ -1883,6 +2122,7 @@
           .join('');
 
         scheduleFlowContainer.innerHTML = sections || '<div class="empty-state">Nenhum fluxo registrado para esta data.</div>';
+        updateScheduleAlertBanner();
       }
 
       function buildResponsibleOptions(emptyLabel = 'Selecione um responsável', { multiple = false } = {}) {
@@ -2034,6 +2274,8 @@
                 videoUrl: data.videoUrl || '',
                 repeatWeekly: !!data.repeatWeekly,
                 repeatDays: Array.isArray(data.repeatDays) ? data.repeatDays.map((value) => value.toString()) : [],
+                alertEnabled: !!data.alertEnabled,
+                alertMessage: typeof data.alertMessage === 'string' ? data.alertMessage : '',
               };
             });
             schedulesByOwner.set(ownerUid, entries);
@@ -2177,6 +2419,8 @@
               email: user.email || undefined,
               label: 'Minha equipe'
             });
+            updateScheduleAlertBanner();
+            ensureScheduleAlertInterval();
             applyOwnerSet(new Set([user.uid]));
             refreshSharedMemberships();
           });
@@ -2407,6 +2651,8 @@
         const notes = (formData.get('scheduleNotes') || '').toString();
         const repeatWeekly = formData.has('scheduleRepeatToggle');
         const repeatDays = repeatWeekly ? formData.getAll('scheduleRepeatDays').map((value) => value.toString()) : [];
+        const alertEnabled = formData.has('scheduleAlertToggle');
+        const alertMessage = (formData.get('scheduleAlertMessage') || '').toString().trim();
 
         if (!title || !scheduledDate || !startTime || !responsible) {
           showStatus(scheduleStatus, 'Preencha os campos obrigatórios da etapa.', 'error');
@@ -2436,6 +2682,8 @@
             createdAt: serverTimestamp(),
             repeatWeekly: repeatWeekly && repeatDays.length > 0,
             repeatDays: repeatDays,
+            alertEnabled,
+            alertMessage: alertEnabled && alertMessage ? alertMessage : null,
           });
           scheduleForm.reset();
           const scheduleDateInput = document.getElementById('scheduleDate');
@@ -2446,6 +2694,7 @@
             scheduleDateFilter.value = scheduledDate;
           }
           updateRepeatDaysVisibility();
+          updateScheduleAlertVisibility({ reset: true });
           renderSchedule();
           showStatus(scheduleStatus, 'Etapa adicionada ao cronograma!');
         } catch (error) {
@@ -2519,6 +2768,10 @@
         }
       });
 
+      scheduleAlertToggle?.addEventListener('change', () => {
+        updateScheduleAlertVisibility();
+      });
+
       updateForm?.addEventListener('submit', async (event) => {
         event.preventDefault();
         if (!db || !currentUser) return;
@@ -2565,14 +2818,30 @@
         }
       });
 
+      document.addEventListener('navbarLoaded', () => {
+        getScheduleAlertElements();
+        updateScheduleAlertBanner();
+        ensureScheduleAlertInterval();
+      });
+
+      document.addEventListener('visibilitychange', () => {
+        if (!document.hidden) {
+          updateScheduleAlertBanner();
+        }
+      });
+
       window.addEventListener('focus', () => {
         if (currentUser) {
           refreshSharedMemberships();
         }
+        updateScheduleAlertBanner();
       });
 
       initializeAuth();
       updateRepeatDaysVisibility();
+      updateScheduleAlertVisibility({ reset: true });
+      updateScheduleAlertBanner();
+      ensureScheduleAlertInterval();
       renderSchedule();
     </script>
   </body>

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -24,6 +24,14 @@
     <input id="navbarSearch" type="text" class="navbar-search" placeholder="Pesquisar..." />
     <div id="navbarSearchResults" class="navbar-search-results hidden"></div>
   </div>
+  <div id="navbarAlertWrapper" class="navbar-center hidden">
+    <div
+      id="scheduleAlertBanner"
+      class="schedule-alert-banner hidden"
+      role="alert"
+      aria-live="assertive"
+    ></div>
+  </div>
   <div class="navbar-right">
     <div id="navbarMeetingsWrapper" class="relative hidden">
       <button

--- a/sku-associado.js
+++ b/sku-associado.js
@@ -31,7 +31,6 @@ let eventosRegistrados = false;
 const COMPONENTES_PADRAO = [
   { nome: 'Fiação', quantidade: null },
   { nome: 'Bocal', quantidade: null },
-
 ];
 
 const CONTEXT_ESCOPOS_PADRAO = [
@@ -286,7 +285,8 @@ function resetarComponentesFormulario(componentes = null) {
 // --------- PRODUTOS COMPOSTOS ---------
 function criarLinhaComposto(item = {}) {
   const linha = document.createElement('div');
-  linha.className = 'composto-row flex flex-col gap-2 md:flex-row md:items-center';
+  linha.className =
+    'composto-row flex flex-col gap-2 md:flex-row md:items-center';
   const inputSku = document.createElement('input');
   inputSku.type = 'text';
   inputSku.className = 'composto-sku flex-1 p-2 border rounded';
@@ -296,10 +296,12 @@ function criarLinhaComposto(item = {}) {
   inputQuantidade.type = 'number';
   inputQuantidade.min = '0';
   inputQuantidade.step = '1';
-  inputQuantidade.className = 'composto-quantidade w-full md:w-32 p-2 border rounded';
+  inputQuantidade.className =
+    'composto-quantidade w-full md:w-32 p-2 border rounded';
   inputQuantidade.placeholder = 'Quantidade';
   const quantidadeSanitizada = sanitizarQuantidadeNumerica(item?.quantidade);
-  inputQuantidade.value = quantidadeSanitizada === null ? '' : quantidadeSanitizada;
+  inputQuantidade.value =
+    quantidadeSanitizada === null ? '' : quantidadeSanitizada;
   const botaoRemover = document.createElement('button');
   botaoRemover.type = 'button';
   botaoRemover.className = 'text-sm font-medium text-red-600';
@@ -321,7 +323,9 @@ function resetarCompostosFormulario(lista = []) {
   const container = document.getElementById('compostosContainer');
   if (!container) return;
   container.innerHTML = '';
-  (Array.isArray(lista) ? lista : []).forEach((it) => adicionarLinhaComposto(it));
+  (Array.isArray(lista) ? lista : []).forEach((it) =>
+    adicionarLinhaComposto(it),
+  );
 }
 
 function normalizarCompostosLista(compostos) {
@@ -403,9 +407,7 @@ function preencherComponentesNoFormulario(componentes = []) {
   const bocalEl = document.getElementById('quantidadeBocal');
   const encontrarQuantidade = (nomeAlvo) => {
     const alvo = normalizarTexto(nomeAlvo);
-    const comp = listaNormalizada.find(
-      (c) => normalizarTexto(c.nome) === alvo,
-    );
+    const comp = listaNormalizada.find((c) => normalizarTexto(c.nome) === alvo);
     return comp?.quantidade ?? null;
   };
   if (fiacaoEl) {
@@ -518,9 +520,7 @@ async function carregarSkus() {
     const quantidadeParafusos = sanitizarQuantidadeParafusos(
       data.quantidadeParafusos,
     );
-    const quantidadePecas = sanitizarQuantidadeNumerica(
-      data.quantidadePecas,
-    );
+    const quantidadePecas = sanitizarQuantidadeNumerica(data.quantidadePecas);
     skuCache.set(docId, {
       ...data,
       id: docId,


### PR DESCRIPTION
## Summary
- add a dedicated alert toggle and message input to the daily cronogram form, with supporting styles and schedule tags
- persist alert metadata with each step and surface active alerts with a prominent banner in the navbar and within the schedule view
- reformat root workflow scripts touched by the pre-commit hook to keep Prettier checks passing

## Testing
- husky pre-commit (eslint & prettier)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690c80a57fc8832a8a432ccde8608ead)