### PR TITLE
Add catalog Excel import/export for bulk updates

### DIFF
--- a/catalogo.html
+++ b/catalogo.html
@@ -498,6 +498,20 @@
                 <i class="fa-solid fa-file-excel"></i>
                 <span>Exportar Excel</span>
               </button>
+              <button
+                id="catalogImportExcel"
+                type="button"
+                class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <i class="fa-solid fa-upload"></i>
+                <span>Importar Excel</span>
+              </button>
+              <input
+                id="catalogImportExcelInput"
+                type="file"
+                accept=".xlsx,.xls,.xlsm"
+                class="hidden"
+              />
             </div>
           </div>
           <div class="card-body">


### PR DESCRIPTION
## Summary
- add an Importar Excel control alongside the existing catalog export actions
- include the Google Drive link in catalog Excel exports for full data coverage
- implement Excel parsing and Firestore batch updates to support bulk catalog imports with feedback and permission checks

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915dbbe0510832ab5d2ae9e2bc2e862)