### PR TITLE
Ajustar cálculo de preços ideal e máximo

### DIFF
--- a/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
+++ b/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
@@ -970,6 +970,11 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
           calculos?.minimo?.preco,
         ),
         ideal: primeiroNumeroValido(
+          calculos?.medio?.preco,
+          calculos?.maximo?.preco,
+          calculos?.minimo?.preco,
+        ),
+        maximo: primeiroNumeroValido(
           calculos?.maximo?.preco,
           calculos?.medio?.preco,
           calculos?.minimo?.preco,
@@ -1024,7 +1029,8 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
       const resumo = {
         precoMinimo: calculos.minimo?.preco ?? null,
         precoMedio: calculos.medio?.preco ?? null,
-        precoIdeal: calculos.maximo?.preco ?? null,
+        precoIdeal: calculos.medio?.preco ?? null,
+        precoMaximo: calculos.maximo?.preco ?? null,
       };
 
       return { calculos, referencia, resumo };

--- a/precificacao-tabs/lista-precos.js
+++ b/precificacao-tabs/lista-precos.js
@@ -140,8 +140,8 @@ function gerarTabelaPreview(resultado) {
     </table>
     <div class="mt-3 grid grid-cols-1 md:grid-cols-3 gap-2 text-xs text-gray-600">
       <div><strong>Preço mínimo:</strong> ${formatCurrency(resultado.precoMinimo)}</div>
-      <div><strong>Preço médio:</strong> ${formatCurrency(resultado.precoMedio)}</div>
       <div><strong>Preço ideal:</strong> ${formatCurrency(resultado.precoIdeal)}</div>
+      <div><strong>Preço máximo:</strong> ${formatCurrency(resultado.precoMaximo)}</div>
     </div>
     <p class="mt-2 text-xs text-gray-500">Referência atual: <strong>${resultado.referenciaCusto?.toUpperCase() || 'MÉDIO'}</strong></p>
   `;
@@ -182,7 +182,8 @@ function calcularPrecosCustos(custos, totalPercentual, totalFixo) {
   const resumo = {
     precoMinimo: calculos.minimo?.preco ?? null,
     precoMedio: calculos.medio?.preco ?? null,
-    precoIdeal: calculos.maximo?.preco ?? null,
+    precoIdeal: calculos.medio?.preco ?? null,
+    precoMaximo: calculos.maximo?.preco ?? null,
   };
   return { calculos, referencia, resumo };
 }
@@ -297,7 +298,7 @@ function renderLista(lista) {
             ${
               data.calculosTaxas
                 ? Object.entries(data.calculosTaxas)
-                    .map(([taxa, valores]) => {
+                  .map(([taxa, valores]) => {
                       const referencia = valores.referencia
                         ? ` (${String(valores.referencia).toUpperCase()})`
                         : '';
@@ -305,9 +306,9 @@ function renderLista(lista) {
               <div class="mb-2">
                 <div class="text-gray-500 text-sm">${taxa}${referencia} - Preços calculados</div>
                 <div class="text-xs text-gray-500 space-y-0.5 mt-1">
-                  <div><strong>Mínimo:</strong> R$ ${parseFloat(valores.precoMinimo).toFixed(2)}</div>
-                  <div><strong>Médio:</strong> R$ ${parseFloat(valores.precoMedio).toFixed(2)}</div>
-                  <div><strong>Ideal:</strong> R$ ${parseFloat(valores.precoIdeal).toFixed(2)}</div>
+                  <div><strong>Mínimo:</strong> R$ ${parseFloat(valores.precoMinimo ?? 0).toFixed(2)}</div>
+                  <div><strong>Ideal:</strong> R$ ${parseFloat(valores.precoIdeal ?? 0).toFixed(2)}</div>
+                  <div><strong>Máximo:</strong> R$ ${parseFloat(valores.precoMaximo ?? valores.precoIdeal ?? 0).toFixed(2)}</div>
                 </div>
               </div>
             `;
@@ -316,7 +317,7 @@ function renderLista(lista) {
                 : `
               <div class="text-gray-500 text-sm">Preço mínimo</div>
               <div class="text-lg font-semibold text-green-600">R$ ${parseFloat(data.precoMinimo).toFixed(2)}</div>
-              <div class="text-xs text-gray-500 mt-1">Médio: R$ ${parseFloat(data.precoMedio).toFixed(2)} | Ideal: R$ ${parseFloat(data.precoIdeal).toFixed(2)}</div>
+              <div class="text-xs text-gray-500 mt-1">Ideal: R$ ${parseFloat(data.precoIdeal ?? data.precoMedio ?? 0).toFixed(2)} | Máximo: R$ ${parseFloat(data.precoMaximo ?? data.precoIdeal ?? 0).toFixed(2)}</div>
             `
             }
           </div>
@@ -400,7 +401,7 @@ function verDetalhes(id) {
     ${custosHtml ? `<div class="mt-3"><strong>Custos cadastrados:</strong>${custosHtml}</div>` : ''}
     <div><strong>Preço mínimo:</strong> R$ ${prod.precoMinimo} (Lucro: ${lucroPercent(prod.precoMinimo)}%)</div>
     <div><strong>Preço ideal:</strong> R$ ${prod.precoIdeal} (Lucro: ${lucroPercent(prod.precoIdeal)}%)</div>
-    <div><strong>Preço médio:</strong> R$ ${prod.precoMedio} (Lucro: ${lucroPercent(prod.precoMedio)}%)</div>
+    <div><strong>Preço máximo:</strong> R$ ${prod.precoMaximo ?? prod.precoIdeal} (Lucro: ${lucroPercent(prod.precoMaximo ?? prod.precoIdeal)}%)</div>
   `;
   // Utilize global modal helpers to ensure proper display
   document.getElementById('detalhesModal').classList.remove('hidden');
@@ -516,6 +517,7 @@ document.getElementById('saveBtn').addEventListener('click', async () => {
     precoMinimo: resultado.precoMinimo,
     precoIdeal: resultado.precoIdeal,
     precoMedio: resultado.precoMedio,
+    precoMaximo: resultado.precoMaximo,
     precoPromo: resultado.precoMinimo,
     custos: resultado.custos,
     precosPorCusto: resultado.precosPorCusto,
@@ -799,19 +801,25 @@ function recalcularPrecos(prod, novosCustosEntrada) {
   const precoMinimoBase =
     primeiroNumeroValido(
       resumo.precoMinimo,
-      resumo.precoMedio,
       resumo.precoIdeal,
+      resumo.precoMaximo,
     ) ?? 0;
   const precoMedioBase =
     primeiroNumeroValido(
       resumo.precoMedio,
       resumo.precoIdeal,
-      resumo.precoMinimo,
+      resumo.precoMaximo,
     ) ?? 0;
   const precoIdealBase =
     primeiroNumeroValido(
       resumo.precoIdeal,
-      resumo.precoMedio,
+      resumo.precoMaximo,
+      resumo.precoMinimo,
+    ) ?? 0;
+  const precoMaximoBase =
+    primeiroNumeroValido(
+      resumo.precoMaximo,
+      resumo.precoIdeal,
       resumo.precoMinimo,
     ) ?? 0;
 
@@ -834,19 +842,25 @@ function recalcularPrecos(prod, novosCustosEntrada) {
       const precoMinimoTaxa =
         primeiroNumeroValido(
           resumoTaxa.precoMinimo,
-          resumoTaxa.precoMedio,
           resumoTaxa.precoIdeal,
+          resumoTaxa.precoMaximo,
         ) ?? 0;
       const precoMedioTaxa =
         primeiroNumeroValido(
-          resumoTaxa.precoMedio,
           resumoTaxa.precoIdeal,
+          resumoTaxa.precoMaximo,
           resumoTaxa.precoMinimo,
         ) ?? 0;
       const precoIdealTaxa =
         primeiroNumeroValido(
           resumoTaxa.precoIdeal,
-          resumoTaxa.precoMedio,
+          resumoTaxa.precoMaximo,
+          resumoTaxa.precoMinimo,
+        ) ?? 0;
+      const precoMaximoTaxa =
+        primeiroNumeroValido(
+          resumoTaxa.precoMaximo,
+          resumoTaxa.precoIdeal,
           resumoTaxa.precoMinimo,
         ) ?? 0;
       calculosTaxas[taxaKey] = {
@@ -855,6 +869,7 @@ function recalcularPrecos(prod, novosCustosEntrada) {
         precoMinimo: precoMinimoTaxa,
         precoMedio: precoMedioTaxa,
         precoIdeal: precoIdealTaxa,
+        precoMaximo: precoMaximoTaxa,
         precoPromo: precoMinimoTaxa,
         taxas: taxasDetalhadas,
       };
@@ -866,6 +881,7 @@ function recalcularPrecos(prod, novosCustosEntrada) {
     precoMinimo: precoMinimoBase,
     precoMedio: precoMedioBase,
     precoIdeal: precoIdealBase,
+    precoMaximo: precoMaximoBase,
     precoPromo: precoMinimoBase,
     custos: custosAtualizados,
     precosPorCusto: calculos,


### PR DESCRIPTION
## Summary
- Ajusta o cálculo dos preços mínimo, ideal e máximo para usar os custos mínimo, médio e máximo com a soma das comissões e taxas
- Exibe o preço máximo recalculado na pré-visualização, cartões e detalhes da lista de preços
- Mantém a nova lógica também na aba principal de precificação

## Testing
- Não foram executados testes automatizados; validação manual não incluída


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b1d37c594832a9a339a51ca82a255)