### PR TITLE
Corrige cálculo de preços com taxas percentuais

### DIFF
--- a/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
+++ b/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
@@ -1005,8 +1005,9 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
         const comissao = Number.parseFloat(info.comissao) || 0;
         if (!(valor > 0)) return;
         const percentualTotal = totalPercentual + comissao;
-        const precoCalculado =
-          valor + totalFixo + (valor * percentualTotal) / 100;
+        const divisor = 1 - percentualTotal / 100;
+        if (divisor <= 0) return;
+        const precoCalculado = (valor + totalFixo) / divisor;
         calculos[nivel] = {
           custo: Number(valor.toFixed(2)),
           comissao,

--- a/precificacao-tabs/lista-precos.js
+++ b/precificacao-tabs/lista-precos.js
@@ -166,7 +166,9 @@ function calcularPrecosCustos(custos, totalPercentual, totalFixo) {
     const info = custos[nivel];
     if (!info || !(info.valor > 0)) return;
     const percentual = totalPercentual + (info.comissao || 0);
-    const precoBase = info.valor + totalFixo + (info.valor * percentual) / 100;
+    const divisor = 1 - percentual / 100;
+    if (divisor <= 0) return;
+    const precoBase = (info.valor + totalFixo) / divisor;
     calculos[nivel] = {
       custo: Number(info.valor.toFixed(2)),
       comissao: info.comissao || 0,


### PR DESCRIPTION
## Summary
- ajusta a fórmula de cálculo de preços na lista de preços para considerar custos fixos divididos pelo percentual líquido
- aplica a mesma correção no fluxo principal de precificação para alinhar o mínimo, ideal e máximo com a regra informada

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b22d95dd8832ab56dd490f38c6469)