### PR TITLE
Colorir linhas por faixa de sobra

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -7311,6 +7311,35 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
         const prazo = p['Prazo de coleta'] || p['Prazo de Coleta'] || '';
         const faixaInfo = classificarSobraPorFaixa(metaInfo, sobra);
 
+        let faixaClasse = '';
+        if (metaInfo) {
+          const minimoMeta = numeroValido(metaInfo.minimo) ? metaInfo.minimo : null;
+          const medioMeta = numeroValido(metaInfo.medio) ? metaInfo.medio : null;
+          const maximoMeta = numeroValido(metaInfo.maximo) ? metaInfo.maximo : null;
+
+          if (minimoMeta !== null && sobra < minimoMeta) {
+            faixaClasse = 'faixa-abaixo-minimo';
+          } else if (maximoMeta !== null && sobra > maximoMeta) {
+            faixaClasse = 'faixa-acima-maximo';
+          } else if (medioMeta !== null && sobra < medioMeta) {
+            faixaClasse = 'faixa-entre-minimo-medio';
+          } else if (
+            medioMeta !== null &&
+            maximoMeta !== null &&
+            sobra >= medioMeta &&
+            sobra <= maximoMeta
+          ) {
+            faixaClasse = 'faixa-entre-medio-maximo';
+          } else if (
+            medioMeta === null &&
+            maximoMeta !== null &&
+            sobra <= maximoMeta &&
+            (minimoMeta === null || sobra >= minimoMeta)
+          ) {
+            faixaClasse = 'faixa-entre-medio-maximo';
+          }
+        }
+
         const pedidoData = {
           id,
           sku,
@@ -7395,7 +7424,7 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
           }
         }
 
-        tr.className = rowClass;
+        tr.className = [rowClass, faixaClasse].filter(Boolean).join(' ');
         tr.innerHTML = `
           <td>${id}</td>
           <td>${sku}</td>

--- a/css/styles.css
+++ b/css/styles.css
@@ -835,6 +835,33 @@ button:hover {
   background-color: #e8f5e9;
   color: #1b5e20;
 }
+
+.data-table tbody tr.faixa-abaixo-minimo {
+  background-color: #f8d7da !important;
+  color: #721c24;
+}
+
+.data-table tbody tr.faixa-entre-minimo-medio {
+  background-color: #fff3cd !important;
+  color: #856404;
+}
+
+.data-table tbody tr.faixa-entre-medio-maximo {
+  background-color: #d1ecf1 !important;
+  color: #0c5460;
+}
+
+.data-table tbody tr.faixa-acima-maximo {
+  background-color: #d4edda !important;
+  color: #155724;
+}
+
+.data-table tbody tr.faixa-abaixo-minimo a,
+.data-table tbody tr.faixa-entre-minimo-medio a,
+.data-table tbody tr.faixa-entre-medio-maximo a,
+.data-table tbody tr.faixa-acima-maximo a {
+  color: inherit;
+}
 .input-with-icon {
   position: relative;
 }


### PR DESCRIPTION
## Summary
- aplica classes específicas às linhas da tabela conforme a sobra calculada para cada pedido
- adiciona estilos para destacar visualmente faixas de sobra abaixo do mínimo, entre mínimo e médio, entre médio e máximo e acima do máximo

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915cf9a3410832a9d952849baf281e8)