### PR TITLE
Update precificação pricing logic to use cost-based variations

### DIFF
--- a/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
+++ b/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
@@ -948,19 +948,39 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
       return `R$ ${Number(valor || 0).toFixed(2)}`;
     }
 
+    function primeiroNumeroValido(...valores) {
+      for (const valor of valores) {
+        if (typeof valor === 'number' && Number.isFinite(valor)) {
+          return valor;
+        }
+      }
+      return null;
+    }
+
     function atualizarCenariosUI(plataforma, calculos) {
-      const camposPorCenario = {
-        promo: 'precoPromo',
-        medio: 'precoMedio',
-        ideal: 'precoIdeal',
+      const valores = {
+        minimo: primeiroNumeroValido(
+          calculos?.minimo?.preco,
+          calculos?.medio?.preco,
+          calculos?.maximo?.preco,
+        ),
+        medio: primeiroNumeroValido(
+          calculos?.medio?.preco,
+          calculos?.maximo?.preco,
+          calculos?.minimo?.preco,
+        ),
+        ideal: primeiroNumeroValido(
+          calculos?.maximo?.preco,
+          calculos?.medio?.preco,
+          calculos?.minimo?.preco,
+        ),
       };
-      Object.entries(camposPorCenario).forEach(([cenario, campo]) => {
-        NIVEIS_CUSTO.forEach((nivel) => {
-          const span = document.getElementById(`preco_${plataforma}_${cenario}_${nivel}`);
-          if (!span) return;
-          const dados = calculos?.[nivel];
-          span.textContent = dados ? formatarMoeda(dados[campo]) : '—';
-        });
+
+      Object.entries(valores).forEach(([tipo, valor]) => {
+        const span = document.getElementById(`preco_${plataforma}_${tipo}`);
+        if (!span) return;
+        span.textContent =
+          valor !== null ? formatarMoeda(valor) : '—';
       });
     }
 
@@ -980,21 +1000,17 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
       let referencia = null;
 
       NIVEIS_CUSTO.forEach((nivel) => {
-        const { valor, comissao } = custos[nivel] || {};
+        const info = custos[nivel] || {};
+        const valor = Number.parseFloat(info.valor) || 0;
+        const comissao = Number.parseFloat(info.comissao) || 0;
         if (!(valor > 0)) return;
         const percentualTotal = totalPercentual + comissao;
-        const precoBase =
+        const precoCalculado =
           valor + totalFixo + (valor * percentualTotal) / 100;
-        const precoPromo = precoBase;
-        const precoMedio = precoBase * 1.05;
-        const precoIdeal = precoBase * 1.1;
         calculos[nivel] = {
-          custo: valor,
+          custo: Number(valor.toFixed(2)),
           comissao,
-          precoMinimo: parseFloat(precoBase.toFixed(2)),
-          precoPromo: parseFloat(precoPromo.toFixed(2)),
-          precoMedio: parseFloat(precoMedio.toFixed(2)),
-          precoIdeal: parseFloat(precoIdeal.toFixed(2)),
+          preco: Number(precoCalculado.toFixed(2)),
         };
         if (!referencia || (referencia !== 'medio' && nivel === 'medio')) {
           referencia = nivel;
@@ -1005,7 +1021,13 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
         referencia = NIVEIS_CUSTO.find((nivel) => calculos[nivel]);
       }
 
-      return { calculos, referencia };
+      const resumo = {
+        precoMinimo: calculos.minimo?.preco ?? null,
+        precoMedio: calculos.medio?.preco ?? null,
+        precoIdeal: calculos.maximo?.preco ?? null,
+      };
+
+      return { calculos, referencia, resumo };
     }
 
     function calcular(plataforma) {
@@ -1118,7 +1140,7 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
         return;
       }
 
-      const { calculos, referencia } = calcularPrecosPorCusto(
+      const { calculos, referencia, resumo } = calcularPrecosPorCusto(
         custosNormalizados,
         totalPercentual,
         totalFixo,
@@ -1132,17 +1154,34 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
         return;
       }
 
-      const base = calculos[referencia];
+      const precoMinimo =
+        primeiroNumeroValido(
+          resumo.precoMinimo,
+          resumo.precoMedio,
+          resumo.precoIdeal,
+        ) ?? 0;
+      const precoMedio =
+        primeiroNumeroValido(
+          resumo.precoMedio,
+          resumo.precoIdeal,
+          resumo.precoMinimo,
+        ) ?? 0;
+      const precoIdeal =
+        primeiroNumeroValido(
+          resumo.precoIdeal,
+          resumo.precoMedio,
+          resumo.precoMinimo,
+        ) ?? 0;
       const resultado = {
         taxaPercentual: taxa,
         custosInformados: custosNormalizados,
         custosCalculados: calculos,
         referencia,
         custoBase: custosNormalizados[referencia]?.valor || 0,
-        precoMinimo: base.precoMinimo,
-        precoIdeal: base.precoIdeal,
-        precoMedio: base.precoMedio,
-        precoPromo: base.precoPromo,
+        precoMinimo,
+        precoIdeal,
+        precoMedio,
+        precoPromo: precoMinimo,
         taxas: taxasDetalhadas,
       };
 
@@ -1222,7 +1261,7 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
         precoMinimo: baseResultado.precoMinimo,
         precoIdeal: baseResultado.precoIdeal,
         precoMedio: baseResultado.precoMedio,
-        precoPromo: baseResultado.precoPromo,
+        precoPromo: baseResultado.precoMinimo,
         taxas: baseResultado.taxas,
         calculosTaxas,
       };
@@ -1245,7 +1284,7 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
             precoMinimo: r.precoMinimo,
             precoIdeal: r.precoIdeal,
             precoMedio: r.precoMedio,
-            precoPromo: r.precoPromo,
+            precoPromo: r.precoMinimo,
             taxas: r.taxas,
           };
         });

--- a/import-card.js
+++ b/import-card.js
@@ -139,19 +139,13 @@
       }
 
       const percentualTotal = totalPercentual + (info.comissao || 0);
