### PR TITLE
Add piece tracking to reembolso flows and enhance reports

### DIFF
--- a/acompanhamento-problemas.html
+++ b/acompanhamento-problemas.html
@@ -194,7 +194,9 @@
               class="card-header flex flex-wrap items-center justify-between gap-3 border-b border-gray-100 px-6 py-4"
             >
               <div class="flex flex-col gap-1">
-                <h2 class="text-lg font-semibold">Peças faltantes registradas</h2>
+                <h2 class="text-lg font-semibold">
+                  Peças faltantes registradas
+                </h2>
                 <span
                   id="pecasSelecaoResumo"
                   class="text-xs text-gray-500 hidden"
@@ -211,10 +213,17 @@
                     <i class="fa-solid fa-download"></i>
                     Modelo Excel
                   </button>
-                  <label class="inline-flex items-center gap-2 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50 cursor-pointer">
+                  <label
+                    class="inline-flex items-center gap-2 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50 cursor-pointer"
+                  >
                     <i class="fa-solid fa-file-import"></i>
                     Importar planilha
-                    <input id="pecasImportarXlsx" type="file" accept=".xlsx,.xls" class="hidden" />
+                    <input
+                      id="pecasImportarXlsx"
+                      type="file"
+                      accept=".xlsx,.xls"
+                      class="hidden"
+                    />
                   </label>
                   <button
                     id="pecasExportExcel"
@@ -361,7 +370,7 @@
                   type="text"
                   id="reembolsosBusca"
                   class="form-control"
-                  placeholder="Número do pedido, loja, NF ou apelido"
+                  placeholder="Número do pedido, loja, NF, peça ou apelido"
                 />
               </div>
             </div>
@@ -392,10 +401,17 @@
                     <i class="fa-solid fa-download"></i>
                     Modelo Excel
                   </button>
-                  <label class="inline-flex items-center gap-2 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50 cursor-pointer">
+                  <label
+                    class="inline-flex items-center gap-2 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50 cursor-pointer"
+                  >
                     <i class="fa-solid fa-file-import"></i>
                     Importar planilha
-                    <input id="reembolsosImportarXlsx" type="file" accept=".xlsx,.xls" class="hidden" />
+                    <input
+                      id="reembolsosImportarXlsx"
+                      type="file"
+                      accept=".xlsx,.xls"
+                      class="hidden"
+                    />
                   </label>
                   <button
                     id="reembolsosExportExcel"
@@ -436,6 +452,7 @@
                       <th class="px-4 py-3">Apelido</th>
                       <th class="px-4 py-3">NF</th>
                       <th class="px-4 py-3">Loja</th>
+                      <th class="px-4 py-3">Peça</th>
                       <th class="px-4 py-3">Problema</th>
                       <th class="px-4 py-3 text-right">Valor</th>
                       <th class="px-4 py-3">PIX</th>

--- a/problemas.html
+++ b/problemas.html
@@ -156,6 +156,19 @@
                       class="mt-1 w-full rounded-xl border-slate-300 focus:border-violet-500 focus:ring-violet-500"
                     />
                   </div>
+                  <div class="flex flex-col">
+                    <label
+                      for="pecaR"
+                      class="block text-sm font-medium text-slate-600"
+                      >Peça</label
+                    >
+                    <input
+                      type="text"
+                      id="pecaR"
+                      name="peca"
+                      class="mt-1 w-full rounded-xl border-slate-300 focus:border-violet-500 focus:ring-violet-500"
+                    />
+                  </div>
                   <div class="flex flex-col md:col-span-3">
                     <label
                       for="problemaR"
@@ -298,6 +311,7 @@
                         <th class="p-2">Data</th>
                         <th class="p-2">Número do Pedido</th>
                         <th class="p-2">Loja</th>
+                        <th class="p-2">Peça</th>
                         <th class="p-2">Apelido</th>
                         <th class="p-2">Problema</th>
                         <th class="p-2">NF</th>

--- a/problemas.js
+++ b/problemas.js
@@ -631,6 +631,7 @@ async function salvarReembolso(ev) {
     data: form.data.value,
     numero: form.numero.value.trim(),
     loja: form.loja.value.trim(),
+    peca: form.peca?.value.trim() || '',
     apelido: form.apelido.value.trim(),
     nf: form.nf.value.trim(),
     valor: parseFloat(form.valor.value) || 0,
@@ -673,6 +674,7 @@ async function carregarReembolsos() {
           ? Number(dados.valor)
           : Number.parseFloat(dados.valor) || 0,
         pix: dados.pix || '',
+        peca: dados.peca || '',
         problema: dados.problema || '',
         status: statusValido,
       };
@@ -737,6 +739,15 @@ function renderReembolsos() {
         tipo: 'text',
         valor: d.loja || '',
         onChange: (valor) => atualizarReembolso(d, { loja: valor.trim() }),
+        classe: baseInputClass,
+      }),
+    );
+
+    tr.appendChild(
+      criarCelulaInput({
+        tipo: 'text',
+        valor: d.peca || '',
+        onChange: (valor) => atualizarReembolso(d, { peca: valor.trim() }),
         classe: baseInputClass,
       }),
     );


### PR DESCRIPTION
## Summary
- add capture and inline editing of the nova coluna de peça in the Problemas reembolsos form and list
- include the peça field throughout the acompanhamento de problemas tables, filtros e exportações de reembolso
- reestruturar o relatório completo para separar reembolsos e peças faltantes com listas detalhadas e indicadores dedicados

## Testing
- n/a

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913c8e89410832a8586e9f72e857c98)