### PR TITLE
Add global schedule alert banner service

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1094,21 +1094,36 @@ body.dark-mode .data-table th {
 }
 .schedule-alert-banner {
   display: none;
+  position: relative;
+  isolation: isolate;
   align-items: center;
   justify-content: center;
   gap: 0.75rem;
-  padding: 0.6rem 1.5rem;
-  border-radius: 999px;
-  background: #fee2e2;
-  color: #b91c1c;
-  border: 2px solid #f87171;
+  padding: 0.75rem 1.75rem;
+  border-radius: 16px;
+  color: #fff;
+  background: linear-gradient(
+    180deg,
+    rgba(220, 38, 38, 0.15) 0%,
+    rgba(220, 38, 38, 0.6) 45%,
+    rgba(185, 28, 28, 0.95) 100%
+  );
+  box-shadow: 0 18px 36px -18px rgba(185, 28, 28, 0.8);
   font-weight: 800;
   font-size: clamp(1rem, 0.9rem + 0.6vw, 1.4rem);
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  box-shadow: 0 12px 24px -18px rgba(185, 28, 28, 0.6);
   text-align: center;
   line-height: 1.2;
+}
+.schedule-alert-banner::before {
+  content: '';
+  position: absolute;
+  inset: 58% -1.5rem -0.9rem -1.5rem;
+  border-radius: 22px;
+  background: linear-gradient(180deg, #ef4444 0%, #b91c1c 100%);
+  box-shadow: 0 18px 32px -18px rgba(185, 28, 28, 0.65);
+  z-index: -1;
 }
 .schedule-alert-banner:not(.hidden) {
   display: inline-flex;

--- a/equipes.html
+++ b/equipes.html
@@ -1355,8 +1355,6 @@
         return acc;
       }, {});
       const weekdayIndexToValue = WEEKDAY_OPTIONS.map((option) => option.value);
-      const SCHEDULE_ALERT_WINDOW_MINUTES = 10;
-      const SCHEDULE_ALERT_INTERVAL_MS = 30000;
 
       const updateForm = document.getElementById('updateForm');
       const updateStatus = document.getElementById('updateStatus');
@@ -1365,10 +1363,6 @@
 
       let app;
       let db;
-      let scheduleAlertBannerEl;
-      let scheduleAlertWrapperEl;
-      let scheduleAlertIntervalId = null;
-      let lastRenderedAlertSignature = '';
       let auth;
       let currentUser = null;
       let currentEmail = '';
@@ -1512,14 +1506,12 @@
         }
       }
 