-      const precoBase =
+      const precoCalculado =
         info.valor + totalFixo + (info.valor * percentualTotal) / 100;
-      const precoPromo = precoBase;
-      const precoMedio = precoBase * 1.05;
-      const precoIdeal = precoBase * 1.1;
 
       calculos[key] = {
         custo: formatTwoDecimals(info.valor),
         comissao: formatTwoDecimals(info.comissao),
-        precoMinimo: formatTwoDecimals(precoBase),
-        precoPromo: formatTwoDecimals(precoPromo),
-        precoMedio: formatTwoDecimals(precoMedio),
-        precoIdeal: formatTwoDecimals(precoIdeal),
+        preco: formatTwoDecimals(precoCalculado),
       };
 
       if (!referencia || (referencia !== 'medio' && key === 'medio')) {
@@ -166,6 +160,14 @@
     }
 
     return { calculos, referencia };
+  }
+
+  function firstAvailable(...values) {
+    return (
+      values.find(
+        (value) => typeof value === 'number' && Number.isFinite(value),
+      ) ?? 0
+    );
   }
 
   function formatTaxas(taxas = {}) {
@@ -193,8 +195,19 @@
       return null;
     }
 
-    const base = calculos[referencia];
     const custosInformados = cloneCosts(custosNormalizados);
