### PR TITLE
Add commission reconciliation import workflow

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -7451,6 +7451,34 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
       };
     }
 
+    function extrairCampoPlanilha(row, headerMap, opcoes) {
+      for (const chave of opcoes) {
+        const normalizada = normalizeHeaderKey(chave);
+        if (headerMap[normalizada] !== undefined) {
+          return row[headerMap[normalizada]];
+        }
+      }
+      return undefined;
+    }
+
+    function lerPlanilhaBasica(file) {
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          try {
+            const data = new Uint8Array(e.target.result);
+            const wb = XLSX.read(data, { type: 'array' });
+            const sheet = wb.Sheets[wb.SheetNames[0]];
+            resolve(XLSX.utils.sheet_to_json(sheet));
+          } catch (error) {
+            reject(error);
+          }
+        };
+        reader.onerror = () => reject(new Error('Não foi possível ler o arquivo.'));
+        reader.readAsArrayBuffer(file);
+      });
+    }
+
     async function processarPlanilha() {
       const fileInput = document.getElementById('inputExcel');
       const file = fileInput.files[0];
@@ -7813,7 +7841,125 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
       if (document.getElementById('graficos').classList.contains('active')) {
         atualizarGraficos();
       }
-    
+
+
+      async function processarConferenciaComissao() {
+        const input = document.getElementById('inputConferenciaComissao');
+        const feedback = document.getElementById('feedbackConferenciaComissao');
+        const tbody = document.querySelector('#resultadoConferenciaComissao tbody');
+        const resumo = document.getElementById('resumoConferenciaComissao');
+        const cardResultado = document.getElementById('conferenciaComissaoResultados');
+        const botao = document.getElementById('btnProcessarConferencia');
+
+        if (!input || !feedback || !tbody || !resumo || !cardResultado || !botao) return;
+
+        feedback.innerHTML = '';
+        resumo.innerHTML = '';
+        tbody.innerHTML = '';
+        cardResultado.style.display = 'none';
+
+        const file = input.files?.[0];
+        if (!file) {
+          feedback.innerHTML = '<span class="badge badge-warning">⚠️ Selecione um arquivo</span>';
+          return;
+        }
+
+        try {
+          toggleLoading(botao, '<i class="fas fa-upload"></i> Processar Comissão');
+
+          const metasSincronizadas = await carregarMetas({
+            atualizarDatalist: false,
+            renderizarInterface: false,
+            mostrarLoading: false
+          });
+
+          if (metasSincronizadas === false) {
+            feedback.innerHTML = '<span class="badge badge-danger">⚠️ Não foi possível carregar as metas dos produtos.</span>';
+            return;
+          }
+
+          const linhas = await lerPlanilhaBasica(file);
+          if (!linhas.length) {
+            feedback.innerHTML = '<span class="badge badge-warning">⚠️ Arquivo sem dados para processar.</span>';
+            return;
+          }
+
+          const headerMap = buildHeaderMap(linhas[0]);
+          let totalItens = 0;
+          let semMeta = 0;
+          let totalComissao = 0;
+          let faixasIdentificadas = 0;
+
+          linhas.forEach((row) => {
+            const sku = String(extrairCampoPlanilha(row, headerMap, ['sku', 'número de referência sku', 'sku produto']) || '').trim();
+            if (!sku) return;
+
+            const sobraValor = parseNumber(extrairCampoPlanilha(row, headerMap, ['sobra']));
+            const numeroVenda = extrairCampoPlanilha(row, headerMap, ['nº da venda', 'numero da venda', 'pedido', 'id', 'id do pedido']) || '';
+            const dataVenda = extrairCampoPlanilha(row, headerMap, ['data', 'data da venda']) || '';
+
+            const metaInfo = obterMetaSku(sku);
+            const faixaInfo = classificarSobraPorFaixa(metaInfo, sobraValor);
+            const metaValor = numeroValido(metaInfo?.valor) ? metaInfo.valor : null;
+            const comissaoValor = numeroValido(faixaInfo.valorApresentacao) ? faixaInfo.valorApresentacao : null;
+
+            const comissaoHtml = comissaoValor !== null
+              ? `<strong>R$ ${Math.abs(comissaoValor).toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</strong>${faixaInfo.comissaoTexto ? `<br><small>${faixaInfo.comissaoTexto}</small>` : ''}`
+              : (faixaInfo.comissaoTexto ? `<small>${faixaInfo.comissaoTexto}</small>` : '<span class="text-muted">-</span>');
+
+            const metaTexto = metaValor !== null ? `Meta: ${formatarMoedaBR(metaValor)}` : 'Sem meta';
+            const situacao = metaInfo
+              ? (faixaInfo.situacao === 'sem-meta' ? 'Sem meta configurada' : 'Comissão encontrada')
+              : 'SKU não cadastrado';
+
+            if (metaInfo) {
+              faixasIdentificadas += faixaInfo.situacao === 'sem-meta' ? 0 : 1;
+            } else {
+              semMeta += 1;
+            }
+
+            if (comissaoValor !== null) {
+              totalComissao += comissaoValor;
+            }
+
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+              <td>${dataVenda || '-'}</td>
+              <td>${numeroVenda || '-'}</td>
+              <td>${sku}</td>
+              <td><strong>${formatarMoedaBR(sobraValor)}</strong></td>
+              <td>${metaInfo ? `<strong>${metaTexto}</strong>` : '<span class="text-muted">SKU não cadastrado</span>'}</td>
+              <td><strong>${faixaInfo.label}</strong>${faixaInfo.detalhe ? `<br><small>${faixaInfo.detalhe}</small>` : ''}</td>
+              <td>${comissaoHtml}</td>
+              <td>${situacao}</td>
+            `;
+            tbody.appendChild(tr);
+            totalItens += 1;
+          });
+
+          if (totalItens === 0) {
+            feedback.innerHTML = '<span class="badge badge-warning">⚠️ Nenhuma linha válida encontrada.</span>';
+            return;
+          }
+
+          cardResultado.style.display = '';
+          resumo.innerHTML = `
+            <div style="display: flex; gap: 0.75rem; flex-wrap: wrap;">
+              <span class="badge badge-primary">Itens avaliados: ${totalItens}</span>
+              <span class="badge badge-success">Faixas com comissão: ${faixasIdentificadas}</span>
+              <span class="badge badge-warning">SKUs sem cadastro/meta: ${semMeta}</span>
+              <span class="badge badge-secondary">Comissão total: ${formatarMoedaBR(totalComissao)}</span>
+            </div>
+          `;
+          feedback.innerHTML = '<span class="badge badge-success">✔️ Comissão conferida com sucesso</span>';
+        } catch (error) {
+          console.error('Erro ao processar conferência de comissão:', error);
+          feedback.innerHTML = '<span class="badge badge-danger">⚠️ Erro no arquivo</span>';
+        } finally {
+          toggleLoading(botao, '<i class="fas fa-upload"></i> Processar Comissão');
+        }
+      }
+
 
     function limparFiltros() {
       document.getElementById("filtroSKU").value = "";
@@ -17160,6 +17306,7 @@ window.atualizarRastreio = atualizarRastreio;
 window.atualizarChecklist = atualizarChecklist;
 window.aplicarFiltroLogistica = aplicarFiltroLogistica;
   window.processarPlanilha = processarPlanilha;
+window.processarConferenciaComissao = processarConferenciaComissao;
 window.toggleExportMenu = toggleExportMenu;
 window.salvarAcompanhamentoDiario = salvarAcompanhamentoDiario;
 window.carregarResumoDiario = carregarResumoDiario;

--- a/sobras-tabs/importar.html
+++ b/sobras-tabs/importar.html
@@ -17,6 +17,39 @@
   <div id="feedbackImportacao" class="mt-2"></div>
 </div>
 
+<div class="card import-card">
+  <div class="card-header">
+    <i class="fas fa-file-circle-check"></i>
+    <h3>Conferência de Comissão</h3>
+    <span
+      class="tooltip tooltip-lg ml-2"
+      data-tooltip="Importe uma planilha no formato DATA, Nº DA VENDA, sobra e SKU para conferir automaticamente em qual faixa de comissão cada item se enquadra."
+    >
+      <i class="fas fa-question-circle text-blue-600"></i>
+    </span>
+  </div>
+  <div class="form-row">
+    <div class="form-group">
+      <input
+        type="file"
+        id="inputConferenciaComissao"
+        accept=".xlsx, .xls"
+        class="form-control"
+        aria-label="Arquivo de conferência de comissão"
+      />
+    </div>
+    <button
+      onclick="processarConferenciaComissao()"
+      class="btn btn-primary btn-lg"
+      id="btnProcessarConferencia"
+      style="margin-left:auto;"
+    >
+      <i class="fas fa-upload"></i> Processar Comissão
+    </button>
+  </div>
+  <div id="feedbackConferenciaComissao" class="mt-2"></div>
+</div>
+
 <div class="card filtros-resultados-card">
   <div class="card-header">
     <i class="fas fa-filter"></i>
@@ -73,6 +106,31 @@
     </table>
   </div>
   <div id="totalSobra" style="margin-top: 1.5rem;"></div>
+</div>
+
+<div class="card filtros-resultados-card" id="conferenciaComissaoResultados" style="display: none;">
+  <div class="card-header">
+    <i class="fas fa-hand-holding-dollar"></i>
+    <h3>Resultado da Conferência de Comissão</h3>
+  </div>
+  <div class="table-container">
+    <table id="resultadoConferenciaComissao" class="data-table">
+      <thead>
+        <tr>
+          <th>Data</th>
+          <th>Nº da Venda</th>
+          <th>SKU</th>
+          <th>Sobra</th>
+          <th>Meta</th>
+          <th>Faixa de Comissão</th>
+          <th>Comissão Calculada</th>
+          <th>Situação</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+  <div id="resumoConferenciaComissao" class="mt-3"></div>
 </div>
 
 <div class="card acoes-card">


### PR DESCRIPTION
## Summary
- add a dedicated upload flow on the import tab for commission reconciliation spreadsheets
- parse commission conference data against product metas to classify commission ranges and totals
- present results in a new table with summary badges for quick validation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b015e9054832aa961206622ad8779)