### PR TITLE
Remove comissão do nível do cálculo de preços

### DIFF
--- a/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
+++ b/Sistema de Precificação COM IMPORTAÇÃO DE PLANILHA DE PROMOÇÕES SHOPEE.html
@@ -1004,9 +1004,9 @@ const tabs = ['dashboard','precificacao','produtos','lista-precos','historico','
         const valor = Number.parseFloat(info.valor) || 0;
         const comissao = Number.parseFloat(info.comissao) || 0;
         if (!(valor > 0)) return;
-        const percentualTotal = totalPercentual + comissao;
-        const precoCalculado =
-          valor + totalFixo + (valor * percentualTotal) / 100;
+        const divisor = 1 - totalPercentual / 100;
+        if (divisor <= 0) return;
+        const precoCalculado = (valor + totalFixo) / divisor;
         calculos[nivel] = {
           custo: Number(valor.toFixed(2)),
           comissao,

--- a/precificacao-tabs/lista-precos.js
+++ b/precificacao-tabs/lista-precos.js
@@ -165,8 +165,9 @@ function calcularPrecosCustos(custos, totalPercentual, totalFixo) {
   NIVEIS_CUSTO.forEach((nivel) => {
     const info = custos[nivel];
     if (!info || !(info.valor > 0)) return;
-    const percentual = totalPercentual + (info.comissao || 0);
-    const precoBase = info.valor + totalFixo + (info.valor * percentual) / 100;
+    const divisor = 1 - totalPercentual / 100;
+    if (divisor <= 0) return;
+    const precoBase = (info.valor + totalFixo) / divisor;
     calculos[nivel] = {
       custo: Number(info.valor.toFixed(2)),
       comissao: info.comissao || 0,


### PR DESCRIPTION
## Summary
- ajusta o cálculo de preços para usar apenas a soma de taxas percentuais globais no divisor
- mantém as comissões por nível apenas como informação, sem impactar o preço calculado

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b22d95dd8832ab56dd490f38c6469)