-      function getScheduleAlertElements() {
-        if (!scheduleAlertBannerEl || !document.body.contains(scheduleAlertBannerEl)) {
-          scheduleAlertBannerEl = document.getElementById('scheduleAlertBanner');
+      function refreshNavbarScheduleAlerts() {
+        try {
+          window.scheduleAlertService?.refreshScheduleAlertBanner?.();
+        } catch (error) {
+          console.error('Erro ao atualizar alertas do cronograma no navbar:', error);
         }
-        if (!scheduleAlertWrapperEl || !document.body.contains(scheduleAlertWrapperEl)) {
-          scheduleAlertWrapperEl = document.getElementById('navbarAlertWrapper');
-        }
-        return { banner: scheduleAlertBannerEl, wrapper: scheduleAlertWrapperEl };
       }
 
       function isScheduleEntryActiveOnDate(entry, targetDateIso, targetDateObj) {
@@ -1541,143 +1533,6 @@
           return false;
         }
         return entry.repeatDays.includes(weekdayKey);
-      }
-
-      function computeAlertTiming(entry, now) {
-        if (!entry.startTime) return null;
-        const [hour, minute] = entry.startTime.split(':').map((value) => parseInt(value, 10));
-        if (!Number.isFinite(hour) || !Number.isFinite(minute)) {
-          return null;
-        }
-        const alertStart = new Date(now);
-        alertStart.setHours(hour, minute, 0, 0);
-        const diffMinutes = (now.getTime() - alertStart.getTime()) / 60000;
-        if (diffMinutes < 0 || diffMinutes > SCHEDULE_ALERT_WINDOW_MINUTES) {
-          return null;
-        }
-        return { alertStart, diffMinutes };
-      }
-
-      function collectActiveScheduleAlerts(now, normalizedEmail, currentDateIso, currentDateObj) {
-        const alerts = [];
-        if (!normalizedEmail) return alerts;
-        trackedOwners.forEach((ownerUid) => {
-          const entries = schedulesByOwner.get(ownerUid) || [];
-          entries.forEach((entry) => {
-            if (!entry.alertEnabled) return;
-            if ((entry.status || 'nao_feito') === 'feito') return;
-            const responsible = (entry.responsibleEmail || '').toLowerCase();
-            if (!responsible || responsible !== normalizedEmail) return;
-            if (!isScheduleEntryActiveOnDate(entry, currentDateIso, currentDateObj)) return;
-            const timing = computeAlertTiming(entry, now);
-            if (!timing) return;
-            alerts.push({ ownerUid, entry, ...timing });
-          });
-        });
-        alerts.sort((a, b) => a.alertStart.getTime() - b.alertStart.getTime());
-        return alerts;
-      }
-
-      function hideScheduleAlertBanner() {
-        const { banner, wrapper } = getScheduleAlertElements();
-        if (wrapper) {
-          wrapper.classList.add('hidden');
-        }
-        if (banner) {
-          banner.classList.add('hidden');
-          banner.innerHTML = '';
-          banner.removeAttribute('data-alert-id');
-        }
-        lastRenderedAlertSignature = '';
-      }
-
-      function updateScheduleAlertBanner() {
-        const { banner, wrapper } = getScheduleAlertElements();
-        if (!banner || !wrapper) {
-          return;
-        }
-        const normalizedEmail = (currentEmail || currentUser?.email || '').toLowerCase();
-        if (!normalizedEmail) {
-          hideScheduleAlertBanner();
-          return;
-        }
-        const now = new Date();
-        const currentDateIso = formatDateISO(now);
-        const currentDateObj = parseISODateString(currentDateIso) || new Date(now.getFullYear(), now.getMonth(), now.getDate());
-        const alerts = collectActiveScheduleAlerts(now, normalizedEmail, currentDateIso, currentDateObj);
-        if (!alerts.length) {
-          hideScheduleAlertBanner();
-          return;
-        }
-        const { ownerUid, entry, alertStart } = alerts[0];
-        const signature = [
-          ownerUid,
-          entry.id,
-          alertStart.getTime(),
-          entry.alertMessage || '',
-          entry.title || '',
-          alerts.length
-        ].join('||');
-        if (signature !== lastRenderedAlertSignature) {
-          const timeLabel = formatTime(entry.startTime);
-          const titleLabel = entry.title || 'Etapa do cronograma';
-          const ownerLabel = resolveOwnerLabel(ownerUid);
-          const message = (entry.alertMessage || '').toString().trim();
-
-          banner.innerHTML = '';
-
-          const titleEl = document.createElement('span');
-          titleEl.className = 'alert-title';
-          titleEl.textContent = 'ALERTA DE CRONOGRAMA';
-          banner.appendChild(titleEl);
-
-          const detailsEl = document.createElement('span');
-          detailsEl.className = 'alert-details';
-          const detailsParts = [];
-          if (timeLabel) detailsParts.push(timeLabel);
-          detailsParts.push(titleLabel);
-          detailsEl.textContent = detailsParts.join(' • ');
-          banner.appendChild(detailsEl);
-
-          const extraParts = [ownerLabel];
-          if (message) {
-            extraParts.push(message);
-          }
-          if (extraParts.length) {
-            const extraEl = document.createElement('span');
-            extraEl.className = 'alert-extra';
-            extraEl.textContent = extraParts.join(' — ');
-            banner.appendChild(extraEl);
-          }
-
-          const additionalAlerts = alerts.length - 1;
-          if (additionalAlerts > 0) {
-            const queueEl = document.createElement('span');
-            queueEl.className = 'alert-extra';
-            queueEl.textContent =
-              additionalAlerts === 1
-                ? 'Mais 1 alerta ativo'
-                : `Mais ${additionalAlerts} alertas ativos`;
-            banner.appendChild(queueEl);
-          }
-
-          lastRenderedAlertSignature = signature;
-        }
-
-        wrapper.classList.remove('hidden');
-        banner.classList.remove('hidden');
-        banner.setAttribute('data-alert-id', signature);
-      }
-
-      function ensureScheduleAlertInterval() {
-        if (scheduleAlertIntervalId !== null) {
-          return;
-        }
-        const { banner } = getScheduleAlertElements();
-        if (!banner) {
-          return;
-        }
-        scheduleAlertIntervalId = window.setInterval(updateScheduleAlertBanner, SCHEDULE_ALERT_INTERVAL_MS);
       }
 
       function parseISODateString(value) {
@@ -2025,7 +1880,7 @@
         const targetDateObj = parseISODateString(targetDate);
         if (!owners.length || !targetDate || !targetDateObj) {
           scheduleFlowContainer.innerHTML = '<div class="empty-state">Cadastre etapas para ver o fluxo diário da equipe.</div>';
-          updateScheduleAlertBanner();
+          refreshNavbarScheduleAlerts();
           return;
         }
 
@@ -2122,7 +1977,7 @@
           .join('');
 
         scheduleFlowContainer.innerHTML = sections || '<div class="empty-state">Nenhum fluxo registrado para esta data.</div>';
-        updateScheduleAlertBanner();
+        refreshNavbarScheduleAlerts();
       }
 
       function buildResponsibleOptions(emptyLabel = 'Selecione um responsável', { multiple = false } = {}) {
@@ -2419,8 +2274,7 @@
               email: user.email || undefined,
               label: 'Minha equipe'
             });
