### PR TITLE
Ajusta meta de sobras para custo mínimo do produto

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -6351,22 +6351,35 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
           const minimoInfo = extrairInfoCustoProduto(custosBrutos.minimo);
           const medioInfo = extrairInfoCustoProduto(custosBrutos.medio);
           const maximoInfo = extrairInfoCustoProduto(custosBrutos.maximo);
+          const minimoTaxaInfo = extrairInfoCustoProduto(calculosTaxas.minimo);
+          const medioTaxaInfo = extrairInfoCustoProduto(calculosTaxas.medio);
           const maximoTaxaInfo = extrairInfoCustoProduto(calculosTaxas.maximo);
-          const minimoTotal = calcularValorTotalComComissao(minimoInfo);
-          const medioTotal = calcularValorTotalComComissao(medioInfo);
-          const maximoTotal = calcularValorTotalComComissao(maximoInfo);
-          const maximoTaxaValor = numeroValido(maximoTaxaInfo.valor)
-            ? maximoTaxaInfo.valor
-            : null;
+          const minimoTotal = selecionarPrimeiroNumeroValido(
+            minimoInfo.valor,
+            calcularValorTotalComComissao(minimoInfo),
+            minimoTaxaInfo.valor
+          );
+          const medioTotal = selecionarPrimeiroNumeroValido(
+            medioInfo.valor,
+            calcularValorTotalComComissao(medioInfo),
+            medioTaxaInfo.valor,
+            minimoTotal
+          );
+          const maximoTotal = selecionarPrimeiroNumeroValido(
+            maximoInfo.valor,
+            calcularValorTotalComComissao(maximoInfo),
+            maximoTaxaInfo.valor,
+            medioTotal,
+            minimoTotal
+          );
           const custoFallback = normalizarNumeroMeta(data.custo, null);
           const custoParaMeta = selecionarPrimeiroNumeroValido(
-            maximoTaxaValor,
-            maximoTotal,
-            maximoInfo.valor,
-            medioTotal,
-            medioInfo.valor,
-            minimoTotal,
             minimoInfo.valor,
+            minimoTotal,
+            medioInfo.valor,
+            medioTotal,
+            maximoInfo.valor,
+            maximoTotal,
             custoFallback
           );
 
@@ -6452,8 +6465,18 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
                 maximo: selecionarPrimeiroNumeroValido(maximoTaxaInfo.comissao, maximoInfo.comissao)
               };
 
+              const custoMinimoParaMeta = selecionarPrimeiroNumeroValido(
+                minimoInfo.valor,
+                minimoTotal,
+                medioInfo.valor,
+                medioTotal,
+                maximoInfo.valor,
+                maximoTotal,
+                custoFallback
+              );
+
               metas[sku] = {
-                valor: numeroValido(maximoTotal) ? maximoTotal : 0,
+                valor: numeroValido(custoMinimoParaMeta) ? custoMinimoParaMeta : 0,
                 minimo: numeroValido(minimoTotal) ? minimoTotal : null,
                 medio: numeroValido(medioTotal) ? medioTotal : null,
                 maximo: numeroValido(maximoTotal)
@@ -6468,7 +6491,7 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
                 atualizadoEm: new Date()
               };
 
-              produtos[sku] = numeroValido(maximoTotal) ? maximoTotal : 0;
+              produtos[sku] = numeroValido(custoMinimoParaMeta) ? custoMinimoParaMeta : 0;
 
               if (datalist) {
                 const opt = document.createElement('option');


### PR DESCRIPTION
## Summary
- passa a priorizar o custo mínimo cadastrado nos produtos ao montar o cache de SKUs utilizados nas abas de sobra
- utiliza o mesmo custo mínimo como meta inicial ao carregar a aba Importar, garantindo a conferência com base no menor custo informado

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69162c80570c832ab83292699d962086)