### PR TITLE
Adiciona classificação de faixas de sobra na importação de pedidos

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -6273,11 +6273,17 @@ let consulta;
           produtosSnap.forEach((doc) => {
             const data = doc.data();
             if (data.sku && data.custo !== undefined) {
+              const custoNormalizado = normalizarNumeroMeta(data.custo, 0);
               metas[data.sku] = {
-                valor: parseFloat(data.custo),
+                valor: numeroValido(custoNormalizado) ? custoNormalizado : 0,
+                minimo: null,
+                medio: null,
+                maximo: null,
+                comissaoPercentual: null,
+                comissaoFixa: null,
                 atualizadoEm: new Date()
               };
-          produtos[data.sku] = data.custo;
+              produtos[data.sku] = data.custo;
             }
           });
 
@@ -6289,9 +6295,54 @@ let consulta;
           const metasSnap = await metasSnapQuery.get();
           metasSnap.forEach((doc) => {
             const originalSku = doc.id.replaceAll('__', '/');
+            const metaDoc = doc.data() || {};
+            const metaAtual = metas[originalSku] || {};
+            const valorDoc = normalizarNumeroMeta(metaDoc.valor, metaAtual.valor ?? 0);
+            const minimoDoc = normalizarNumeroMeta(
+              metaDoc.minimo ?? metaDoc.valorMinimo ?? metaDoc.sobraMinimo ?? metaDoc.faixaMinima,
+              metaAtual.minimo ?? null
+            );
+            const medioDoc = normalizarNumeroMeta(
+              metaDoc.medio ?? metaDoc.valorMedio ?? metaDoc.sobraMedio ?? metaDoc.faixaMedia,
+              metaAtual.medio ?? null
+            );
+            const maximoDoc = normalizarNumeroMeta(
+              metaDoc.maximo ?? metaDoc.valorMaximo ?? metaDoc.sobraMaximo ?? metaDoc.faixaMaxima,
+              metaAtual.maximo ?? null
+            );
+            const comissaoPercentualDoc = normalizarNumeroMeta(
+              metaDoc.comissaoPercentual ?? metaDoc.percentualComissao ?? metaDoc.comissao,
+              metaAtual.comissaoPercentual ?? null
+            );
+            const comissaoFixaDoc = normalizarNumeroMeta(
+              metaDoc.comissaoFixa ?? metaDoc.comissaoValor ?? metaDoc.valorComissao ?? metaDoc.comissaoFixaReais,
+              metaAtual.comissaoFixa ?? null
+            );
+
+            let atualizadoEm = new Date();
+            if (metaDoc.atualizadoEm) {
+              if (typeof metaDoc.atualizadoEm.toDate === 'function') {
+                atualizadoEm = metaDoc.atualizadoEm.toDate();
+              } else {
+                const dataConvertida = new Date(metaDoc.atualizadoEm);
+                if (!Number.isNaN(dataConvertida.getTime())) {
+                  atualizadoEm = dataConvertida;
+                }
+              }
+            }
+
             metas[originalSku] = {
-              valor: doc.data().valor,
-              atualizadoEm: doc.data().atualizadoEm?.toDate() || new Date()
+              valor: numeroValido(valorDoc)
+                ? valorDoc
+                : numeroValido(metaAtual.valor)
+                  ? metaAtual.valor
+                  : 0,
+              minimo: numeroValido(minimoDoc) ? minimoDoc : null,
+              medio: numeroValido(medioDoc) ? medioDoc : null,
+              maximo: numeroValido(maximoDoc) ? maximoDoc : null,
+              comissaoPercentual: numeroValido(comissaoPercentualDoc) ? comissaoPercentualDoc : null,
+              comissaoFixa: numeroValido(comissaoFixaDoc) ? comissaoFixaDoc : null,
+              atualizadoEm
             };
           });
           
@@ -6511,8 +6562,24 @@ let consulta;
         toggleLoading(document.getElementById('btnAdicionarMeta'), '<i class="fas fa-plus"></i> Adicionar Meta');
         
         const safeSku = sku.replaceAll('/', '__');
+        const metaAtual = metas[sku] || {};
+        const minimoExistente = numeroValido(metaAtual.minimo) ? metaAtual.minimo : null;
+        const medioExistente = numeroValido(metaAtual.medio) ? metaAtual.medio : null;
+        const maximoExistente = numeroValido(metaAtual.maximo) ? metaAtual.maximo : null;
+        const comissaoPercentualExistente = numeroValido(metaAtual.comissaoPercentual)
+          ? metaAtual.comissaoPercentual
+          : null;
+        const comissaoFixaExistente = numeroValido(metaAtual.comissaoFixa)
+          ? metaAtual.comissaoFixa
+          : null;
+
         const metaData = {
           valor: valor,
+          minimo: minimoExistente,
+          medio: medioExistente,
+          maximo: maximoExistente,
+          comissaoPercentual: comissaoPercentualExistente,
+          comissaoFixa: comissaoFixaExistente,
           atualizadoEm: firebase.firestore.FieldValue.serverTimestamp(),
           uid: usuarioLogado.uid
         };