-            updateScheduleAlertBanner();
-            ensureScheduleAlertInterval();
+            refreshNavbarScheduleAlerts();
             applyOwnerSet(new Set([user.uid]));
             refreshSharedMemberships();
           });
@@ -2819,14 +2673,12 @@
       });
 
       document.addEventListener('navbarLoaded', () => {
-        getScheduleAlertElements();
-        updateScheduleAlertBanner();
-        ensureScheduleAlertInterval();
+        refreshNavbarScheduleAlerts();
       });
 
       document.addEventListener('visibilitychange', () => {
         if (!document.hidden) {
-          updateScheduleAlertBanner();
+          refreshNavbarScheduleAlerts();
         }
       });
 
@@ -2834,14 +2686,13 @@
         if (currentUser) {
           refreshSharedMemberships();
         }
-        updateScheduleAlertBanner();
+        refreshNavbarScheduleAlerts();
       });
 
       initializeAuth();
       updateRepeatDaysVisibility();
       updateScheduleAlertVisibility({ reset: true });
-      updateScheduleAlertBanner();
-      ensureScheduleAlertInterval();
+      refreshNavbarScheduleAlerts();
       renderSchedule();
     </script>
   </body>

--- a/schedule-alerts.js
+++ b/schedule-alerts.js
@@ -1,0 +1,583 @@
+const SCHEDULE_ALERT_WINDOW_MINUTES = 10;
+const SCHEDULE_ALERT_INTERVAL_MS = 30000;
+const WEEKDAY_OPTIONS = [
+  { value: 'domingo', label: 'Domingo' },
+  { value: 'segunda', label: 'Segunda-feira' },
+  { value: 'terca', label: 'Terça-feira' },
+  { value: 'quarta', label: 'Quarta-feira' },
+  { value: 'quinta', label: 'Quinta-feira' },
+  { value: 'sexta', label: 'Sexta-feira' },
+  { value: 'sabado', label: 'Sábado' },
+];
+const WEEKDAY_INDEX_TO_VALUE = WEEKDAY_OPTIONS.map((option) => option.value);
+
+function formatDateISO(date) {
+  if (!date) return '';
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function parseISODateString(value) {
+  if (!value) return null;
+  const [year, month, day] = value.split('-').map((part) => parseInt(part, 10));
+  if (!year || !month || !day) return null;
+  const date = new Date(year, month - 1, day);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function formatTime(timeString) {
+  if (!timeString) return '';
+  try {
+    const [hour, minute] = timeString.split(':');
+    return `${hour.padStart(2, '0')}:${minute.padStart(2, '0')}`;
+  } catch (error) {
+    return timeString;
+  }
+}
+
+class ScheduleAlertManager {
+  constructor() {
+    this.appId =
+      typeof window !== 'undefined' && typeof window.__app_id !== 'undefined'
+        ? window.__app_id
+        : 'equipes';
+
+    this.firebaseApp = null;
+    this.db = null;
+    this.auth = null;
+    this.onAuthStateChanged = null;
+
+    this.currentUser = null;
+    this.currentEmail = '';
+
+    this.trackedOwners = new Set();
+    this.schedulesByOwner = new Map();
+    this.scheduleUnsubs = new Map();
+    this.ownerInfo = new Map();
+
+    this.bannerEl = null;
+    this.wrapperEl = null;
+    this.intervalId = null;
+    this.lastRenderedAlertSignature = '';
+
+    this.collection = null;
+    this.collectionGroup = null;
+    this.query = null;
+    this.where = null;
+    this.orderBy = null;
+    this.onSnapshot = null;
+    this.getDocs = null;
+
+    this.authUnsub = null;
+    this.membershipRefreshPromise = null;
+    this.initPromise = null;
+
+    if (typeof document !== 'undefined') {
+      document.addEventListener('navbarLoaded', () => {
+        this.handleNavbarLoaded();
+      });
+    }
+  }
+
+  async initialize() {
+    if (this.initPromise) {
+      return this.initPromise;
+    }
+
+    this.initPromise = this.setup().catch((error) => {
+      console.error('Erro ao iniciar monitor de alertas do cronograma:', error);
+      this.initPromise = null;
+      throw error;
+    });
+
+    return this.initPromise;
+  }
+
+  async setup() {
+    const [appModule, authModule, firestoreModule, configModule] =
+      await Promise.all([
+        import('https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js'),
+        import('https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js'),
+        import(
+          'https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js'
+        ),
+        import('./firebase-config.js'),
+      ]);
+
+    const firebaseConfig =
+      configModule?.firebaseConfig ||
+      (typeof window !== 'undefined' ? window.firebaseConfig : null);
+
+    if (!firebaseConfig || !firebaseConfig.projectId) {
+      throw new Error(
+        'Configuração do Firebase indisponível para alertas do cronograma.',
+      );
+    }
+
+    const { initializeApp, getApps, getApp } = appModule;
+    const { getAuth, onAuthStateChanged } = authModule;
+    const {
+      getFirestore,
+      collection,
+      collectionGroup,
+      query,
+      where,
+      orderBy,
+      onSnapshot,
+      getDocs,
+    } = firestoreModule;
+
+    this.firebaseApp = getApps().length
+      ? getApp()
+      : initializeApp(firebaseConfig);
+    this.db = getFirestore(this.firebaseApp);
+    this.collection = collection;
+    this.collectionGroup = collectionGroup;
+    this.query = query;
+    this.where = where;
+    this.orderBy = orderBy;
+    this.onSnapshot = onSnapshot;
+    this.getDocs = getDocs;
+
+    this.auth = getAuth(this.firebaseApp);
+    this.onAuthStateChanged = onAuthStateChanged;
+
+    if (this.authUnsub) {
+      this.authUnsub();
+      this.authUnsub = null;
+    }
+
+    this.authUnsub = this.onAuthStateChanged(this.auth, (user) => {
+      this.handleAuth(user);
+    });
+
+    if (this.auth.currentUser) {
+      this.handleAuth(this.auth.currentUser);
+    }
+
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', () => {
+        if (!document.hidden) {
+          this.updateBanner();
+        }
+      });
+    }
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('focus', () => {
+        this.refreshMemberships();
+        this.updateBanner();
+      });
+    }
+
+    this.handleNavbarLoaded();
+  }
+
+  handleNavbarLoaded() {
+    this.resolveBannerElements();
+    this.updateBanner();
+    this.ensureInterval();
+  }
+
+  resolveBannerElements() {
+    if (typeof document === 'undefined') return;
+    this.bannerEl = document.getElementById('scheduleAlertBanner');
+    this.wrapperEl = document.getElementById('navbarAlertWrapper');
+  }
+
+  ensureInterval() {
+    if (this.intervalId !== null) return;
+    if (!this.bannerEl) return;
+    this.intervalId = window.setInterval(
+      () => this.updateBanner(),
+      SCHEDULE_ALERT_INTERVAL_MS,
+    );
+  }
+
+  handleAuth(user) {
+    this.currentUser = user || null;
+    this.currentEmail = (user?.email || '').toLowerCase();
+    this.ownerInfo.clear();
+
+    if (!this.currentUser) {
+      this.applyOwnerSet(new Set());
+      this.hideBanner();
+      return;
+    }
+
+    this.ensureOwnerMeta(this.currentUser.uid, {
+      email: this.currentUser.email || undefined,
+      label: 'Minha equipe',
+    });
+
+    const owners = new Set([this.currentUser.uid]);
+    this.applyOwnerSet(owners);
+    this.refreshMemberships();
+    this.updateBanner();
+  }
+
+  async refreshMemberships() {
+    if (
+      !this.db ||
+      !this.collectionGroup ||
+      !this.currentUser ||
+      !this.currentEmail
+    ) {
+      return;
+    }
+
+    if (this.membershipRefreshPromise) {
+      return this.membershipRefreshPromise;
+    }
+
+    this.membershipRefreshPromise = (async () => {
+      try {
+        const membersQuery = this.query(
+          this.collectionGroup(this.db, 'members'),
+          this.where('emailLower', '==', this.currentEmail),
+        );
+        const snapshot = await this.getDocs(membersQuery);
+        const owners = new Set([this.currentUser.uid]);
+
+        snapshot.forEach((docSnap) => {
+          const data = docSnap.data();
+          const ownerUid =
+            data.ownerUid || this.extractOwnerUidFromPath(docSnap.ref.path);
+          if (!ownerUid) return;
+          owners.add(ownerUid);
+          this.ensureOwnerMeta(ownerUid, {
+            email: data.ownerEmail || undefined,
+            label: data.ownerName ? `Equipe de ${data.ownerName}` : undefined,
+          });
+        });
+
+        this.applyOwnerSet(owners);
+      } catch (error) {
+        console.error(
+          'Erro ao buscar equipes compartilhadas para alertas do cronograma:',
+          error,
+        );
+      } finally {
+        this.membershipRefreshPromise = null;
+      }
+    })();
+
+    return this.membershipRefreshPromise;
+  }
+
+  subscribeToOwnerSchedules(ownerUid) {
+    if (!this.db || !this.collection || !this.onSnapshot) return;
+    if (this.scheduleUnsubs.has(ownerUid)) return;
+
+    try {
+      const scheduleRef = this.collection(
+        this.db,
+        'artifacts',
+        this.appId,
+        'users',
+        ownerUid,
+        'dailySchedules',
+      );
+      const scheduleQuery = this.query(
+        scheduleRef,
+        this.orderBy('scheduledDate', 'desc'),
+        this.orderBy('startTime', 'asc'),
+      );
+      const unsubscribe = this.onSnapshot(
+        scheduleQuery,
+        (snapshot) => {
+          const entries = snapshot.docs.map((docSnap) => {
+            const data = docSnap.data();
+            if (data.ownerUid && data.ownerEmail) {
+              this.ensureOwnerMeta(data.ownerUid, { email: data.ownerEmail });
+            }
+            return {
+              id: docSnap.id,
+              title: data.title || '',
+              scheduledDate: data.scheduledDate || '',
+              startTime: data.startTime || '',
+              endTime: data.endTime || '',
+              notes: data.notes || '',
+              responsibleEmail: data.responsibleEmail || '',
+              status: data.status || 'nao_feito',
+              videoUrl: data.videoUrl || '',
+              repeatWeekly: !!data.repeatWeekly,
+              repeatDays: Array.isArray(data.repeatDays)
+                ? data.repeatDays.map((value) => value.toString())
+                : [],
+              alertEnabled: !!data.alertEnabled,
+              alertMessage:
+                typeof data.alertMessage === 'string' ? data.alertMessage : '',
+            };
+          });
+          this.schedulesByOwner.set(ownerUid, entries);
+          this.updateBanner();
+        },
+        (error) => {
+          console.error(
+            'Erro ao acompanhar cronograma diário para alertas do navbar:',
+            error,
+          );
+        },
+      );
+
+      this.scheduleUnsubs.set(ownerUid, unsubscribe);
+    } catch (error) {
+      console.error(
+        'Erro ao iniciar acompanhamento do cronograma para alertas do navbar:',
+        error,
+      );
+    }
+  }
+
+  unsubscribeFromOwner(ownerUid) {
+    const unsubscribe = this.scheduleUnsubs.get(ownerUid);
+    if (typeof unsubscribe === 'function') {
+      unsubscribe();
+    }
+    this.scheduleUnsubs.delete(ownerUid);
+    this.schedulesByOwner.delete(ownerUid);
+  }
+
+  applyOwnerSet(ownerSet) {
+    const desiredOwners =
+      ownerSet instanceof Set ? ownerSet : new Set(ownerSet);
+
+    desiredOwners.forEach((ownerUid) => {
+      if (!this.trackedOwners.has(ownerUid)) {
+        this.subscribeToOwnerSchedules(ownerUid);
+      }
+    });
+
+    this.trackedOwners.forEach((ownerUid) => {
+      if (!desiredOwners.has(ownerUid)) {
+        this.unsubscribeFromOwner(ownerUid);
+      }
+    });
+
+    this.trackedOwners = desiredOwners;
+    this.updateBanner();
+  }
+
+  ensureOwnerMeta(ownerUid, meta = {}) {
+    const currentMeta = this.ownerInfo.get(ownerUid) || {};
+    this.ownerInfo.set(ownerUid, { ...currentMeta, ...meta });
+  }
+
+  extractOwnerUidFromPath(path) {
+    if (!path || typeof path !== 'string') return null;
+    const segments = path.split('/');
+    const index = segments.indexOf('users');
+    if (index >= 0 && segments.length > index + 1) {
+      return segments[index + 1];
+    }
+    return null;
+  }
+
+  isScheduleEntryActiveOnDate(entry, targetDateIso, targetDateObj) {
+    if (!entry || !targetDateIso || !targetDateObj) {
+      return false;
+    }
+
+    if (entry.scheduledDate === targetDateIso) {
+      return true;
+    }
+
+    if (!entry.repeatWeekly || !entry.repeatDays?.length) {
+      return false;
+    }
+
+    const entryDate = parseISODateString(entry.scheduledDate);
+    if (entryDate && entryDate > targetDateObj) {
+      return false;
+    }
+
+    const weekdayKey = WEEKDAY_INDEX_TO_VALUE[targetDateObj.getDay()];
+    if (!weekdayKey) {
+      return false;
+    }
+
+    return entry.repeatDays.includes(weekdayKey);
+  }
+
+  computeAlertTiming(entry, now) {
+    if (!entry.startTime) return null;
+    const [hour, minute] = entry.startTime
+      .split(':')
+      .map((value) => parseInt(value, 10));
+    if (!Number.isFinite(hour) || !Number.isFinite(minute)) {
+      return null;
+    }
+
+    const alertStart = new Date(now);
+    alertStart.setHours(hour, minute, 0, 0);
+    const diffMinutes = (now.getTime() - alertStart.getTime()) / 60000;
+    if (diffMinutes < 0 || diffMinutes > SCHEDULE_ALERT_WINDOW_MINUTES) {
+      return null;
+    }
+
+    return { alertStart, diffMinutes };
+  }
+
+  collectActiveScheduleAlerts(now) {
+    const normalizedEmail = (this.currentEmail || '').toLowerCase();
+    if (!normalizedEmail) return [];
+
+    const currentDateIso = formatDateISO(now);
+    const currentDateObj =
+      parseISODateString(currentDateIso) ||
+      new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const alerts = [];
+
+    this.trackedOwners.forEach((ownerUid) => {
+      const entries = this.schedulesByOwner.get(ownerUid) || [];
+      entries.forEach((entry) => {
+        if (!entry.alertEnabled) return;
+        if ((entry.status || 'nao_feito') === 'feito') return;
+        const responsible = (entry.responsibleEmail || '').toLowerCase();
+        if (!responsible || responsible !== normalizedEmail) return;
+        if (
+          !this.isScheduleEntryActiveOnDate(
+            entry,
+            currentDateIso,
+            currentDateObj,
+          )
+        )
+          return;
+        const timing = this.computeAlertTiming(entry, now);
+        if (!timing) return;
+        alerts.push({ ownerUid, entry, ...timing });
+      });
+    });
+
+    alerts.sort((a, b) => a.alertStart.getTime() - b.alertStart.getTime());
+    return alerts;
+  }
+
+  resolveOwnerLabel(ownerUid) {
+    if (!ownerUid) return 'Equipe compartilhada';
+    if (this.currentUser && ownerUid === this.currentUser.uid) {
+      return 'Minha equipe';
+    }
+    const meta = this.ownerInfo.get(ownerUid) || {};
+    if (meta.label) return meta.label;
+    if (meta.email) return `Equipe de ${meta.email}`;
+    return 'Equipe compartilhada';
+  }
+
+  hideBanner() {
+    if (this.wrapperEl) {
+      this.wrapperEl.classList.add('hidden');
+    }
+    if (this.bannerEl) {
+      this.bannerEl.classList.add('hidden');
+      this.bannerEl.innerHTML = '';
+      this.bannerEl.removeAttribute('data-alert-id');
+    }
+    this.lastRenderedAlertSignature = '';
+  }
+
+  updateBanner() {
+    if (!this.bannerEl || !this.wrapperEl) {
+      this.resolveBannerElements();
+    }
+
+    if (!this.bannerEl || !this.wrapperEl) {
+      return;
+    }
+
+    const now = new Date();
+    const alerts = this.collectActiveScheduleAlerts(now);
+    if (!alerts.length) {
+      this.hideBanner();
+      return;
+    }
+
+    const { ownerUid, entry, alertStart } = alerts[0];
+    const signature = [
+      ownerUid,
+      entry.id,
+      alertStart.getTime(),
+      entry.alertMessage || '',
+      entry.title || '',
+      alerts.length,
+    ].join('||');
+
+    if (signature !== this.lastRenderedAlertSignature) {
+      const timeLabel = formatTime(entry.startTime);
+      const titleLabel = entry.title || 'Etapa do cronograma';
+      const ownerLabel = this.resolveOwnerLabel(ownerUid);
+      const message = (entry.alertMessage || '').toString().trim();
+
+      this.bannerEl.innerHTML = '';
+
+      const titleEl = document.createElement('span');
+      titleEl.className = 'alert-title';
+      titleEl.textContent = 'ALERTA DE CRONOGRAMA';
+      this.bannerEl.appendChild(titleEl);
+
+      const detailsEl = document.createElement('span');
+      detailsEl.className = 'alert-details';
+      const detailsParts = [];
+      if (timeLabel) detailsParts.push(timeLabel);
+      detailsParts.push(titleLabel);
+      detailsEl.textContent = detailsParts.join(' • ');
+      this.bannerEl.appendChild(detailsEl);
+
+      const extraParts = [ownerLabel];
+      if (message) {
+        extraParts.push(message);
+      }
+      if (extraParts.length) {
+        const extraEl = document.createElement('span');
+        extraEl.className = 'alert-extra';
+        extraEl.textContent = extraParts.join(' — ');
+        this.bannerEl.appendChild(extraEl);
+      }
+
+      const additionalAlerts = alerts.length - 1;
+      if (additionalAlerts > 0) {
+        const queueEl = document.createElement('span');
+        queueEl.className = 'alert-extra';
+        queueEl.textContent =
+          additionalAlerts === 1
+            ? 'Mais 1 alerta ativo'
+            : `Mais ${additionalAlerts} alertas ativos`;
+        this.bannerEl.appendChild(queueEl);
+      }
+
+      this.lastRenderedAlertSignature = signature;
+    }
+
+    this.wrapperEl.classList.remove('hidden');
+    this.bannerEl.classList.remove('hidden');
+    this.bannerEl.setAttribute(
+      'data-alert-id',
+      this.lastRenderedAlertSignature,
+    );
+  }
+}
+
+const manager = new ScheduleAlertManager();
+
+export function initializeScheduleAlertService() {
+  return manager.initialize();
+}
+
+export function refreshScheduleAlertBanner() {
+  manager.updateBanner();
+}
+
+export function refreshScheduleAlertMemberships() {
+  return manager.refreshMemberships();
+}
+
+if (typeof window !== 'undefined') {
+  window.scheduleAlertService = {
+    initialize: () => manager.initialize(),
+    refreshScheduleAlertBanner: () => manager.updateBanner(),
+    refreshScheduleAlertMemberships: () => manager.refreshMemberships(),
+  };
+}

