### PR TITLE
Adiciona faixas de custo e preço ao catálogo

### DIFF
--- a/catalogo.html
+++ b/catalogo.html
@@ -156,35 +156,67 @@
                     placeholder="Código ou referência"
                   />
                 </div>
-                <div class="flex flex-col">
-                  <label
-                    for="catalogProductCost"
-                    class="text-sm font-medium text-gray-700"
-                    >Custo</label
+                <div class="flex flex-col sm:col-span-2">
+                  <label class="text-sm font-medium text-gray-700"
+                    >Custos (R$)</label
                   >
-                  <input
-                    id="catalogProductCost"
-                    type="number"
-                    step="0.01"
-                    min="0"
-                    class="mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                    placeholder="0,00"
-                  />
+                  <div class="mt-1 grid gap-3 sm:grid-cols-3">
+                    <input
+                      id="catalogProductCostMin"
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      class="rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                      placeholder="Mínimo"
+                    />
+                    <input
+                      id="catalogProductCostAvg"
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      class="rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                      placeholder="Médio"
+                    />
+                    <input
+                      id="catalogProductCostMax"
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      class="rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                      placeholder="Máximo"
+                    />
+                  </div>
                 </div>
-                <div class="flex flex-col">
-                  <label
-                    for="catalogProductPrice"
-                    class="text-sm font-medium text-gray-700"
-                    >Preço de venda sugerido</label
+                <div class="flex flex-col sm:col-span-2">
+                  <label class="text-sm font-medium text-gray-700"
+                    >Preços sugeridos (R$)</label
                   >
-                  <input
-                    id="catalogProductPrice"
-                    type="number"
-                    step="0.01"
-                    min="0"
-                    class="mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                    placeholder="0,00"
-                  />
+                  <div class="mt-1 grid gap-3 sm:grid-cols-3">
+                    <input
+                      id="catalogProductPriceMin"
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      class="rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                      placeholder="Mínimo"
+                    />
+                    <input
+                      id="catalogProductPriceAvg"
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      class="rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                      placeholder="Médio"
+                    />
+                    <input
+                      id="catalogProductPriceMax"
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      class="rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                      placeholder="Máximo"
+                    />
+                  </div>
                 </div>
                 <div class="flex flex-col sm:col-span-2">
                   <label
@@ -537,8 +569,8 @@
                     <th scope="col" class="px-3 py-3 text-left">SKU</th>
                     <th scope="col" class="px-3 py-3 text-left">Produto</th>
                     <th scope="col" class="px-3 py-3 text-left">Categoria</th>
-                    <th scope="col" class="px-3 py-3 text-right">Custo</th>
-                    <th scope="col" class="px-3 py-3 text-right">Venda</th>
+                    <th scope="col" class="px-3 py-3 text-right">Custos</th>
+                    <th scope="col" class="px-3 py-3 text-right">Preços</th>
                     <th scope="col" class="px-3 py-3 text-left">Ações</th>
                   </tr>
                 </thead>
@@ -620,7 +652,7 @@
                 </div>
                 <div>
                   <p class="text-xs font-semibold uppercase text-gray-500">
-                    Custo
+                    Custos sugeridos
                   </p>
                   <p
                     class="mt-1 text-sm font-medium text-gray-900"
@@ -629,7 +661,7 @@
                 </div>
                 <div>
                   <p class="text-xs font-semibold uppercase text-gray-500">
-                    Preço sugerido
+                    Preços sugeridos
                   </p>
                   <p
                     class="mt-1 text-sm font-medium text-gray-900"


### PR DESCRIPTION
## Summary
- permitir informar custos mínimo, médio e máximo e preços sugeridos mínimo, médio e máximo no formulário do catálogo
- exibir as faixas de custo e preço nos cards, modal, lista e cálculo de kit do catálogo
- incluir as novas faixas nas exportações em PDF e Excel

## Testing
- npx prettier --write catalogo.html catalogo.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915d5da5d18832aa9af9556334986c6)