### PR TITLE
Ajusta cálculo dos preços importados na aba de precificação

### DIFF
--- a/import-card.js
+++ b/import-card.js
@@ -197,8 +197,17 @@
       return null;
     }
 
-    const base = calculos[referencia];
     const custosInformados = cloneCosts(custosNormalizados);
+
+    const precoMinimoBase = calculos.minimo?.precoPromo;
+    const precoMedioBase = calculos.medio?.precoPromo;
+    const precoIdealBase = calculos.maximo?.precoPromo;
+
+    const precoMinimo =
+      precoMinimoBase ?? precoMedioBase ?? precoIdealBase ?? 0;
+    const precoMedio = precoMedioBase ?? precoIdealBase ?? precoMinimo;
+    const precoIdeal = precoIdealBase ?? precoMedioBase ?? precoMedio;
+    const precoPromo = precoMinimo;
 
     return {
       taxaPercentual: formatTwoDecimals(taxaPercentual),
@@ -206,10 +215,10 @@
       custosCalculados: calculos,
       referencia,
       custoBase: custosInformados[referencia]?.valor || 0,
-      precoMinimo: base.precoMinimo,
-      precoIdeal: base.precoIdeal,
-      precoMedio: base.precoMedio,
-      precoPromo: base.precoPromo,
+      precoMinimo: formatTwoDecimals(precoMinimo),
+      precoIdeal: formatTwoDecimals(precoIdeal),
+      precoMedio: formatTwoDecimals(precoMedio),
+      precoPromo: formatTwoDecimals(precoPromo),
       taxas: formatTaxas(taxasDetalhadas),
     };
   }


### PR DESCRIPTION
## Summary
- ajusta o pós-processamento da importação de planilhas para que os preços mínimo, médio e ideal usem os custos mínimo, médio e máximo somados às taxas da plataforma

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691286a1180c832a8343dd73683001c9)