+    const precoMinimo = calculos.minimo?.preco;
+    const precoMedio = calculos.medio?.preco;
+    const precoIdeal = calculos.maximo?.preco;
+    const precoMinimoFinal = formatTwoDecimals(
+      firstAvailable(precoMinimo, precoMedio, precoIdeal),
+    );
+    const precoMedioFinal = formatTwoDecimals(
+      firstAvailable(precoMedio, precoIdeal, precoMinimo),
+    );
+    const precoIdealFinal = formatTwoDecimals(
+      firstAvailable(precoIdeal, precoMedio, precoMinimo),
+    );
 
     return {
       taxaPercentual: formatTwoDecimals(taxaPercentual),
@@ -202,10 +215,10 @@
       custosCalculados: calculos,
       referencia,
       custoBase: custosInformados[referencia]?.valor || 0,
-      precoMinimo: base.precoMinimo,
-      precoIdeal: base.precoIdeal,
-      precoMedio: base.precoMedio,
-      precoPromo: base.precoPromo,
+      precoMinimo: precoMinimoFinal,
+      precoMedio: precoMedioFinal,
+      precoIdeal: precoIdealFinal,
+      precoPromo: precoMinimoFinal,
       taxas: formatTaxas(taxasDetalhadas),
     };
   }

--- a/precificacao-tabs/precificacao.html
+++ b/precificacao-tabs/precificacao.html
@@ -112,33 +112,21 @@
               <input id="preco_ml" disabled class="p-3 bg-gray-100 font-bold text-lg">
             </div>
 
-            <div class="scenario-card scenario-promo">
-              <span class="scenario-dot"></span>
-              <span class="scenario-title">Sem Lucro</span>
-              <div class="scenario-values">
-                <div><span class="scenario-label">Mín.</span> <span class="scenario-value" id="preco_ml_promo_minimo">R$ 0,00</span></div>
-                <div><span class="scenario-label">Méd.</span> <span class="scenario-value" id="preco_ml_promo_medio">R$ 0,00</span></div>
-                <div><span class="scenario-label">Máx.</span> <span class="scenario-value" id="preco_ml_promo_maximo">R$ 0,00</span></div>
+            <div class="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
+                <div class="text-xs uppercase text-gray-500">Preço mínimo</div>
+                <div class="text-lg font-semibold text-green-600" id="preco_ml_minimo">R$ 0,00</div>
+                <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo mínimo.</p>
               </div>
-            </div>
-
-            <div class="scenario-card scenario-medium">
-              <span class="scenario-dot"></span>
-              <span class="scenario-title">Lucro 5%</span>
-              <div class="scenario-values">
-                <div><span class="scenario-label">Mín.</span> <span class="scenario-value" id="preco_ml_medio_minimo">R$ 0,00</span></div>
-                <div><span class="scenario-label">Méd.</span> <span class="scenario-value" id="preco_ml_medio_medio">R$ 0,00</span></div>
-                <div><span class="scenario-label">Máx.</span> <span class="scenario-value" id="preco_ml_medio_maximo">R$ 0,00</span></div>
+              <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
+                <div class="text-xs uppercase text-gray-500">Preço médio</div>
+                <div class="text-lg font-semibold text-blue-600" id="preco_ml_medio">R$ 0,00</div>
+                <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo médio.</p>
               </div>
-            </div>
-
-            <div class="scenario-card scenario-ideal">
-              <span class="scenario-dot"></span>
-              <span class="scenario-title">Lucro 10%</span>
-              <div class="scenario-values">
-                <div><span class="scenario-label">Mín.</span> <span class="scenario-value" id="preco_ml_ideal_minimo">R$ 0,00</span></div>
-                <div><span class="scenario-label">Méd.</span> <span class="scenario-value" id="preco_ml_ideal_medio">R$ 0,00</span></div>
-                <div><span class="scenario-label">Máx.</span> <span class="scenario-value" id="preco_ml_ideal_maximo">R$ 0,00</span></div>
+              <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
+                <div class="text-xs uppercase text-gray-500">Preço ideal</div>
+                <div class="text-lg font-semibold text-purple-600" id="preco_ml_ideal">R$ 0,00</div>
+                <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo máximo.</p>
               </div>
             </div>
           </div>
@@ -194,33 +182,21 @@
               <input id="preco_shopee" disabled class="p-3 bg-gray-100 font-bold text-lg">
             </div>
 
