### PR TITLE
Fix XLSX export to preserve summary styles

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -10404,7 +10404,7 @@ await db
         });
 
         const nomeArquivo = `relatorio_sobras_${new Date().toISOString().slice(0,10)}.xlsx`;
-        XLSX.writeFile(workbook, nomeArquivo);
+        XLSX.writeFile(workbook, nomeArquivo, { cellStyles: true });
         mostrarSucesso('Arquivo Excel exportado com sucesso!');
       } catch (error) {
         mostrarErro(`Erro ao exportar Excel: ${error.message}`);


### PR DESCRIPTION
## Summary
- enable cell style preservation when exporting the sobras report workbook so summary sheet colors/borders are kept

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69287e7452b8832a8583618198dfd7d1)