### PR TITLE
Handle missing DOM elements in pricing page auth UI

### DIFF
--- a/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
+++ b/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
@@ -432,7 +432,10 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
     }
 
     function showUserArea(user) {
-      document.getElementById('currentUser').textContent = user.email;
+      const currentUserEl = document.getElementById('currentUser');
+      if (currentUserEl) {
+        currentUserEl.textContent = user.email;
+      }
       
       // Atualizar avatar com iniciais, se o elemento existir
       const nameParts = user.email.split('@')[0].split('.');
@@ -448,11 +451,20 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
     }
 
     function hideUserArea() {
-      document.getElementById('currentUser').textContent = '';
+      const currentUserEl = document.getElementById('currentUser');
+      if (currentUserEl) {
+        currentUserEl.textContent = '';
+      }
       
       // Remove todas as restrições de permissão
-      document.getElementById('configTab').classList.remove('hidden');
-      document.getElementById('historyTab').classList.remove('hidden');
+      const configTabEl = document.getElementById('configTab');
+      if (configTabEl) {
+        configTabEl.classList.remove('hidden');
+      }
+      const historyTabEl = document.getElementById('historyTab');
+      if (historyTabEl) {
+        historyTabEl.classList.remove('hidden');
+      }
       // Limpa dados carregados
       sistema.produtos = [];
       sistema.historico = [];
@@ -466,7 +478,10 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
       // Verificação simplificada de permissões
       // Implementação real dependeria de dados do Firestore
       if (user.email !== "admin@empresa.com") {
-        document.getElementById('configTab').classList.add('hidden');
+        const configTabEl = document.getElementById('configTab');
+        if (configTabEl) {
+          configTabEl.classList.add('hidden');
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- prevent showUserArea from throwing when the header user node is unavailable
- guard tab permission toggles against missing navbar elements to keep recalculation stable

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ef285acc832a884aeaec3c7c6cd4)