@@ -6525,6 +6592,11 @@ let consulta;
         // Atualizar localmente
         metas[sku] = {
           valor: valor,
+          minimo: minimoExistente,
+          medio: medioExistente,
+          maximo: maximoExistente,
+          comissaoPercentual: comissaoPercentualExistente,
+          comissaoFixa: comissaoFixaExistente,
           atualizadoEm: new Date()
         };
         
@@ -6578,8 +6650,24 @@ let consulta;
           
           const valorAnterior = metas[sku].valor;
           const safeSku = sku.replaceAll('/', '__');
+          const metaAtual = metas[sku] || {};
+          const minimoExistente = numeroValido(metaAtual.minimo) ? metaAtual.minimo : null;
+          const medioExistente = numeroValido(metaAtual.medio) ? metaAtual.medio : null;
+          const maximoExistente = numeroValido(metaAtual.maximo) ? metaAtual.maximo : null;
+          const comissaoPercentualExistente = numeroValido(metaAtual.comissaoPercentual)
+            ? metaAtual.comissaoPercentual
+            : null;
+          const comissaoFixaExistente = numeroValido(metaAtual.comissaoFixa)
+            ? metaAtual.comissaoFixa
+            : null;
+
           const metaData = {
             valor: novoValor,
+            minimo: minimoExistente,
+            medio: medioExistente,
+            maximo: maximoExistente,
+            comissaoPercentual: comissaoPercentualExistente,
+            comissaoFixa: comissaoFixaExistente,
             atualizadoEm: firebase.firestore.FieldValue.serverTimestamp(),
             uid: usuarioLogado.uid
           };
@@ -6592,6 +6680,11 @@ let consulta;
           // Atualizar localmente
           metas[sku] = {
             valor: novoValor,
+            minimo: minimoExistente,
+            medio: medioExistente,
+            maximo: maximoExistente,
+            comissaoPercentual: comissaoPercentualExistente,
+            comissaoFixa: comissaoFixaExistente,
             atualizadoEm: new Date()
           };
           
@@ -6658,6 +6751,134 @@ let consulta;
     // FUNÇÕES DE PROCESSAMENTO DE PEDIDOS
     // =============================================
     
