### PR TITLE
Corrige cor da linha para referência mínima

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -7290,9 +7290,9 @@ function extrairLinhaTiny(row, { dataReferencia } = {}) {
       const limiteTresPorCento = numeroValido(maximo) ? maximo * 1.03 : null;
       const excedenteAcimaLimite = limiteTresPorCento ? Math.max(0, sobra - limiteTresPorCento) : 0;
       const classePorNivel = {
-        minimo: 'faixa-entre-minimo-medio',
-        medio: 'faixa-entre-medio-maximo',
-        maximo: 'faixa-acima-maximo'
+        minimo: 'referencia-minima',
+        medio: 'referencia-media',
+        maximo: 'referencia-maxima'
       };
 
       return {


### PR DESCRIPTION
## Summary
- ajusta a classe CSS atribuída às linhas que utilizam a classificação "Referência ... mais próxima" para utilizar as classes de referência já existentes
- garante que itens classificados como referência mínima apareçam com a coloração vermelha esperada (e média/máxima com suas cores correspondentes)

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691da8fb6a4c832aa8b87fb6b01f67d1)