-            <div class="scenario-card scenario-promo">
-              <span class="scenario-dot"></span>
-              <span class="scenario-title">Sem Lucro</span>
-              <div class="scenario-values">
-                <div><span class="scenario-label">Mín.</span> <span class="scenario-value" id="preco_shopee_promo_minimo">R$ 0,00</span></div>
-                <div><span class="scenario-label">Méd.</span> <span class="scenario-value" id="preco_shopee_promo_medio">R$ 0,00</span></div>
-                <div><span class="scenario-label">Máx.</span> <span class="scenario-value" id="preco_shopee_promo_maximo">R$ 0,00</span></div>
+            <div class="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
+                <div class="text-xs uppercase text-gray-500">Preço mínimo</div>
+                <div class="text-lg font-semibold text-green-600" id="preco_shopee_minimo">R$ 0,00</div>
+                <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo mínimo.</p>
               </div>
-            </div>
-
-            <div class="scenario-card scenario-medium">
-              <span class="scenario-dot"></span>
-              <span class="scenario-title">Lucro 5%</span>
-              <div class="scenario-values">
-                <div><span class="scenario-label">Mín.</span> <span class="scenario-value" id="preco_shopee_medio_minimo">R$ 0,00</span></div>
-                <div><span class="scenario-label">Méd.</span> <span class="scenario-value" id="preco_shopee_medio_medio">R$ 0,00</span></div>
-                <div><span class="scenario-label">Máx.</span> <span class="scenario-value" id="preco_shopee_medio_maximo">R$ 0,00</span></div>
+              <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
+                <div class="text-xs uppercase text-gray-500">Preço médio</div>
+                <div class="text-lg font-semibold text-blue-600" id="preco_shopee_medio">R$ 0,00</div>
+                <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo médio.</p>
               </div>
-            </div>
-
-            <div class="scenario-card scenario-ideal">
-              <span class="scenario-dot"></span>
-              <span class="scenario-title">Lucro 10%</span>
-              <div class="scenario-values">
-                <div><span class="scenario-label">Mín.</span> <span class="scenario-value" id="preco_shopee_ideal_minimo">R$ 0,00</span></div>
-                <div><span class="scenario-label">Méd.</span> <span class="scenario-value" id="preco_shopee_ideal_medio">R$ 0,00</span></div>
-                <div><span class="scenario-label">Máx.</span> <span class="scenario-value" id="preco_shopee_ideal_maximo">R$ 0,00</span></div>
+              <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
+                <div class="text-xs uppercase text-gray-500">Preço ideal</div>
+                <div class="text-lg font-semibold text-purple-600" id="preco_shopee_ideal">R$ 0,00</div>
+                <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo máximo.</p>
               </div>
             </div>
           </div>
@@ -270,33 +246,21 @@
               <input id="preco_magalu" disabled class="p-3 bg-gray-100 font-bold text-lg">
             </div>
 
-            <div class="scenario-card scenario-promo">
-              <span class="scenario-dot"></span>
-              <span class="scenario-title">Sem Lucro</span>
-              <div class="scenario-values">
-                <div><span class="scenario-label">Mín.</span> <span class="scenario-value" id="preco_magalu_promo_minimo">R$ 0,00</span></div>
-                <div><span class="scenario-label">Méd.</span> <span class="scenario-value" id="preco_magalu_promo_medio">R$ 0,00</span></div>
-                <div><span class="scenario-label">Máx.</span> <span class="scenario-value" id="preco_magalu_promo_maximo">R$ 0,00</span></div>
+            <div class="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
+                <div class="text-xs uppercase text-gray-500">Preço mínimo</div>
+                <div class="text-lg font-semibold text-green-600" id="preco_magalu_minimo">R$ 0,00</div>
+                <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo mínimo.</p>
               </div>
