### PR TITLE
Use custo mínimo na sobra esperada

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -13666,7 +13666,18 @@ let uids = [];
             const querySnap = await produtosRef.where('sku', '==', sku).limit(1).get();
             if (!querySnap.empty) {
               const dados = querySnap.docs[0].data();
-              custo = Number(dados.custo || 0);
+              const custoMinimoRaw = dados?.custos?.minimo;
+              const custoMinimoInfo =
+                typeof custoMinimoRaw === 'object'
+                  ? custoMinimoRaw?.valor
+                  : custoMinimoRaw;
+              const custoMinimo = Number(custoMinimoInfo);
+              const custoPadrao = Number(dados.custo || 0);
+              const possuiCustoMinimo =
+                custoMinimoInfo !== undefined &&
+                custoMinimoInfo !== null &&
+                Number.isFinite(custoMinimo);
+              custo = possuiCustoMinimo ? custoMinimo : custoPadrao;
 
             }
           } catch (e) {


### PR DESCRIPTION
## Summary
- priorizar o custo mínimo cadastrado do produto ao calcular a sobra esperada no detalhamento da aba Importar
- manter o custo padrão como fallback quando o custo mínimo não estiver disponível

## Testing
- no tests run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691628d83ee0832ab9ef3fbc10f53161)