### PR TITLE
Atualiza cor dos pedidos entre mínimo e médio na importação de sobras

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -842,8 +842,8 @@ button:hover {
 }
 
 .data-table tbody tr.faixa-entre-minimo-medio {
-  background-color: #cfe2ff !important;
-  color: #084298;
+  background-color: #fff3cd !important;
+  color: #856404;
 }
 
 .data-table tbody tr.faixa-entre-medio-maximo {


### PR DESCRIPTION
## Summary
- ajusta o estilo da tabela de sobras para que pedidos na faixa entre mínimo e médio apareçam com destaque amarelo

## Testing
- not run (css change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691622e74bf0832ab485c68d63ec0491)