+    function normalizarNumeroMeta(valor, fallback = null) {
+      if (valor === undefined || valor === null) return fallback;
+      if (typeof valor === 'number') {
+        return Number.isFinite(valor) ? valor : fallback;
+      }
+      const textoBruto = valor.toString().trim();
+      if (!textoBruto) return fallback;
+      let texto = textoBruto.replace(/\s+/g, '');
+      const temVirgula = texto.includes(',');
+      const temPonto = texto.includes('.');
+      if (temVirgula && temPonto) {
+        texto = texto.replace(/\./g, '').replace(/,/g, '.');
+      } else if (temVirgula) {
+        texto = texto.replace(/,/g, '.');
+      }
+      const numero = Number.parseFloat(texto);
+      return Number.isFinite(numero) ? numero : fallback;
+    }
+
+    function numeroValido(valor) {
+      return typeof valor === 'number' && Number.isFinite(valor);
+    }
+
+    function formatarMoedaBR(valor) {
+      const numero = Number(valor);
+      if (!Number.isFinite(numero)) return 'R$ 0,00';
+      return `R$ ${numero.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}`;
+    }
+
+    function classificarSobraPorFaixa(metaInfo, sobra) {
+      if (!metaInfo) {
+        return {
+          label: 'Sem meta',
+          detalhe: 'Cadastre uma meta para este SKU',
+          situacao: 'sem-meta',
+          diferenca: 0,
+          comissao: null
+        };
+      }
+
+      const minimo = numeroValido(metaInfo.minimo) ? metaInfo.minimo : null;
+      const maximo = numeroValido(metaInfo.maximo) ? metaInfo.maximo : null;
+      let medio = numeroValido(metaInfo.medio) ? metaInfo.medio : null;
+
+      if (medio === null && numeroValido(minimo) && numeroValido(maximo)) {
+        medio = (minimo + maximo) / 2;
+      }
+
+      const comissaoPercentual = numeroValido(metaInfo.comissaoPercentual)
+        ? metaInfo.comissaoPercentual
+        : null;
+      const comissaoFixa = numeroValido(metaInfo.comissaoFixa)
+        ? metaInfo.comissaoFixa
+        : null;
+
+      const faixaConfigurada =
+        numeroValido(minimo) || numeroValido(medio) || numeroValido(maximo);
+
+      if (!faixaConfigurada) {
+        return {
+          label: 'Sem faixa configurada',
+          detalhe: 'Configure mínimo, médio ou máximo para este SKU',
+          situacao: 'sem-faixa',
+          diferenca: 0,
+          comissao: null
+        };
+      }
+
+      if (minimo !== null && sobra < minimo) {
+        const diferenca = minimo - sobra;
+        return {
+          label: 'Abaixo do Mínimo',
+          detalhe: `Falta ${formatarMoedaBR(diferenca)}`,
+          situacao: 'abaixo',
+          diferenca,
+          comissao: null
+        };
+      }
+
+      if (maximo !== null && sobra > maximo) {
+        const diferenca = sobra - maximo;
+        return {
+          label: 'Acima do Máximo',
+          detalhe: `Excedente de ${formatarMoedaBR(diferenca)}`,
+          situacao: 'acima',
+          diferenca,
+          comissao: null
+        };
+      }
+
+      let faixa = 'Dentro da Faixa';
+      if (medio !== null) {
+        if (maximo !== null && sobra >= maximo) {
+          faixa = 'Máximo';
+        } else if (sobra >= medio) {
+          faixa = 'Médio';
+        } else {
+          faixa = 'Mínimo';
+        }
+      } else if (maximo !== null) {
+        faixa = 'Máximo';
+      } else if (minimo !== null) {
+        faixa = 'Mínimo';
+      }
+
+      let comissaoCalculada = null;
+      if (comissaoFixa !== null) {
+        comissaoCalculada = comissaoFixa;
+      } else if (comissaoPercentual !== null) {
+        const percentual = comissaoPercentual > 1
+          ? comissaoPercentual / 100
+          : comissaoPercentual;
+        comissaoCalculada = sobra * percentual;
+      }
+
+      const detalhe = comissaoCalculada !== null
+        ? `Comissão estimada: ${formatarMoedaBR(comissaoCalculada)}`
+        : 'Dentro da faixa configurada';
+
+      return {
+        label: faixa,
+        detalhe,
+        situacao: 'dentro',
+        diferenca: 0,
+        comissao: comissaoCalculada
+      };
+    }
+
     function processarPlanilha() {
       const fileInput = document.getElementById('inputExcel');
       const file = fileInput.files[0];
@@ -6730,14 +6951,32 @@ let consulta;
         const comissao = parseFloat(p['Taxa de comissão']) || 0;
         const servico = parseFloat(p['Taxa de serviço']) || 0;
         const sobra = subtotal + reembolso - cupom - comissao - servico;
-        const meta = metas[sku]?.valor || 0;
+        const metaInfo = metas[sku];
+        const meta = numeroValido(metaInfo?.valor) ? metaInfo.valor : 0;
         const percentual = meta ? ((sobra - meta) / meta) * 100 : 0;
-       const prazo = p['Prazo de coleta'] || p['Prazo de Coleta'] || '';
+        const prazo = p['Prazo de coleta'] || p['Prazo de Coleta'] || '';
+        const faixaInfo = classificarSobraPorFaixa(metaInfo, sobra);
 
         const pedidoData = {
-          id, sku, subtotal, reembolso, cupom, comissao, servico, sobra, meta, percentual, status, prazo
+          id,
+          sku,
+          subtotal,
+          reembolso,
+          cupom,
+          comissao,
+          servico,
+          sobra,
+          meta,
+          percentual,
+          status,
+          prazo,
+          faixa: faixaInfo.label,
+          detalheFaixa: faixaInfo.detalhe,
+          situacaoFaixa: faixaInfo.situacao,
+          diferencaFaixa: faixaInfo.diferenca,
+          comissaoFaixa: faixaInfo.comissao
         };
-        
+
         pedidosProcessados.push(pedidoData);
 
         const tr = document.createElement('tr');
@@ -6778,6 +7017,10 @@ let consulta;
           <td>R$ ${comissao.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</td>
           <td>R$ ${servico.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</td>
           <td><strong>R$ ${sobra.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</strong><br><small>Meta: R$ ${meta.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</small></td>
+          <td>
+            <strong>${faixaInfo.label}</strong>
+            ${faixaInfo.detalhe ? `<br><small>${faixaInfo.detalhe}</small>` : ''}
+          </td>
           <td>${percentual.toFixed(2)}%</td>
           <td class="status-only" data-status="${statusText}">${statusIcon} ${statusText}</td>
         `;
@@ -6863,12 +7106,19 @@ let consulta;
     vendido: p.subtotal,
     sobra: p.sobra,
     meta: p.meta,
+    faixa: p.faixa,
+    detalheFaixa: p.detalheFaixa,
+    comissaoFaixa: p.comissaoFaixa,
     data: new Date().toLocaleDateString()
   };
 });
 
 document.getElementById("dadosSobrasIA").value = sobras.map(s => {
-  return `SKU: ${s.sku}, Vendido: R$ ${s.vendido.toFixed(2)}, Sobra: R$ ${s.sobra.toFixed(2)}, Meta: R$ ${s.meta?.toFixed(2) || 0}, Data: ${s.data}`;
+  const comissaoTexto = typeof s.comissaoFaixa === 'number'
+    ? `, Comissão: R$ ${s.comissaoFaixa.toFixed(2)}`
+    : '';
+  const detalheFaixa = s.detalheFaixa ? `, Detalhe: ${s.detalheFaixa}` : '';
+  return `SKU: ${s.sku}, Vendido: R$ ${s.vendido.toFixed(2)}, Sobra: R$ ${s.sobra.toFixed(2)}, Meta: R$ ${s.meta?.toFixed(2) || 0}, Faixa: ${s.faixa || 'Não definida'}${detalheFaixa}${comissaoTexto}, Data: ${s.data}`;
 }).join("\n");
         renderizarTabelaLogistica();
 }
@@ -8713,16 +8963,21 @@ await db
       
       try {
         // Cabeçalhos
-        let csv = 'ID do Pedido;SKU;Subtotal;Reembolso;Cupom;Comissão;Serviço;Sobra;Meta;% vs Meta;Status\n';
-        
+        let csv = 'ID do Pedido;SKU;Subtotal;Reembolso;Cupom;Comissão;Serviço;Sobra;Meta;Faixa de Sobra;Detalhe da Faixa;Comissão Estimada;% vs Meta;Status\n';
+
         // Dados
         pedidosProcessados.forEach(pedido => {
-          const status = pedido.meta ? 
-            (pedido.percentual <= -10 ? 'Crítico' : 
-             pedido.percentual <= -5 ? 'Atenção' : 
+          const status = pedido.meta ?
+            (pedido.percentual <= -10 ? 'Crítico' :
+             pedido.percentual <= -5 ? 'Atenção' :
              pedido.percentual >= 5 ? 'Bom' : 'Normal') : 'Sem meta';
-          
-          csv += `"${pedido.id}";"${pedido.sku}";"${pedido.subtotal.toFixed(2)}";"${pedido.reembolso.toFixed(2)}";"${pedido.cupom.toFixed(2)}";"${pedido.comissao.toFixed(2)}";"${pedido.servico.toFixed(2)}";"${pedido.sobra.toFixed(2)}";"${pedido.meta.toFixed(2)}";"${pedido.percentual.toFixed(2)}";"${status}"\n`;
+
+          const detalheFaixa = (pedido.detalheFaixa || '').replace(/"/g, '""');
+          const comissaoFaixa = pedido.comissaoFaixa !== null && pedido.comissaoFaixa !== undefined
+            ? pedido.comissaoFaixa.toFixed(2)
+            : '';
+
+          csv += `"${pedido.id}";"${pedido.sku}";"${pedido.subtotal.toFixed(2)}";"${pedido.reembolso.toFixed(2)}";"${pedido.cupom.toFixed(2)}";"${pedido.comissao.toFixed(2)}";"${pedido.servico.toFixed(2)}";"${pedido.sobra.toFixed(2)}";"${pedido.meta.toFixed(2)}";"${pedido.faixa || ''}";"${detalheFaixa}";"${comissaoFaixa}";"${pedido.percentual.toFixed(2)}";"${status}"\n`;
         });
         
         const blob = new Blob(["\uFEFF" + csv], { type: 'text/csv;charset=utf-8;' });

--- a/sobras-tabs/importar.html
+++ b/sobras-tabs/importar.html
@@ -60,6 +60,7 @@
           <th>Comissão</th>
           <th>Serviço</th>
           <th>Sobra</th>
+          <th>Faixa de Sobra</th>
           <th>% vs Meta</th>
           <th>Status</th>
         </tr>


### PR DESCRIPTION
## Summary
- carrega metas com limites mínimo, médio e máximo opcionais para cada SKU
- classifica pedidos importados por faixa de sobra, exibindo diferenças e estimativa de comissão
- inclui as novas colunas nas exportações e no resumo analisado pela IA

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911f48d3378832a8e90ede7d48c7f4c)