-            </div>
-
-            <div class="scenario-card scenario-medium">
-              <span class="scenario-dot"></span>
-              <span class="scenario-title">Lucro 5%</span>
-              <div class="scenario-values">
-                <div><span class="scenario-label">Mín.</span> <span class="scenario-value" id="preco_magalu_medio_minimo">R$ 0,00</span></div>
-                <div><span class="scenario-label">Méd.</span> <span class="scenario-value" id="preco_magalu_medio_medio">R$ 0,00</span></div>
-                <div><span class="scenario-label">Máx.</span> <span class="scenario-value" id="preco_magalu_medio_maximo">R$ 0,00</span></div>
+              <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
+                <div class="text-xs uppercase text-gray-500">Preço médio</div>
+                <div class="text-lg font-semibold text-blue-600" id="preco_magalu_medio">R$ 0,00</div>
+                <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo médio.</p>
               </div>
-            </div>
-
-            <div class="scenario-card scenario-ideal">
-              <span class="scenario-dot"></span>
-              <span class="scenario-title">Lucro 10%</span>
-              <div class="scenario-values">
-                <div><span class="scenario-label">Mín.</span> <span class="scenario-value" id="preco_magalu_ideal_minimo">R$ 0,00</span></div>
-                <div><span class="scenario-label">Méd.</span> <span class="scenario-value" id="preco_magalu_ideal_medio">R$ 0,00</span></div>
-                <div><span class="scenario-label">Máx.</span> <span class="scenario-value" id="preco_magalu_ideal_maximo">R$ 0,00</span></div>
+              <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
+                <div class="text-xs uppercase text-gray-500">Preço ideal</div>
+                <div class="text-lg font-semibold text-purple-600" id="preco_magalu_ideal">R$ 0,00</div>
+                <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo máximo.</p>
               </div>
             </div>
           </div>
@@ -344,33 +308,21 @@
               <input id="preco_shein" disabled class="p-3 bg-gray-100 font-bold text-lg">
             </div>
 
-            <div class="scenario-card scenario-promo">
-              <span class="scenario-dot"></span>
-              <span class="scenario-title">Sem Lucro</span>
-              <div class="scenario-values">
-                <div><span class="scenario-label">Mín.</span> <span class="scenario-value" id="preco_shein_promo_minimo">R$ 0,00</span></div>
-                <div><span class="scenario-label">Méd.</span> <span class="scenario-value" id="preco_shein_promo_medio">R$ 0,00</span></div>
-                <div><span class="scenario-label">Máx.</span> <span class="scenario-value" id="preco_shein_promo_maximo">R$ 0,00</span></div>
+            <div class="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
+                <div class="text-xs uppercase text-gray-500">Preço mínimo</div>
+                <div class="text-lg font-semibold text-green-600" id="preco_shein_minimo">R$ 0,00</div>
+                <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo mínimo.</p>
               </div>
-            </div>
-
-            <div class="scenario-card scenario-medium">
-              <span class="scenario-dot"></span>
-              <span class="scenario-title">Lucro 5%</span>
-              <div class="scenario-values">
-                <div><span class="scenario-label">Mín.</span> <span class="scenario-value" id="preco_shein_medio_minimo">R$ 0,00</span></div>
-                <div><span class="scenario-label">Méd.</span> <span class="scenario-value" id="preco_shein_medio_medio">R$ 0,00</span></div>
-                <div><span class="scenario-label">Máx.</span> <span class="scenario-value" id="preco_shein_medio_maximo">R$ 0,00</span></div>
+              <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
+                <div class="text-xs uppercase text-gray-500">Preço médio</div>
+                <div class="text-lg font-semibold text-blue-600" id="preco_shein_medio">R$ 0,00</div>
+                <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo médio.</p>
               </div>
