### PR TITLE
Apply 6% threshold to below-cost Excel export

### DIFF
--- a/CONTROLE DE SOBRAS SHOPEE.html
+++ b/CONTROLE DE SOBRAS SHOPEE.html
@@ -10485,8 +10485,14 @@ await db
           5: 'FFC6EFCE'    // verde claro
         };
 
-        const isAbaixoCustoMinimo = (pedido) =>
-          pedido.abaixoCustoMinimo && Number.isFinite(pedido.custoMinimo) && pedido.custoMinimo > 0;
+        const isAbaixoCustoMinimo = (pedido) => {
+          if (!pedido.abaixoCustoMinimo || !Number.isFinite(pedido.custoMinimo) || pedido.custoMinimo <= 0) {
+            return false;
+          }
+
+          const diferencaPercentual = ((pedido.sobra - pedido.custoMinimo) / pedido.custoMinimo) * 100;
+          return diferencaPercentual <= -6;
+        };
 
         const mapearPedidoParaLinha = (pedido) => {
           const descricaoComissao = obterDescricaoComissaoPercentual(pedido);


### PR DESCRIPTION
## Summary
- require pedidos to be at least 6% abaixo do custo mínimo para entrarem na aba "Abaixo Custo Mínimo" ao exportar XLSX

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f39ff521c832a89d635b27d615a5f)