--- a/shared.js
+++ b/shared.js
@@ -601,6 +601,31 @@ document.addEventListener('navbarLoaded', () => {
   }
 });
 
+let scheduleAlertsModulePromise = null;
+document.addEventListener('navbarLoaded', () => {
+  if (!scheduleAlertsModulePromise) {
+    scheduleAlertsModulePromise = import('./schedule-alerts.js')
+      .then(async (module) => {
+        if (module?.initializeScheduleAlertService) {
+          await module.initializeScheduleAlertService();
+          module.refreshScheduleAlertBanner?.();
+        }
+        return module;
+      })
+      .catch((error) => {
+        console.error(
+          'Erro ao carregar alertas do cronograma no navbar:',
+          error,
+        );
+        scheduleAlertsModulePromise = null;
+      });
+  } else {
+    scheduleAlertsModulePromise.then((module) => {
+      module?.refreshScheduleAlertBanner?.();
+    });
+  }
+});
+
 // Controle de visibilidade do sidebar baseado no perfil do usuário
 document.addEventListener('sidebarLoaded', async () => {
   const sidebar = document.getElementById('sidebar');


### PR DESCRIPTION
## Summary
- add a shared schedule-alerts module that monitors cronograma entries across every page and updates the navbar banner
- simplify equipes.html to rely on the shared banner refresher instead of duplicating alert logic
- refresh the navbar alert styling to use a red highlight under the text and ensure the module loads via shared.js

## Testing
- n/a

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e1dbe4500832ab51f95bcc3115562)