-            </div>
-
-            <div class="scenario-card scenario-ideal">
-              <span class="scenario-dot"></span>
-              <span class="scenario-title">Lucro 10%</span>
-              <div class="scenario-values">
-                <div><span class="scenario-label">Mín.</span> <span class="scenario-value" id="preco_shein_ideal_minimo">R$ 0,00</span></div>
-                <div><span class="scenario-label">Méd.</span> <span class="scenario-value" id="preco_shein_ideal_medio">R$ 0,00</span></div>
-                <div><span class="scenario-label">Máx.</span> <span class="scenario-value" id="preco_shein_ideal_maximo">R$ 0,00</span></div>
+              <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
+                <div class="text-xs uppercase text-gray-500">Preço ideal</div>
+                <div class="text-lg font-semibold text-purple-600" id="preco_shein_ideal">R$ 0,00</div>
+                <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo máximo.</p>
               </div>
             </div>
           </div>

--- a/promocoes-shopee.html
+++ b/promocoes-shopee.html
@@ -467,24 +467,56 @@ const searchSku = (sku || parentSku || '').toUpperCase();
       priceEntry?.precosPorCusto ||
       systemProduct.precosPorCusto ||
       {};
-    const custoInfo =
-      precosPorCusto[selectedCost] ||
-      precosPorCusto.medio ||
-      Object.values(precosPorCusto)[0];
-    const scenarioMap = {
-      promo: 'precoPromo',
-      medium: 'precoMedio',
-      ideal: 'precoIdeal',
+    const escolherPreco = (...valores) => {
+      for (const valor of valores) {
+        const numero = Number.parseFloat(valor);
+        if (Number.isFinite(numero)) {
+          return numero;
+        }
+      }
+      return 0;
     };
-    const campo = scenarioMap[type] || 'precoMinimo';
-    let priceToApply;
-    if (custoInfo && custoInfo[campo] !== undefined) {
-      priceToApply = Number.parseFloat(custoInfo[campo] || 0).toFixed(2);
-    } else if (priceSet[campo] !== undefined) {
-      priceToApply = Number.parseFloat(priceSet[campo] || 0).toFixed(2);
-    } else {
-      priceToApply = Number.parseFloat(priceSet.precoMinimo || 0).toFixed(2);
-    }
+
+    const precosResumo = {
+      minimo: precosPorCusto.minimo?.preco,
+      medio: precosPorCusto.medio?.preco,
+      maximo: precosPorCusto.maximo?.preco,
+    };
+
+    const precoMinimoValor = escolherPreco(
+      precosPorCusto[selectedCost]?.preco,
+      precosResumo.minimo,
+      precosResumo.medio,
+      precosResumo.maximo,
+      priceSet.precoMinimo,
+      priceSet.precoMedio,
+      priceSet.precoIdeal,
+    );
+    const precoMedioValor = escolherPreco(
+      precosResumo.medio,
+      precosResumo.maximo,
+      precoMinimoValor,
+      priceSet.precoMedio,
+      priceSet.precoIdeal,
+      priceSet.precoMinimo,
+    );
+    const precoIdealValor = escolherPreco(
+      precosResumo.maximo,
+      precoMedioValor,
+      precoMinimoValor,
+      priceSet.precoIdeal,
+      priceSet.precoMedio,
+    );
+
+    const scenarioMap = {
+      promo: precoMinimoValor,
+      medium: precoMedioValor,
+      ideal: precoIdealValor,
+    };
+    const priceToApply = escolherPreco(
+      scenarioMap[type],
+      precoMinimoValor,
+    ).toFixed(2);
 
     const oldPrice = importedProduct['Preço de desconto'];
     if (parseFloat(oldPrice) !== parseFloat(priceToApply)) {


### PR DESCRIPTION
## Summary
- simplify the precificação tab UI to present minimum, medium, and ideal prices derived from the configured cost tiers
- revise pricing computations so each cost level adds platform fees directly and expose the same structure across imports, listings, dashboards, and promo sync workflows
- update downstream consumers to treat the legacy promo price as an alias of the minimum price and ensure exports/previews reflect the new model

## Testing
- Prettier (pre-commit hook)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914adca3058832aa3ccd2ccd9be2765)