### PR TITLE
Ajusta cálculo de preços mínimo, ideal e máximo

### DIFF
--- a/import-card.js
+++ b/import-card.js
@@ -197,16 +197,16 @@
 
     const custosInformados = cloneCosts(custosNormalizados);
     const precoMinimo = calculos.minimo?.preco;
-    const precoMedio = calculos.medio?.preco;
-    const precoIdeal = calculos.maximo?.preco;
+    const precoIdeal = calculos.medio?.preco;
+    const precoMaximo = calculos.maximo?.preco;
     const precoMinimoFinal = formatTwoDecimals(
-      firstAvailable(precoMinimo, precoMedio, precoIdeal),
-    );
-    const precoMedioFinal = formatTwoDecimals(
-      firstAvailable(precoMedio, precoIdeal, precoMinimo),
+      firstAvailable(precoMinimo, precoIdeal, precoMaximo),
     );
     const precoIdealFinal = formatTwoDecimals(
-      firstAvailable(precoIdeal, precoMedio, precoMinimo),
+      firstAvailable(precoIdeal, precoMaximo, precoMinimo),
+    );
+    const precoMaximoFinal = formatTwoDecimals(
+      firstAvailable(precoMaximo, precoIdeal, precoMinimo),
     );
 
     return {
@@ -216,8 +216,9 @@
       referencia,
       custoBase: custosInformados[referencia]?.valor || 0,
       precoMinimo: precoMinimoFinal,
-      precoMedio: precoMedioFinal,
       precoIdeal: precoIdealFinal,
+      precoMedio: precoIdealFinal,
+      precoMaximo: precoMaximoFinal,
       precoPromo: precoMinimoFinal,
       taxas: formatTaxas(taxasDetalhadas),
     };

--- a/precificacao-tabs/precificacao.html
+++ b/precificacao-tabs/precificacao.html
@@ -119,12 +119,12 @@
                 <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo mínimo.</p>
               </div>
               <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
-                <div class="text-xs uppercase text-gray-500">Preço médio</div>
+                <div class="text-xs uppercase text-gray-500">Preço ideal</div>
                 <div class="text-lg font-semibold text-blue-600" id="preco_ml_medio">R$ 0,00</div>
                 <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo médio.</p>
               </div>
               <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
-                <div class="text-xs uppercase text-gray-500">Preço ideal</div>
+                <div class="text-xs uppercase text-gray-500">Preço máximo</div>
                 <div class="text-lg font-semibold text-purple-600" id="preco_ml_ideal">R$ 0,00</div>
                 <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo máximo.</p>
               </div>
@@ -189,12 +189,12 @@
                 <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo mínimo.</p>
               </div>
               <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
-                <div class="text-xs uppercase text-gray-500">Preço médio</div>
+                <div class="text-xs uppercase text-gray-500">Preço ideal</div>
                 <div class="text-lg font-semibold text-blue-600" id="preco_shopee_medio">R$ 0,00</div>
                 <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo médio.</p>
               </div>
               <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
-                <div class="text-xs uppercase text-gray-500">Preço ideal</div>
+                <div class="text-xs uppercase text-gray-500">Preço máximo</div>
                 <div class="text-lg font-semibold text-purple-600" id="preco_shopee_ideal">R$ 0,00</div>
                 <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo máximo.</p>
               </div>
@@ -253,12 +253,12 @@
                 <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo mínimo.</p>
               </div>
               <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
-                <div class="text-xs uppercase text-gray-500">Preço médio</div>
+                <div class="text-xs uppercase text-gray-500">Preço ideal</div>
                 <div class="text-lg font-semibold text-blue-600" id="preco_magalu_medio">R$ 0,00</div>
                 <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo médio.</p>
               </div>
               <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
-                <div class="text-xs uppercase text-gray-500">Preço ideal</div>
+                <div class="text-xs uppercase text-gray-500">Preço máximo</div>
                 <div class="text-lg font-semibold text-purple-600" id="preco_magalu_ideal">R$ 0,00</div>
                 <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo máximo.</p>
               </div>
@@ -315,12 +315,12 @@
                 <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo mínimo.</p>
               </div>
               <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
-                <div class="text-xs uppercase text-gray-500">Preço médio</div>
+                <div class="text-xs uppercase text-gray-500">Preço ideal</div>
                 <div class="text-lg font-semibold text-blue-600" id="preco_shein_medio">R$ 0,00</div>
                 <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo médio.</p>
               </div>
               <div class="bg-gray-50 border border-gray-200 rounded-lg p-3">
-                <div class="text-xs uppercase text-gray-500">Preço ideal</div>
+                <div class="text-xs uppercase text-gray-500">Preço máximo</div>
                 <div class="text-lg font-semibold text-purple-600" id="preco_shein_ideal">R$ 0,00</div>
                 <p class="text-xs text-gray-500 mt-1">Cálculo a partir do custo máximo.</p>
               </div>


### PR DESCRIPTION
## Resumo
- altera o cálculo para tratar o preço ideal a partir do custo médio e incluir o preço máximo baseado no custo máximo
- ajusta listagem, modais e exportações para exibir os novos preços mínimo, ideal e máximo
- atualiza textos da aba de precificação para refletir a nova lógica de preços

## Testes
- não executado (não especificado)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b1d37c594832a9a339a51ca82a255)