### PR TITLE
Fix import tab overflow and add Excel export

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -8960,7 +8960,7 @@ await db
         mostrarErro('Nenhum dado disponível para exportar. Processe um arquivo primeiro.');
         return;
       }
-      
+
       try {
         // Cabeçalhos
         let csv = 'ID do Pedido;SKU;Subtotal;Reembolso;Cupom;Comissão;Serviço;Sobra;Meta;Faixa de Sobra;Detalhe da Faixa;Comissão Estimada;% vs Meta;Status\n';
@@ -8979,14 +8979,60 @@ await db
 
           csv += `"${pedido.id}";"${pedido.sku}";"${pedido.subtotal.toFixed(2)}";"${pedido.reembolso.toFixed(2)}";"${pedido.cupom.toFixed(2)}";"${pedido.comissao.toFixed(2)}";"${pedido.servico.toFixed(2)}";"${pedido.sobra.toFixed(2)}";"${pedido.meta.toFixed(2)}";"${pedido.faixa || ''}";"${detalheFaixa}";"${comissaoFaixa}";"${pedido.percentual.toFixed(2)}";"${status}"\n`;
         });
-        
+
         const blob = new Blob(["\uFEFF" + csv], { type: 'text/csv;charset=utf-8;' });
         saveAs(blob, `relatorio_sobras_${new Date().toISOString().slice(0,10)}.csv`);
-        
+
         mostrarSucesso('Arquivo CSV exportado com sucesso!');
       } catch (error) {
         mostrarErro(`Erro ao exportar CSV: ${error.message}`);
         console.error("Erro ao exportar CSV:", error);
+      }
+    }
+
+    function exportarExcel() {
+      if (pedidosProcessados.length === 0) {
+        mostrarErro('Nenhum dado disponível para exportar. Processe um arquivo primeiro.');
+        return;
+      }
+
+      try {
+        const linhas = pedidosProcessados.map(pedido => {
+          const status = pedido.meta ?
+            (pedido.percentual <= -10 ? 'Crítico' :
+              pedido.percentual <= -5 ? 'Atenção' :
+              pedido.percentual >= 5 ? 'Bom' : 'Normal') : 'Sem meta';
+
+          return {
+            'ID do Pedido': pedido.id,
+            'SKU': pedido.sku,
+            'Subtotal (R$)': Number(pedido.subtotal.toFixed(2)),
+            'Reembolso (R$)': Number(pedido.reembolso.toFixed(2)),
+            'Cupom (R$)': Number(pedido.cupom.toFixed(2)),
+            'Comissão (R$)': Number(pedido.comissao.toFixed(2)),
+            'Serviço (R$)': Number(pedido.servico.toFixed(2)),
+            'Sobra (R$)': Number(pedido.sobra.toFixed(2)),
+            'Meta (R$)': Number(pedido.meta.toFixed(2)),
+            'Faixa de Sobra': pedido.faixa || '',
+            'Detalhe da Faixa': pedido.detalheFaixa || '',
+            'Comissão Estimada (R$)': pedido.comissaoFaixa !== null && pedido.comissaoFaixa !== undefined
+              ? Number(pedido.comissaoFaixa.toFixed(2))
+              : '',
+            '% vs Meta': Number(pedido.percentual.toFixed(2)),
+            'Status': status
+          };
+        });
+
+        const worksheet = XLSX.utils.json_to_sheet(linhas);
+        const workbook = XLSX.utils.book_new();
+        XLSX.utils.book_append_sheet(workbook, worksheet, 'Sobras');
+
+        const nomeArquivo = `relatorio_sobras_${new Date().toISOString().slice(0,10)}.xlsx`;
+        XLSX.writeFile(workbook, nomeArquivo);
+        mostrarSucesso('Arquivo Excel exportado com sucesso!');
+      } catch (error) {
+        mostrarErro(`Erro ao exportar Excel: ${error.message}`);
+        console.error('Erro ao exportar Excel:', error);
       }
     }
     const registrosFaturamentoSelecionados = new Set();
@@ -16216,6 +16262,7 @@ window.excluirFaturamentosSelecionados = excluirFaturamentosSelecionados;
 window.excluirFaturamento = excluirFaturamento;
 window.analisarSobrasIA = analisarSobrasIA;
 window.exportarCSV = exportarCSV;
+window.exportarExcel = exportarExcel;
 window.exportarJSON = exportarJSON;
 window.verificarConexao = verificarConexao;
 window.editarMeta = editarMeta;

--- a/css/styles.css
+++ b/css/styles.css
@@ -1285,15 +1285,24 @@ select:focus {
 }
 .table-container {
   border-radius: 0.5rem;
-  overflow: hidden;
   border: 1px solid var(--border);
   background: var(--background);
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
 }
 .table {
   width: 100%;
   border-collapse: collapse;
 }
-.table th {
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 960px;
+}
+.table th,
+.data-table th {
   background: var(--background);
   text-align: left;
   padding: 12px 15px;
@@ -1304,18 +1313,23 @@ select:focus {
   position: sticky;
   top: 0;
 }
-.table td {
+.table td,
+.data-table td {
   padding: 12px 15px;
   border-bottom: 1px solid var(--border);
   font-size: 14px;
+  vertical-align: top;
 }
-.table tr:last-child td {
+.table tr:last-child td,
+.data-table tr:last-child td {
   border-bottom: none;
 }
-.table tr:nth-child(2n) {
+.table tr:nth-child(2n),
+.data-table tr:nth-child(2n) {
   background: rgba(0, 0, 0, 0.02);
 }
-body.dark-mode .table tr:nth-child(2n) {
+body.dark-mode .table tr:nth-child(2n),
+body.dark-mode .data-table tr:nth-child(2n) {
   background: rgba(255, 255, 255, 0.03);
 }
 .platform-tag {

--- a/sobras-tabs/importar.html
+++ b/sobras-tabs/importar.html
@@ -83,6 +83,7 @@
       </button>
       <div class="dropdown-menu" id="exportMenu">
         <a class="dropdown-item" onclick="exportarCSV()">CSV</a>
+        <a class="dropdown-item" onclick="exportarExcel()">Excel (.xlsx)</a>
         <a class="dropdown-item" onclick="exportarJSON()">JSON</a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- ensure the imported sobras table keeps its layout visible by updating the container and table styles
- add an Excel (.xlsx) export option alongside existing CSV/JSON exports for the processed sobras

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691210414c5c832ab0639a1598314c6f)