### PR TITLE
Adjust pricing import calculation to exclude cost commissions

### DIFF
--- a/import-card.js
+++ b/import-card.js
@@ -138,9 +138,12 @@
         return;
       }
 
-      const percentualTotal = totalPercentual + (info.comissao || 0);
-      const precoCalculado =
-        info.valor + totalFixo + (info.valor * percentualTotal) / 100;
+      const divisor = 1 - totalPercentual / 100;
+      if (divisor <= 0) {
+        calculos[key] = null;
+        return;
+      }
+      const precoCalculado = (info.valor + totalFixo) / divisor;
 
       calculos[key] = {
         custo: formatTwoDecimals(info.valor),


### PR DESCRIPTION
## Summary
- align spreadsheet import pricing calculations with the shared price-per-cost formula
- stop adding cost-level commissions when computing prices during spreadsheet imports

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b2d4452ac832ab850a2082788b514)